### PR TITLE
Implement Jetty adapter phase one

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ Use it when you want to answer: **does this skill improve the agent, where does 
 - **Review UI** — render a static HTML benchmark viewer.
 - **Trigger checks** — run Pi skill-trigger smoke evals without forcing `--skill`.
 - **Manifest audits** — detect missing eval categories, hidden split gaps, missing ablations, trigger/no-trigger gaps, saturated cases, non-discriminating assertions, and fixture recommendations.
+- **Jetty adapter** — export runbook-mode Jetty payloads, run them via Jetty REST, and import trajectory artifacts back into the local run layout.
 
 ## Quick start
 
 > Requires Python 3.10+ and [uv](https://docs.astral.sh/uv/). Install from GitHub first:
 >
 > ```bash
-> uv tool install git+https://github.com/adewale/skill-eval-harness.git@v0.1.1
+> uv tool install git+https://github.com/adewale/skill-eval-harness.git@v0.2.0
 > ```
 
 ```bash
@@ -60,12 +61,12 @@ skill-benchmark render-viewer \
 ### From GitHub
 
 ```bash
-uv tool install git+https://github.com/adewale/skill-eval-harness.git@v0.1.1
+uv tool install git+https://github.com/adewale/skill-eval-harness.git@v0.2.0
 skill-benchmark --help
 skill-pi-trigger-eval --help
 
 # One-shot without installing globally:
-uvx --from git+https://github.com/adewale/skill-eval-harness.git@v0.1.1 skill-benchmark --help
+uvx --from git+https://github.com/adewale/skill-eval-harness.git@v0.2.0 skill-benchmark --help
 ```
 
 ### Local development
@@ -309,6 +310,41 @@ skill-pi-trigger-eval ../repo/evals/shared-benchmark.json \
 
 This creates a temporary `PI_CODING_AGENT_DIR`, copies the skill under `skills/`, runs Pi without forced `--skill`, and detects whether the model loaded the skill from JSON stream events.
 
+### Jetty adapter
+
+Jetty support is an optional execution adapter. The harness still owns manifests and grading; Jetty runs the task and returns trajectory artifacts.
+
+```bash
+# Export runbook-mode Jetty chat-completion payloads. No network calls.
+skill-benchmark export-jetty ../repo/evals/shared-benchmark.json \
+  --split tune \
+  --out jetty-payloads.jsonl
+
+# Dry-run payload loading without a token.
+skill-benchmark run-jetty \
+  --payloads jetty-payloads.jsonl \
+  --dry-run \
+  --out jetty-dry-run.jsonl
+
+# Live execution requires JETTY_API_TOKEN.
+export JETTY_API_TOKEN=...
+skill-benchmark run-jetty \
+  --payloads jetty-payloads.jsonl \
+  --out jetty-runs.jsonl
+
+# Import Jetty artifacts into the normal run layout, then grade locally.
+skill-benchmark import-jetty-results \
+  --manifest ../repo/evals/shared-benchmark.json \
+  --jetty-runs jetty-runs.jsonl \
+  --runs ../repo/eval-runs/jetty
+
+skill-benchmark benchmark ../repo/evals/shared-benchmark.json \
+  --runs ../repo/eval-runs/jetty \
+  --out jetty-benchmark.json
+```
+
+Defaults follow Jetty docs and `jettyio/jettyio-skills`: `claude-code`, `claude-sonnet-4-6`, `model_provider=anthropic`, `snapshot=python312-uv`, runbook content in the system message, runtime values in `jetty.template_variables`, and uploaded files in `jetty.file_paths`. Use `JETTY_BASE_URL` to override `https://flows-api.jetty.io`.
+
 ## Ablations
 
 Ablations are opt-in variants that simulate removing part of a skill. Add entries under `manifest.ablations`, then prepare with `--include-ablations`.
@@ -327,11 +363,11 @@ Ablation task variants are named `ablation:<id>`. Trigger cases are skipped for 
 - **Anthropic skill-creator**: use `grade --write-grading-files` and `export-anthropic` for compatible `grading.json`/`benchmark.json` shapes.
 - **Pi**: use `examples/adewale-workspace/run_pi_smoke.py` for the Adewale multi-repo smoke workflow and `skill-pi-trigger-eval` for autonomous trigger checks.
 - **Other runners**: use `prepare` JSONL as the import format and write results back to the run output contract.
-- **Jetty**: use the OpenAI-compatible `/v1/chat/completions` endpoint with a `jetty` block as an external runner; add an adapter that exports prepared rows and imports Jetty trajectories into the run layout.
+- **Jetty**: use `export-jetty`, `run-jetty`, and `import-jetty-results` for REST runbook-mode execution. Live API response shapes still need token-backed smoke validation before claiming broad Jetty production coverage.
 
 ## Non-goals
 
-- This harness does not call a model from `skill_benchmark.py`; execution stays runner-agnostic.
+- Local grading does not call a model. Execution stays runner-agnostic except for explicit adapter commands such as `run-jetty`.
 - It does not replace human/LLM qualitative review; it emits judge tasks and merges results.
 - It does not make hidden prompts safe if you pass `--include-answer-key` to generation jobs.
 - It does not guarantee a skill triggers autonomously unless you run trigger evals.
@@ -361,7 +397,7 @@ python3 -m py_compile *.py
 python3 -m unittest discover tests -v
 ```
 
-The test suite covers repeated runs, artifact outputs, judge-result merging, answer-key omission, and Anthropic export shape.
+The test suite covers repeated runs, artifact outputs, judge-result merging, answer-key omission, Anthropic export shape, Jetty export shape, mocked Jetty execution, and Jetty import round trips.
 
 ## Source checked
 

--- a/TODO.md
+++ b/TODO.md
@@ -6,48 +6,50 @@ Jetty is an OpenAI-compatible workflow/agent platform with `POST https://flows-a
 
 ## API adapter
 
-- [ ] Add `export-jetty` command that converts prepared task rows into Jetty chat-completion payloads.
-- [ ] Support Jetty auth via `JETTY_API_TOKEN` / `JETTY_API_KEY`.
-- [ ] Use base URL `https://flows-api.jetty.io` by default with override env/flag.
-- [ ] Emit OpenAI-compatible fields: `model`, `messages`, `stream`.
-- [ ] Emit Jetty extension block with `runbook`, `collection`, `task`, `agent`, `model_provider`, `snapshot`, `template_variables`, `use_trial_keys`, and `file_paths` where applicable.
-- [ ] Preserve harness IDs in Jetty metadata: `skill_name`, `case_id`, `variant`, `run_number`, `split`, `run_dir`.
+- [x] Add `export-jetty` command that converts prepared task rows into Jetty chat-completion payloads.
+- [x] Support Jetty auth via `JETTY_API_TOKEN` for live `run-jetty`.
+- [x] Use base URL `https://flows-api.jetty.io` by default with `JETTY_BASE_URL` override.
+- [x] Emit OpenAI-compatible fields: `model`, `messages`, `stream`.
+- [x] Emit Jetty extension block with `runbook`, `collection`, `task`, `agent`, `model_provider`, `snapshot`, `template_variables`, `use_trial_keys`, and `file_paths` where applicable.
+- [x] Preserve harness IDs in Jetty records: `skill_name`, `case_id`, `variant`, `run_number`, `split`, `run_dir`.
 
 ## Runbook execution
 
-- [ ] Add a canonical Jetty runbook template for one harness task.
-- [ ] The runbook must write `/app/results/output.md`.
-- [ ] The runbook must write `/app/results/metadata.json`.
-- [ ] The runbook should copy artifacts to `/app/results/outputs/`.
-- [ ] Support practical Jetty agent runtimes from `jettyio-skills`: `claude-code`, `opencode`, `codex`, and `gemini-cli`.
-- [ ] Add per-variant runbook instructions for `with_skill`, `without_skill`, `old_skill`, and `ablation:<id>`.
+- [x] Add a canonical Jetty runbook template for one harness task.
+- [x] The runbook must write `/app/results/output.md`.
+- [x] The runbook must write `/app/results/metadata.json`.
+- [x] The runbook should copy artifacts to `/app/results/outputs/`.
+- [x] Support practical Jetty agent runtimes from `jettyio-skills`: `claude-code`, `opencode`, `codex`, and `gemini-cli`.
+- [x] Add per-variant runbook instructions for `with_skill`, `without_skill`, `old_skill`, and `ablation:<id>`.
 
 ## Skill and fixture mounting
 
-- [ ] Upload/mount skill files for `with_skill` runs.
-- [ ] Hide or omit skill files for `without_skill` runs; do not rely only on prose instructions when file controls are possible.
-- [ ] Upload old skill snapshots for `old_skill` runs.
-- [ ] Materialize ablated skill variants or generate an explicit ablation patch/instruction for `ablation:<id>`.
-- [ ] Upload private `prompt_ref` content only to executor jobs, not to public artifacts.
-- [ ] Upload fixture repos/files referenced by eval cases.
+- [x] Upload/mount skill files for `with_skill` runs.
+- [x] Hide or omit skill files for `without_skill` runs; do not rely only on prose instructions when file controls are possible.
+- [x] Upload old skill snapshots for `old_skill` runs.
+- [x] Generate an explicit instruction-simulated ablation marker for `ablation:<id>`.
+- [x] Put prompt content only in private generated `task.json`, not public artifacts.
+- [x] Upload fixture repos/files referenced by eval cases.
+- [ ] Materialize true ablated skill files instead of instruction-simulated ablations.
 
 ## Running and polling
 
-- [ ] Add `run-jetty` command that submits payloads and polls trajectory status.
-- [ ] Handle streaming and non-streaming Jetty responses.
-- [ ] Persist Jetty trajectory IDs immediately.
-- [ ] Retry transient API failures with bounded backoff.
+- [x] Add `run-jetty` command that submits payloads and polls trajectory status.
+- [x] Handle non-streaming Jetty responses.
+- [x] Persist Jetty trajectory IDs in run records as soon as submit returns them.
+- [x] Retry transient 429/5xx API failures with bounded backoff.
 - [ ] Support concurrency limits and rate-limit handling.
-- [ ] Support dry-run payload export without submission.
+- [x] Support dry-run payload loading without submission.
+- [ ] Handle streaming Jetty responses.
 
 ## Importing results
 
-- [ ] Add `import-jetty-results` command.
-- [ ] Download final assistant output into `runs/<case_id>/<variant>/run-<n>/output.md`.
-- [ ] Download generated artifacts into `outputs/`.
-- [ ] Normalize Jetty metrics into `metadata.json`: `elapsed_ms`, `input_tokens`, `output_tokens`, `total_tokens`, `model`, `total_tool_calls`, `errors_encountered`.
-- [ ] Preserve raw Jetty metadata: `jetty_trajectory_id`, `jetty_collection`, `jetty_task`, `jetty_agent`, `trace_url`, `jetty_raw`.
-- [ ] Keep local deterministic grading unchanged after import.
+- [x] Add `import-jetty-results` command.
+- [x] Import final assistant output into `runs/<case_id>/<variant>/run-<n>/output.md` when repeated, or the existing one-run layout.
+- [x] Import generated artifacts into `outputs/` when present in trajectory records.
+- [x] Normalize Jetty metrics into `metadata.json`: `elapsed_ms`, `input_tokens`, `output_tokens`, `total_tokens`, `model`, `total_tool_calls`, `errors_encountered`.
+- [x] Preserve raw Jetty metadata: `jetty_trajectory_id`, `jetty_collection`, `jetty_task`, `jetty_agent`, `trace_url`, `jetty_raw`.
+- [x] Keep local deterministic grading unchanged after import.
 
 ## Jetty evaluation integration
 
@@ -58,18 +60,19 @@ Jetty is an OpenAI-compatible workflow/agent platform with `POST https://flows-a
 
 ## Manifest extensions
 
-- [ ] Add optional `jetty` block to manifests.
-- [ ] Suggested fields: `collection`, `task_prefix`, `agent`, `model`, `model_provider`, `snapshot`, `use_trial_keys`, `grader_mode`, `skill_mount_strategy`.
+- [x] Read optional `jetty` block from manifests.
+- [x] Suggested fields: `collection`, `task_prefix`, `agent`, `model`, `model_provider`, `snapshot`, `use_trial_keys`, `grader_mode`, `skill_mount_strategy`.
 - [ ] Allow per-variant Jetty overrides under `jetty.variants.<variant>`.
 - [ ] Validate Jetty fields without making them required for non-Jetty users.
 
 ## CI and tests
 
-- [ ] Add golden tests for `export-jetty` payload shape.
-- [ ] Add mocked Jetty trajectory fixture.
-- [ ] Add importer round-trip test: Jetty result JSON -> harness run layout -> `benchmark`.
-- [ ] Add hidden-prompt safety test proving answer keys are not uploaded in executor payloads.
-- [ ] Add README quick start for Jetty once API behavior is verified with a real account.
+- [x] Add golden-style tests for `export-jetty` payload shape.
+- [x] Add mocked Jetty trajectory fixture coverage inline in tests.
+- [x] Add importer round-trip test: Jetty result JSON -> harness run layout -> `benchmark`.
+- [x] Add hidden-prompt/answer-key safety test proving answer keys are not uploaded in executor payloads.
+- [x] Add README quick start for the current mocked/dry-run Jetty path.
+- [ ] Add README live-smoke notes after API behavior is verified with a real account.
 
 ## Open questions to verify against current Jetty docs/API
 

--- a/docs/jetty-support-spec.md
+++ b/docs/jetty-support-spec.md
@@ -1,6 +1,6 @@
 # Jetty Support Spec
 
-Status: planned implementation, grounded in Jetty public docs and `jettyio/jettyio-skills` checked on 2026-06-09.
+Status: phase-1 adapter implemented for deterministic export, REST submission/polling, dry-run mode, and mocked trajectory import; live Jetty response shapes still need token-backed validation. Grounded in Jetty public docs and `jettyio/jettyio-skills` checked on 2026-06-09.
 
 This spec defines the simplest useful Jetty adapter for Skill Eval Harness. Jetty executes harness tasks in runbook mode and records trajectories/artifacts. Skill Eval Harness remains the source of truth for manifests, variants, splits, deterministic assertions, benchmark summaries, and saturation/no-lift flags.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "skill-eval-harness"
-version = "0.1.1"
-description = "Repo-agnostic Agent Skill evaluation harness with paired variants, holdout splits, repeated-run stats, Anthropic-compatible exports, and static review output."
+version = "0.2.0"
+description = "Repo-agnostic Agent Skill evaluation harness with paired variants, holdout splits, repeated-run stats, Anthropic-compatible exports, Jetty adapter support, and static review output."
 requires-python = ">=3.10"
 readme = "README.md"
 license = {text = "MIT"}

--- a/skill_benchmark.py
+++ b/skill_benchmark.py
@@ -8,13 +8,18 @@ and aggregates timing/token/pass-rate data.
 from __future__ import annotations
 
 import argparse
+import copy
 import html
 import json
+import os
 import random
 import re
 import statistics
 import sys
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -189,49 +194,684 @@ def variant_instruction(variant: str, manifest: dict[str, Any], repo_root: Path 
     return f"Run variant {variant}."
 
 
-def prepare(args: argparse.Namespace) -> int:
-    path = Path(args.manifest)
-    manifest = validate_manifest(path)
+def task_variants(manifest: dict[str, Any], *, include_old_skill: bool = False, include_ablations: bool = False) -> list[str]:
     variants = list(manifest.get("variants", DEFAULT_VARIANTS))
-    if args.include_old_skill:
+    if include_old_skill:
         old_paths = manifest.get("old_skill_paths") or []
         if not old_paths:
             die("--include-old-skill requires manifest.old_skill_paths to be populated")
         variants.append("old_skill")
-    if args.include_ablations:
+    if include_ablations:
         variants.extend(f"ablation:{a['id']}" for a in manifest.get("ablations", []))
-    runs_per_variant = max(1, int(getattr(args, "runs_per_variant", 1)))
-    cases = iter_cases(manifest, args.split)
-    repo_root = repo_root_for_manifest(path)
+    return variants
+
+
+def prepared_task_rows(
+    manifest_path: Path,
+    manifest: dict[str, Any],
+    *,
+    split: str | None = None,
+    include_old_skill: bool = False,
+    include_ablations: bool = False,
+    runs_per_variant: int = 1,
+    allow_missing_prompts: bool = False,
+    include_answer_key: bool = False,
+) -> list[dict[str, Any]]:
+    variants = task_variants(manifest, include_old_skill=include_old_skill, include_ablations=include_ablations)
+    runs_per_variant = max(1, int(runs_per_variant))
+    cases = iter_cases(manifest, split)
+    repo_root = repo_root_for_manifest(manifest_path)
+    rows: list[dict[str, Any]] = []
+    for case in cases:
+        for variant in variants:
+            if variant.startswith("ablation:") and case.get("kind") == "trigger":
+                continue
+            for run_number in range(1, runs_per_variant + 1):
+                run_dir = f"{case['id']}/{variant}" if runs_per_variant == 1 else f"{case['id']}/{variant}/run-{run_number}"
+                task = {
+                    "case_id": case["id"],
+                    "split": case["split"],
+                    "kind": case.get("kind", "behavior"),
+                    "variant": variant,
+                    "run_number": run_number,
+                    "skill_name": manifest["skill_name"],
+                    "repo_root": str(repo_root),
+                    "skill_paths": [str((repo_root / p).resolve()) for p in manifest.get("skill_paths", [])],
+                    "input_files": [str((manifest_path.parent / f).resolve()) for f in case.get("files", [])],
+                    "run_dir": run_dir,
+                    "instruction": variant_instruction(variant, manifest, repo_root),
+                    "prompt": case_prompt(case, manifest_path, allow_missing=allow_missing_prompts),
+                    **({"expected_behavior": case.get("expected_behavior", []), "review_rubric": case.get("review_rubric", [])} if include_answer_key else {}),
+                    "tags": case.get("tags", []),
+                }
+                rows.append(task)
+    return rows
+
+
+def prepare(args: argparse.Namespace) -> int:
+    path = Path(args.manifest)
+    manifest = validate_manifest(path)
+    rows = prepared_task_rows(
+        path,
+        manifest,
+        split=args.split,
+        include_old_skill=args.include_old_skill,
+        include_ablations=args.include_ablations,
+        runs_per_variant=getattr(args, "runs_per_variant", 1),
+        allow_missing_prompts=args.allow_missing_prompts,
+        include_answer_key=args.include_answer_key,
+    )
     out = Path(args.out) if args.out else None
     fh = out.open("w", encoding="utf-8") if out else sys.stdout
     try:
-        for case in cases:
-            for variant in variants:
-                if variant.startswith("ablation:") and case.get("kind") == "trigger":
-                    continue
-                for run_number in range(1, runs_per_variant + 1):
-                    run_dir = f"{case['id']}/{variant}" if runs_per_variant == 1 else f"{case['id']}/{variant}/run-{run_number}"
-                    task = {
-                        "case_id": case["id"],
-                        "split": case["split"],
-                        "kind": case.get("kind", "behavior"),
-                        "variant": variant,
-                        "run_number": run_number,
-                        "skill_name": manifest["skill_name"],
-                        "repo_root": str(repo_root),
-                        "skill_paths": [str((repo_root / p).resolve()) for p in manifest.get("skill_paths", [])],
-                        "input_files": [str((path.parent / f).resolve()) for f in case.get("files", [])],
-                        "run_dir": run_dir,
-                        "instruction": variant_instruction(variant, manifest, repo_root),
-                        "prompt": case_prompt(case, path, allow_missing=args.allow_missing_prompts),
-                        **({"expected_behavior": case.get("expected_behavior", []), "review_rubric": case.get("review_rubric", [])} if args.include_answer_key else {}),
-                        "tags": case.get("tags", []),
-                    }
-                    fh.write(json.dumps(task, ensure_ascii=False) + "\n")
+        for task in rows:
+            fh.write(json.dumps(task, ensure_ascii=False) + "\n")
     finally:
         if out:
             fh.close()
+    return 0
+
+
+JETTY_DEFAULT_AGENT = "claude-code"
+JETTY_DEFAULT_MODEL = "claude-sonnet-4-6"
+JETTY_DEFAULT_MODEL_PROVIDER = "anthropic"
+JETTY_DEFAULT_SNAPSHOT = "python312-uv"
+JETTY_ALLOWED_AGENTS = {"claude-code", "opencode", "codex", "gemini-cli"}
+JETTY_TERMINAL_SUCCESS = {"completed", "complete", "succeeded", "success"}
+JETTY_TERMINAL_FAILURE = {"failed", "failure", "error", "errored", "canceled", "cancelled", "timeout", "timed_out"}
+JETTY_PENDING = {"pending", "queued", "running", "in_progress", "starting"}
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip().lower()).strip("-")
+    return slug or "task"
+
+
+def jetty_task_name(task: dict[str, Any], prefix: str | None = None) -> str:
+    base = prefix or task.get("skill_name") or "skill-eval"
+    return "-".join(slugify(str(part)) for part in [base, task["case_id"], task["variant"], str(task.get("run_number", 1))])
+
+
+def canonical_jetty_runbook(agent: str, model: str, model_provider: str, snapshot: str) -> str:
+    return f'''---
+version: "1.0.0"
+evaluation: programmatic
+agent: {agent}
+model: {model}
+model_provider: {model_provider}
+snapshot: {snapshot}
+primary_outputs:
+  - output.md
+---
+
+# Skill Eval Harness Task
+
+## Objective
+
+Execute one Skill Eval Harness task exactly once. Write the final assistant answer and metadata to the required output files.
+
+## REQUIRED OUTPUT FILES
+
+| Path | Purpose |
+|---|---|
+| `{{{{results_dir}}}}/output.md` | Final assistant answer only. |
+| `{{{{results_dir}}}}/metadata.json` | JSON metadata for model/runtime/tool/error data. |
+| `{{{{results_dir}}}}/outputs/` | Optional generated artifacts. |
+
+## Parameters
+
+- `{{{{results_dir}}}}` — defaults to `/app/results` on Jetty.
+- `{{{{task_json}}}}` — uploaded task JSON generated by Skill Eval Harness.
+
+## Steps
+
+1. Read `{{{{task_json}}}}`.
+2. Read every fixture listed in `task_json.input_files`.
+3. If `task_json.variant` is `with_skill`, read and follow the mounted skill files.
+4. If `task_json.variant` is `without_skill`, do not use a skill. No skill files should be mounted.
+5. Answer the user task directly.
+6. Write `{{{{results_dir}}}}/output.md`.
+7. Write `{{{{results_dir}}}}/metadata.json`.
+8. Put any additional generated artifacts under `{{{{results_dir}}}}/outputs/`.
+
+## Evaluation
+
+Programmatic evaluation happens after import by Skill Eval Harness. Do not include hidden grading rubrics or answer keys in the output.
+'''
+
+
+def placeholder(task_name: str, role: str, index: int | str) -> str:
+    return f"upload://{task_name}/{role}/{index}"
+
+
+def safe_task_json(task: dict[str, Any], manifest: dict[str, Any], *, task_name: str, upload_files: list[dict[str, Any]]) -> dict[str, Any]:
+    variant = str(task["variant"])
+    safe = {
+        "case_id": task["case_id"],
+        "split": task["split"],
+        "kind": task.get("kind", "behavior"),
+        "variant": variant,
+        "run_number": task.get("run_number", 1),
+        "skill_name": task["skill_name"],
+        "instruction": task.get("instruction", ""),
+        "prompt": task.get("prompt", ""),
+        "input_files": [item["placeholder"] for item in upload_files if item.get("role") == "fixture"],
+        "skill_files": [],
+        "tags": task.get("tags", []),
+    }
+    if variant == "with_skill":
+        safe["skill_files"] = [item["placeholder"] for item in upload_files if item.get("role") == "skill"]
+    elif variant == "old_skill":
+        safe["skill_files"] = [item["placeholder"] for item in upload_files if item.get("role") == "old_skill"]
+    elif variant.startswith("ablation:"):
+        aid = variant.split(":", 1)[1]
+        ablation = next((a for a in manifest.get("ablations", []) if a.get("id") == aid), {})
+        safe["skill_files"] = [item["placeholder"] for item in upload_files if item.get("role") == "skill"]
+        safe["ablation"] = {
+            "id": aid,
+            "mode": "instruction_simulated",
+            "removed_component": ablation.get("removed_component"),
+            "expected_regressions": ablation.get("expected_regressions", []),
+        }
+    else:
+        safe["skill_files"] = []
+    return safe
+
+
+def build_jetty_payload(
+    task: dict[str, Any],
+    manifest: dict[str, Any],
+    *,
+    collection: str,
+    task_prefix: str | None,
+    agent: str,
+    model: str,
+    model_provider: str,
+    snapshot: str,
+    use_trial_keys: bool = False,
+) -> dict[str, Any]:
+    variant = str(task["variant"])
+    task_name = jetty_task_name(task, task_prefix)
+    files: list[dict[str, Any]] = []
+    for i, local in enumerate(task.get("input_files", []), 1):
+        files.append({
+            "role": "fixture",
+            "placeholder": placeholder(task_name, "fixture", i),
+            "local_path": str(Path(local).resolve()),
+            "remote_path_hint": f"fixtures/{Path(local).name}",
+            "private": False,
+        })
+    if variant == "with_skill":
+        for i, local in enumerate(task.get("skill_paths", []), 1):
+            files.append({
+                "role": "skill",
+                "placeholder": placeholder(task_name, "skill", i),
+                "local_path": str(Path(local).resolve()),
+                "remote_path_hint": f"skills/{task['skill_name']}/{Path(local).name}",
+                "private": False,
+            })
+    elif variant == "old_skill":
+        old_paths = manifest.get("old_skill_paths") or []
+        if not old_paths:
+            die("old_skill export requires manifest.old_skill_paths to be populated")
+        repo_root = Path(task["repo_root"])
+        for i, raw in enumerate(old_paths, 1):
+            local = Path(raw)
+            if not local.is_absolute():
+                local = repo_root / local
+            files.append({
+                "role": "old_skill",
+                "placeholder": placeholder(task_name, "old-skill", i),
+                "local_path": str(local.resolve()),
+                "remote_path_hint": f"old-skills/{task['skill_name']}/{local.name}",
+                "private": False,
+            })
+    elif variant.startswith("ablation:"):
+        for i, local in enumerate(task.get("skill_paths", []), 1):
+            files.append({
+                "role": "skill",
+                "placeholder": placeholder(task_name, "skill", i),
+                "local_path": str(Path(local).resolve()),
+                "remote_path_hint": f"skills/{task['skill_name']}/{Path(local).name}",
+                "private": False,
+            })
+    task_json = safe_task_json(task, manifest, task_name=task_name, upload_files=files)
+    task_placeholder = placeholder(task_name, "task", "json")
+    task_item = {
+        "role": "task",
+        "placeholder": task_placeholder,
+        "content": json.dumps(task_json, ensure_ascii=False, indent=2) + "\n",
+        "remote_path_hint": f"tasks/{task_name}.json",
+        "private": True,
+    }
+    all_files = [task_item] + files
+    if variant == "without_skill" and any(item.get("role") in {"skill", "old_skill", "ablation_skill"} for item in all_files):
+        die(f"{task['case_id']}: without_skill payload attempted to mount skill files")
+    if variant == "with_skill" and not any(item.get("role") == "skill" for item in all_files):
+        die(f"{task['case_id']}: with_skill payload has no skill files")
+    jetty_block = {
+        "runbook": True,
+        "collection": collection,
+        "task": task_name,
+        "agent": agent,
+        "model_provider": model_provider,
+        "snapshot": snapshot,
+        "template_variables": {
+            "results_dir": "/app/results",
+            "task_json": task_placeholder,
+        },
+        "file_paths": [item["placeholder"] for item in all_files],
+    }
+    if use_trial_keys:
+        jetty_block["use_trial_keys"] = True
+    return {
+        "harness": {
+            "skill_name": task["skill_name"],
+            "case_id": task["case_id"],
+            "variant": variant,
+            "run_number": task.get("run_number", 1),
+            "split": task["split"],
+            "run_dir": task["run_dir"],
+            "executable": not str(task.get("prompt", "")).startswith("<hidden prompt:"),
+        },
+        "jetty_request": {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": canonical_jetty_runbook(agent, model, model_provider, snapshot)},
+                {"role": "user", "content": "Execute the runbook."},
+            ],
+            "stream": False,
+            "jetty": jetty_block,
+        },
+        "upload_plan": {"files": all_files},
+    }
+
+
+def export_jetty(args: argparse.Namespace) -> int:
+    path = Path(args.manifest)
+    manifest = validate_manifest(path)
+    agent = getattr(args, "jetty_agent", None) or manifest.get("jetty", {}).get("agent") or JETTY_DEFAULT_AGENT
+    if agent not in JETTY_ALLOWED_AGENTS:
+        die(f"unsupported Jetty agent {agent!r}; expected one of {sorted(JETTY_ALLOWED_AGENTS)}")
+    model = getattr(args, "jetty_model", None) or manifest.get("jetty", {}).get("model") or JETTY_DEFAULT_MODEL
+    model_provider = getattr(args, "jetty_model_provider", None) or manifest.get("jetty", {}).get("model_provider") or JETTY_DEFAULT_MODEL_PROVIDER
+    snapshot = getattr(args, "jetty_snapshot", None) or manifest.get("jetty", {}).get("snapshot") or JETTY_DEFAULT_SNAPSHOT
+    collection = getattr(args, "jetty_collection", None) or manifest.get("jetty", {}).get("collection") or "skill-evals"
+    task_prefix = getattr(args, "jetty_task_prefix", None) or manifest.get("jetty", {}).get("task_prefix")
+    rows = prepared_task_rows(
+        path,
+        manifest,
+        split=getattr(args, "split", None),
+        include_old_skill=getattr(args, "include_old_skill", False),
+        include_ablations=getattr(args, "include_ablations", False),
+        runs_per_variant=getattr(args, "runs_per_variant", 1),
+        allow_missing_prompts=getattr(args, "allow_missing_prompts", False),
+        include_answer_key=False,
+    )
+    payloads = [build_jetty_payload(
+        row,
+        manifest,
+        collection=collection,
+        task_prefix=task_prefix,
+        agent=agent,
+        model=model,
+        model_provider=model_provider,
+        snapshot=snapshot,
+        use_trial_keys=bool(getattr(args, "use_trial_keys", False) or manifest.get("jetty", {}).get("use_trial_keys", False)),
+    ) for row in rows]
+    out = Path(args.out) if getattr(args, "out", None) else None
+    fh = out.open("w", encoding="utf-8") if out else sys.stdout
+    try:
+        for payload in payloads:
+            fh.write(json.dumps(payload, ensure_ascii=False) + "\n")
+    finally:
+        if out:
+            fh.close()
+    return 0
+
+
+def replace_placeholders(value: Any, mapping: dict[str, str]) -> Any:
+    if isinstance(value, str):
+        out = value
+        for old, new in mapping.items():
+            out = out.replace(old, new)
+        return out
+    if isinstance(value, list):
+        return [replace_placeholders(v, mapping) for v in value]
+    if isinstance(value, dict):
+        return {k: replace_placeholders(v, mapping) for k, v in value.items()}
+    return value
+
+
+def extract_trajectory_id(response: dict[str, Any]) -> str | None:
+    for key in ["trajectory_id", "trajectoryId", "id"]:
+        if response.get(key):
+            return str(response[key])
+    jetty = response.get("jetty")
+    if isinstance(jetty, dict):
+        for key in ["trajectory_id", "trajectoryId", "id"]:
+            if jetty.get(key):
+                return str(jetty[key])
+    return None
+
+
+class JettyClient:
+    def __init__(self, token: str, base_url: str = "https://flows-api.jetty.io"):
+        self.token = token
+        self.base_url = base_url.rstrip("/")
+
+    def _open_with_retries(self, req: urllib.request.Request, *, timeout: int = 120, attempts: int = 3) -> Any:
+        for attempt in range(attempts):
+            try:
+                return urllib.request.urlopen(req, timeout=timeout)
+            except urllib.error.HTTPError as exc:
+                transient = exc.code == 429 or 500 <= exc.code < 600
+                if not transient or attempt == attempts - 1:
+                    raise
+                time.sleep(min(2 ** attempt, 10))
+        raise RuntimeError("unreachable retry state")
+
+    def _json_request(self, method: str, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        data = None if body is None else json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(
+            self.base_url + path,
+            data=data,
+            method=method,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+        )
+        with self._open_with_retries(req, timeout=120) as resp:
+            text = resp.read().decode("utf-8", errors="replace")
+            return json.loads(text) if text.strip() else {}
+
+    def upload(self, item: dict[str, Any], collection: str) -> str:
+        boundary = f"----skill-eval-harness-{int(time.time() * 1000)}"
+        parts: list[bytes] = []
+        def add_field(name: str, value: str) -> None:
+            parts.append(f"--{boundary}\r\nContent-Disposition: form-data; name=\"{name}\"\r\n\r\n{value}\r\n".encode("utf-8"))
+        add_field("collection", collection)
+        filename = item.get("remote_path_hint") or (Path(str(item.get("local_path", "file"))).name)
+        if "content" in item:
+            raw = item["content"]
+            content = json.dumps(raw, ensure_ascii=False).encode("utf-8") if isinstance(raw, (dict, list)) else str(raw).encode("utf-8")
+        else:
+            content = Path(str(item["local_path"])).read_bytes()
+        parts.append(f"--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"{filename}\"\r\nContent-Type: application/octet-stream\r\n\r\n".encode("utf-8"))
+        parts.append(content)
+        parts.append(b"\r\n")
+        parts.append(f"--{boundary}--\r\n".encode("utf-8"))
+        req = urllib.request.Request(
+            self.base_url + "/api/v1/files/upload",
+            data=b"".join(parts),
+            method="POST",
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": f"multipart/form-data; boundary={boundary}"},
+        )
+        with self._open_with_retries(req, timeout=120) as resp:
+            data = json.loads(resp.read().decode("utf-8", errors="replace") or "{}")
+        for key in ["path", "file_path", "filePath", "url", "id"]:
+            if data.get(key):
+                return str(data[key])
+        if isinstance(data.get("file"), dict):
+            for key in ["path", "file_path", "filePath", "url", "id"]:
+                if data["file"].get(key):
+                    return str(data["file"][key])
+        raise RuntimeError(f"Jetty upload response did not include a file path: {data}")
+
+    def submit(self, request_body: dict[str, Any]) -> dict[str, Any]:
+        return self._json_request("POST", "/v1/chat/completions", request_body)
+
+    def poll(self, collection: str, task: str, trajectory_id: str, *, timeout_s: int = 1800, poll_interval_s: float = 5) -> dict[str, Any]:
+        deadline = time.time() + timeout_s
+        quoted = "/".join(urllib.parse.quote(part, safe="") for part in [collection, task, trajectory_id])
+        path = f"/api/v1/db/trajectory/{quoted}"
+        last: dict[str, Any] = {}
+        while time.time() <= deadline:
+            last = self._json_request("GET", path)
+            status = str(last.get("status", last.get("state", "unknown"))).lower()
+            if status in JETTY_TERMINAL_SUCCESS | JETTY_TERMINAL_FAILURE:
+                return last
+            if status not in JETTY_PENDING:
+                last["status"] = status or "unknown"
+                return last
+            time.sleep(poll_interval_s)
+        last["status"] = "timeout"
+        return last
+
+
+def execute_jetty_payloads(payloads: list[dict[str, Any]], *, client: Any, timeout_s: int = 1800, poll_interval_s: float = 5) -> Any:
+    for row in payloads:
+        harness = row.get("harness", {})
+        if harness.get("executable") is False:
+            yield {
+                "harness": harness,
+                "status": "failed",
+                "trajectory_id": None,
+                "jetty": row.get("jetty_request", {}).get("jetty", {}),
+                "error": "payload is non-executable; missing hidden prompt content or dry-run placeholder",
+                "artifacts": [],
+            }
+            continue
+        request = copy.deepcopy(row.get("jetty_request", {}))
+        jetty = request.get("jetty", {})
+        collection = str(jetty.get("collection", ""))
+        task_name = str(jetty.get("task", ""))
+        mapping: dict[str, str] = {}
+        trajectory_id = None
+        try:
+            files = list(row.get("upload_plan", {}).get("files", []))
+            files.sort(key=lambda item: 1 if item.get("role") == "task" else 0)
+            for item in files:
+                upload_item = replace_placeholders(copy.deepcopy(item), mapping)
+                remote = client.upload(upload_item, collection)
+                if item.get("placeholder"):
+                    mapping[str(item["placeholder"])] = remote
+            request = replace_placeholders(request, mapping)
+            submission = client.submit(request)
+            trajectory_id = extract_trajectory_id(submission)
+            if not trajectory_id:
+                raise RuntimeError(f"Jetty submit response did not include trajectory_id: {submission}")
+            trajectory = client.poll(collection, task_name, trajectory_id, timeout_s=timeout_s, poll_interval_s=poll_interval_s)
+            status = str(trajectory.get("status", trajectory.get("state", "unknown"))).lower()
+            if status in JETTY_TERMINAL_SUCCESS:
+                normalized_status = "completed"
+            elif status in JETTY_TERMINAL_FAILURE:
+                normalized_status = "failed" if status != "timeout" else "timeout"
+            else:
+                normalized_status = "unknown"
+            yield {
+                "harness": harness,
+                "status": normalized_status,
+                "trajectory_id": trajectory_id,
+                "jetty": {
+                    "collection": collection,
+                    "task": task_name,
+                    "agent": jetty.get("agent"),
+                    "model": request.get("model"),
+                    "model_provider": jetty.get("model_provider"),
+                    "snapshot": jetty.get("snapshot"),
+                },
+                "submitted_request": request,
+                "submission_response": submission,
+                "trajectory": trajectory,
+                "artifacts": trajectory.get("artifacts", trajectory.get("outputs", [])) if isinstance(trajectory, dict) else [],
+            }
+        except Exception as exc:
+            yield {
+                "harness": harness,
+                "status": "failed",
+                "trajectory_id": trajectory_id,
+                "jetty": {
+                    "collection": collection,
+                    "task": task_name,
+                    "agent": jetty.get("agent"),
+                    "model": request.get("model"),
+                    "model_provider": jetty.get("model_provider"),
+                    "snapshot": jetty.get("snapshot"),
+                },
+                "error": str(exc),
+                "artifacts": [],
+            }
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def run_jetty(args: argparse.Namespace) -> int:
+    payloads = load_jsonl(Path(args.payloads))
+    if getattr(args, "dry_run", False):
+        records = [{"harness": p.get("harness", {}), "status": "dry_run", "jetty": p.get("jetty_request", {}).get("jetty", {})} for p in payloads]
+    else:
+        token = os.environ.get("JETTY_API_TOKEN")
+        if not token:
+            die("JETTY_API_TOKEN is required for run-jetty (use --dry-run to validate payload loading only)")
+        client = JettyClient(token, os.environ.get("JETTY_BASE_URL", "https://flows-api.jetty.io"))
+        records = list(execute_jetty_payloads(payloads, client=client, timeout_s=getattr(args, "timeout", 1800), poll_interval_s=getattr(args, "poll_interval", 5)))
+    out = Path(args.out) if getattr(args, "out", None) else None
+    fh = out.open("w", encoding="utf-8") if out else sys.stdout
+    try:
+        for record in records:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    finally:
+        if out:
+            fh.close()
+    return 0
+
+
+def artifact_content(artifact: dict[str, Any]) -> Any:
+    for key in ["content", "text", "body"]:
+        if key in artifact:
+            return artifact[key]
+    return None
+
+
+def artifact_rel_path(artifact: dict[str, Any]) -> Path | None:
+    raw = str(artifact.get("path") or artifact.get("name") or artifact.get("filename") or "")
+    if not raw:
+        return None
+    raw = raw.replace("\\", "/")
+    for prefix in ["/app/results/", "app/results/", "results/"]:
+        if raw.startswith(prefix):
+            raw = raw[len(prefix):]
+            break
+    raw = raw.lstrip("/")
+    if not raw or ".." in Path(raw).parts:
+        return None
+    rel = Path(raw)
+    if rel.parts and rel.parts[0] in {"output.md", "metadata.json", "outputs"}:
+        return rel
+    if rel.name in {"output.md", "metadata.json"}:
+        return Path(rel.name)
+    return Path("outputs") / rel.name
+
+
+def write_artifact(base: Path, artifact: dict[str, Any]) -> None:
+    rel = artifact_rel_path(artifact)
+    if rel is None:
+        return
+    content = artifact_content(artifact)
+    if content is None:
+        return
+    dest = base / rel
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, (dict, list)):
+        dest.write_text(json.dumps(content, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    else:
+        dest.write_text(str(content), encoding="utf-8")
+
+
+def find_output_artifact(artifacts: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for artifact in artifacts:
+        rel = artifact_rel_path(artifact)
+        if rel and rel.as_posix() == "output.md" and artifact_content(artifact) is not None:
+            return artifact
+    return None
+
+
+def artifact_metadata(artifacts: list[dict[str, Any]]) -> dict[str, Any]:
+    for artifact in artifacts:
+        rel = artifact_rel_path(artifact)
+        if not rel or rel.as_posix() != "metadata.json":
+            continue
+        content = artifact_content(artifact)
+        if isinstance(content, dict):
+            return content
+        if isinstance(content, str):
+            try:
+                data = json.loads(content)
+                return data if isinstance(data, dict) else {}
+            except json.JSONDecodeError:
+                return {"metadata_error": "invalid Jetty metadata artifact"}
+    return {}
+
+
+def normalized_jetty_metadata(record: dict[str, Any], *, success: bool) -> dict[str, Any]:
+    jetty = record.get("jetty", {}) if isinstance(record.get("jetty"), dict) else {}
+    trajectory = record.get("trajectory", {}) if isinstance(record.get("trajectory"), dict) else {}
+    usage = trajectory.get("usage", {}) if isinstance(trajectory.get("usage"), dict) else {}
+    collection = jetty.get("collection")
+    task = jetty.get("task")
+    trajectory_id = record.get("trajectory_id")
+    elapsed = trajectory.get("elapsed_ms", trajectory.get("duration_ms"))
+    total_tokens = trajectory.get("total_tokens", usage.get("total_tokens"))
+    tool_calls = trajectory.get("total_tool_calls")
+    if tool_calls is None and isinstance(trajectory.get("tool_calls"), int):
+        tool_calls = trajectory.get("tool_calls")
+    meta = {
+        "provider": "jetty",
+        "model": jetty.get("model"),
+        "model_provider": jetty.get("model_provider"),
+        "elapsed_ms": elapsed,
+        "input_tokens": trajectory.get("input_tokens", usage.get("input_tokens", usage.get("prompt_tokens"))),
+        "output_tokens": trajectory.get("output_tokens", usage.get("output_tokens", usage.get("completion_tokens"))),
+        "total_tokens": total_tokens,
+        "total_tool_calls": tool_calls,
+        "errors_encountered": 0 if success else 1,
+        "returncode": 0 if success else 1,
+        "timed_out": record.get("status") == "timeout",
+        "jetty_trajectory_id": trajectory_id,
+        "jetty_collection": collection,
+        "jetty_task": task,
+        "jetty_agent": jetty.get("agent"),
+        "jetty_snapshot": jetty.get("snapshot"),
+        "trace_url": f"https://jetty.io/{collection}/{task}/{trajectory_id}" if collection and task and trajectory_id else None,
+        "jetty_raw_path": "jetty_raw.json",
+    }
+    return {k: v for k, v in meta.items() if v is not None}
+
+
+def import_jetty_results(args: argparse.Namespace) -> int:
+    validate_manifest(Path(args.manifest))
+    runs = Path(args.runs)
+    records = load_jsonl(Path(args.jetty_runs))
+    for record in records:
+        harness = record.get("harness", {})
+        run_dir = harness.get("run_dir")
+        if run_dir:
+            base = runs / str(run_dir)
+        else:
+            case_id = str(harness.get("case_id", "unknown-case"))
+            variant = str(harness.get("variant", "unknown-variant"))
+            run_number = int(harness.get("run_number", 1) or 1)
+            base = runs / case_id / variant if run_number == 1 else runs / case_id / variant / f"run-{run_number}"
+        base.mkdir(parents=True, exist_ok=True)
+        write_json(base / "jetty_raw.json", record)
+        artifacts = record.get("artifacts") or []
+        if not artifacts and isinstance(record.get("trajectory"), dict):
+            artifacts = record["trajectory"].get("artifacts", record["trajectory"].get("outputs", [])) or []
+        artifacts = [a for a in artifacts if isinstance(a, dict)]
+        success = str(record.get("status", "")).lower() == "completed" and find_output_artifact(artifacts) is not None
+        if success:
+            for artifact in artifacts:
+                write_artifact(base, artifact)
+        else:
+            (base / "output.md").write_text("[JETTY FAILURE: trajectory failed before producing output]\n", encoding="utf-8")
+        meta = artifact_metadata(artifacts)
+        meta.update(normalized_jetty_metadata(record, success=success))
+        write_json(base / "metadata.json", meta)
     return 0
 
 
@@ -1194,6 +1834,36 @@ def main() -> int:
     p.add_argument("--allow-missing-prompts", action="store_true", help="dry-run hidden prompt_ref cases even when private files are absent")
     p.add_argument("--include-answer-key", action="store_true", help="include expected_behavior/review_rubric in prepared tasks; use only for judge/debug tasks, not generation")
 
+    p = sub.add_parser("export-jetty")
+    p.add_argument("manifest")
+    p.add_argument("--split", choices=sorted(VALID_SPLITS))
+    p.add_argument("--out")
+    p.add_argument("--include-ablations", action="store_true")
+    p.add_argument("--include-old-skill", action="store_true")
+    p.add_argument("--runs-per-variant", type=int, default=1)
+    p.add_argument("--allow-missing-prompts", action="store_true")
+    p.add_argument("--jetty-collection", default=None)
+    p.add_argument("--jetty-task-prefix", default=None)
+    p.add_argument("--jetty-agent", default=None)
+    p.add_argument("--jetty-model", default=None)
+    p.add_argument("--jetty-model-provider", default=None)
+    p.add_argument("--jetty-snapshot", default=None)
+    p.add_argument("--use-trial-keys", action="store_true")
+    p.add_argument("--dry-run", action="store_true", help="accepted for symmetry; export never performs network calls")
+
+    p = sub.add_parser("run-jetty")
+    p.add_argument("--payloads", required=True)
+    p.add_argument("--out")
+    p.add_argument("--timeout", type=int, default=1800)
+    p.add_argument("--poll-interval", type=float, default=5)
+    p.add_argument("--concurrency", type=int, default=1, help="reserved; current implementation runs sequentially")
+    p.add_argument("--dry-run", action="store_true")
+
+    p = sub.add_parser("import-jetty-results")
+    p.add_argument("--manifest", required=True)
+    p.add_argument("--jetty-runs", required=True)
+    p.add_argument("--runs", required=True)
+
     p = sub.add_parser("grade")
     p.add_argument("manifest")
     p.add_argument("--runs", required=True)
@@ -1272,6 +1942,12 @@ def main() -> int:
         return 0
     if args.cmd == "prepare":
         return prepare(args)
+    if args.cmd == "export-jetty":
+        return export_jetty(args)
+    if args.cmd == "run-jetty":
+        return run_jetty(args)
+    if args.cmd == "import-jetty-results":
+        return import_jetty_results(args)
     if args.cmd == "grade":
         return grade(args)
     if args.cmd == "benchmark":

--- a/tests/test_skill_benchmark.py
+++ b/tests/test_skill_benchmark.py
@@ -3,6 +3,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 
 ROOT = Path(__file__).resolve().parents[1]
 SPEC = importlib.util.spec_from_file_location("skill_benchmark", ROOT / "skill_benchmark.py")
@@ -213,6 +214,155 @@ class SkillBenchmarkTests(unittest.TestCase):
             sb.prepare(Args)
             first = json.loads(Path(Args.out).read_text(encoding="utf-8").splitlines()[0])
             self.assertEqual(first["input_files"], [str(fixture.resolve())])
+
+    def test_export_jetty_payload_has_runbook_contract_and_variant_mounts(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            manifest = self.make_manifest(root)
+            fixture = manifest.parent / "fixtures" / "case-1" / "input.txt"
+            fixture.parent.mkdir(parents=True)
+            fixture.write_text("fixture", encoding="utf-8")
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            data["cases"][0]["files"] = ["fixtures/case-1/input.txt"]
+            manifest.write_text(json.dumps(data), encoding="utf-8")
+            out = root / "jetty-payloads.jsonl"
+            args = SimpleNamespace(
+                manifest=str(manifest), split="tune", runs_per_variant=1,
+                include_old_skill=False, include_ablations=False, allow_missing_prompts=False,
+                jetty_collection="skill-evals", jetty_task_prefix=None,
+                jetty_agent="claude-code", jetty_model="claude-sonnet-4-6",
+                jetty_model_provider="anthropic", jetty_snapshot="python312-uv",
+                use_trial_keys=False, out=str(out), dry_run=False,
+            )
+            sb.export_jetty(args)
+            rows = [json.loads(line) for line in out.read_text(encoding="utf-8").splitlines()]
+            self.assertEqual([r["harness"]["variant"] for r in rows], ["with_skill", "without_skill"])
+            with_row, without_row = rows
+            jetty = with_row["jetty_request"]["jetty"]
+            self.assertEqual(with_row["jetty_request"]["messages"][1]["content"], "Execute the runbook.")
+            self.assertEqual(jetty["model_provider"], "anthropic")
+            self.assertEqual(jetty["snapshot"], "python312-uv")
+            self.assertEqual(jetty["template_variables"]["results_dir"], "/app/results")
+            self.assertIn("task_json", jetty["template_variables"])
+            self.assertNotIn("expected_behavior", json.dumps(with_row))
+            self.assertNotIn("review_rubric", json.dumps(with_row))
+            self.assertIn("{{task_json}}", with_row["jetty_request"]["messages"][0]["content"])
+            with_roles = {f["role"] for f in with_row["upload_plan"]["files"]}
+            without_roles = {f["role"] for f in without_row["upload_plan"]["files"]}
+            self.assertTrue({"task", "skill", "fixture"}.issubset(with_roles))
+            self.assertNotIn("skill", without_roles)
+            self.assertTrue({"task", "fixture"}.issubset(without_roles))
+            without_task_json = next(f for f in without_row["upload_plan"]["files"] if f["role"] == "task")["content"]
+            self.assertEqual(json.loads(without_task_json)["skill_files"], [])
+
+    def test_import_jetty_results_roundtrip_can_be_benchmarked(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            manifest = self.make_manifest(root)
+            runs = root / "runs"
+            jetty_runs = root / "jetty-runs.jsonl"
+            completed = {
+                "harness": {"skill_name": "demo", "case_id": "case-1", "variant": "with_skill", "run_number": 1, "split": "tune", "run_dir": "case-1/with_skill"},
+                "status": "completed",
+                "trajectory_id": "traj_1",
+                "jetty": {"collection": "skill-evals", "task": "demo-case-1-with-skill-1", "agent": "claude-code", "model": "claude-sonnet-4-6", "model_provider": "anthropic", "snapshot": "python312-uv"},
+                "trajectory": {"usage": {"total_tokens": 12}, "elapsed_ms": 34},
+                "artifacts": [
+                    {"path": "/app/results/output.md", "content": "alpha beta"},
+                    {"path": "/app/results/metadata.json", "content": {"total_tool_calls": 2}},
+                ],
+            }
+            failed = {
+                "harness": {"skill_name": "demo", "case_id": "case-1", "variant": "without_skill", "run_number": 1, "split": "tune", "run_dir": "case-1/without_skill"},
+                "status": "failed",
+                "trajectory_id": "traj_2",
+                "jetty": {"collection": "skill-evals", "task": "demo-case-1-without-skill-1", "agent": "claude-code", "model": "claude-sonnet-4-6", "model_provider": "anthropic", "snapshot": "python312-uv"},
+                "trajectory": {"error": "boom"},
+            }
+            jetty_runs.write_text(json.dumps(completed) + "\n" + json.dumps(failed) + "\n", encoding="utf-8")
+            sb.import_jetty_results(SimpleNamespace(manifest=str(manifest), jetty_runs=str(jetty_runs), runs=str(runs)))
+            self.assertEqual((runs / "case-1" / "with_skill" / "output.md").read_text(encoding="utf-8"), "alpha beta")
+            meta = json.loads((runs / "case-1" / "with_skill" / "metadata.json").read_text(encoding="utf-8"))
+            self.assertEqual(meta["provider"], "jetty")
+            self.assertEqual(meta["jetty_trajectory_id"], "traj_1")
+            self.assertIn("JETTY FAILURE", (runs / "case-1" / "without_skill" / "output.md").read_text(encoding="utf-8"))
+            report = sb.build_benchmark_report(manifest, runs, variants_arg=["with_skill"])
+            self.assertEqual(report["summary"]["with_skill"]["mean_objective_pass_rate"], 1.0)
+
+    def test_export_jetty_hidden_prompt_placeholder_is_non_executable(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            manifest = self.make_manifest(root)
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            data["cases"] = [{
+                "id": "holdout-1",
+                "split": "holdout",
+                "kind": "behavior",
+                "prompt_ref": "holdout/private.md",
+                "assertions": [{"name": "has-alpha", "type": "contains", "value": "alpha"}],
+            }]
+            manifest.write_text(json.dumps(data), encoding="utf-8")
+            out = root / "jetty-payloads.jsonl"
+            args = SimpleNamespace(
+                manifest=str(manifest), split="holdout", runs_per_variant=1,
+                include_old_skill=False, include_ablations=False, allow_missing_prompts=True,
+                jetty_collection="skill-evals", jetty_task_prefix=None,
+                jetty_agent="claude-code", jetty_model="claude-sonnet-4-6",
+                jetty_model_provider="anthropic", jetty_snapshot="python312-uv",
+                use_trial_keys=False, out=str(out), dry_run=True,
+            )
+            sb.export_jetty(args)
+            row = json.loads(out.read_text(encoding="utf-8").splitlines()[0])
+            self.assertFalse(row["harness"]["executable"])
+
+            class ShouldNotCallClient:
+                def upload(self, *args, **kwargs):
+                    raise AssertionError("non-executable payload should not upload")
+
+            records = list(sb.execute_jetty_payloads([row], client=ShouldNotCallClient()))
+            self.assertEqual(records[0]["status"], "failed")
+            self.assertIn("non-executable", records[0]["error"])
+
+    def test_run_jetty_uploads_submits_polls_and_replaces_placeholders(self):
+        row = {
+            "harness": {"skill_name": "demo", "case_id": "case-1", "variant": "with_skill", "run_number": 1, "split": "tune", "run_dir": "case-1/with_skill"},
+            "jetty_request": {
+                "model": "claude-sonnet-4-6",
+                "messages": [{"role": "system", "content": "runbook"}, {"role": "user", "content": "Execute the runbook."}],
+                "stream": False,
+                "jetty": {
+                    "runbook": True,
+                    "collection": "skill-evals",
+                    "task": "demo-case-1-with-skill-1",
+                    "agent": "claude-code",
+                    "model_provider": "anthropic",
+                    "snapshot": "python312-uv",
+                    "template_variables": {"results_dir": "/app/results", "task_json": "upload://task-json"},
+                    "file_paths": ["upload://task-json"],
+                },
+            },
+            "upload_plan": {"files": [{"role": "task", "placeholder": "upload://task-json", "content": "{}", "remote_path_hint": "task.json", "private": True}]},
+        }
+
+        class FakeClient:
+            def __init__(self):
+                self.submitted = None
+            def upload(self, item, collection):
+                self.uploaded = (item, collection)
+                return "uploads/task.json"
+            def submit(self, request_body):
+                self.submitted = request_body
+                return {"trajectory_id": "traj_1"}
+            def poll(self, collection, task, trajectory_id, *, timeout_s=1800, poll_interval_s=5):
+                return {"status": "completed", "artifacts": [{"path": "/app/results/output.md", "content": "alpha beta"}]}
+
+        client = FakeClient()
+        records = list(sb.execute_jetty_payloads([row], client=client, timeout_s=1, poll_interval_s=0))
+        self.assertEqual(client.uploaded[1], "skill-evals")
+        self.assertEqual(client.submitted["jetty"]["template_variables"]["task_json"], "uploads/task.json")
+        self.assertEqual(client.submitted["jetty"]["file_paths"], ["uploads/task.json"])
+        self.assertEqual(records[0]["status"], "completed")
+        self.assertEqual(records[0]["trajectory_id"], "traj_1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
Implements the first unblocked Jetty adapter slice:
- `export-jetty` — deterministic runbook-mode payload export.
- `run-jetty` — REST submission/polling with dry-run mode and injectable/mocked client path.
- `import-jetty-results` — trajectory/artifact import into the existing harness run layout.

Also updates README/TODO/spec status and bumps package version to `0.2.0`.

## Why
The Jetty spec is now grounded in Jetty docs and `jettyio/jettyio-skills`. This turns that spec into a minimal, testable implementation while keeping Skill Eval Harness as the source of truth for manifests and grading.

## Key behavior
- Uses Jetty runbook-mode chat completions with `model`, `messages`, `stream:false`, and `jetty` block.
- Includes `model_provider`, `snapshot`, `template_variables.results_dir`, and uploaded `task_json`.
- Omits skill files for `without_skill` by construction.
- Keeps answer keys and judge rubrics out of executor payloads.
- Marks missing hidden-prompt exports as non-executable and refuses to submit them.
- Normalizes Jetty metadata into `metadata.json` and preserves raw records as `jetty_raw.json`.

## Testing
```sh
python3 -m py_compile *.py examples/adewale-workspace/*.py
python3 -m unittest discover tests -v
python3 skill_benchmark.py export-jetty ../good-pr/evals/shared-benchmark.json --split tune --out /tmp/good-pr-jetty.jsonl
python3 skill_benchmark.py run-jetty --payloads /tmp/good-pr-jetty.jsonl --dry-run --out /tmp/good-pr-jetty-runs.jsonl
python3 skill_benchmark.py import-jetty-results --manifest ../good-pr/evals/shared-benchmark.json --jetty-runs /tmp/good-pr-jetty-completed.jsonl --runs /tmp/good-pr-jetty-runs
python3 skill_benchmark.py benchmark ../good-pr/evals/shared-benchmark.json --runs /tmp/good-pr-jetty-runs --split tune --variant with_skill --out /tmp/good-pr-jetty-benchmark.json
```

Result: 14/14 unit tests passed; Jetty export/dry-run/import smoke passed.

## Not included
- Live Jetty token-backed validation.
- Streaming response support.
- Concurrent live submissions.
- `simple_judge` export/import.
- Materialized ablated skill files.
