### PR TITLE
Improve README and repo contribution surfaces

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,37 @@
+name: Bug report
+description: Report a harness bug, wrong grading result, or broken CLI command
+title: "bug: "
+labels: [bug]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What command did you run, and what result did you get?
+      placeholder: |
+        skill-benchmark validate evals/shared-benchmark.json
+        FAIL: ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should the harness have done instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction files or snippet
+      description: Include the smallest manifest/run-output snippet that reproduces the issue. Do not paste private holdout prompts or answer keys.
+  - type: input
+    id: version
+    attributes:
+      label: Harness version
+      placeholder: v0.3.0 or commit SHA
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Python version, OS, runner, and whether scripts/JETTY/PI were involved.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Suggest a harness feature or eval workflow improvement
+title: "feat: "
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What eval workflow is hard or brittle today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What command, manifest field, assertion type, or report shape should change?
+  - type: textarea
+    id: example
+    attributes:
+      label: Example
+      description: Include a small manifest/assertion/result example if you have one.
+  - type: textarea
+    id: safety
+    attributes:
+      label: Safety / compatibility notes
+      description: Does this affect hidden prompts, answer keys, script execution, live model calls, or existing manifests?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+- 
+
+## Validation
+
+Run the smallest command that proves the change:
+
+- [ ] `python3 -m py_compile *.py examples/adewale-workspace/*.py`
+- [ ] `python3 -m unittest discover tests -v`
+- [ ] Manifest/eval command, if changed: `skill-benchmark validate ...`
+
+## Eval / docs impact
+
+- [ ] README or docs updated, if behavior changed
+- [ ] Tests added or updated, if CLI behavior changed
+- [ ] Existing manifests remain answer-key safe
+
+## Notes / risks
+
+- 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Compile Python files
+        run: python -m py_compile *.py examples/adewale-workspace/*.py
+
+      - name: Run unit tests
+        run: python -m unittest discover tests -v
+
+      - name: Check CLI entrypoints
+        run: |
+          python skill_benchmark.py --help
+          python run_pi_trigger_eval.py --help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable public changes are listed here. Release tags are the source of truth for exact code state.
+
+## Unreleased
+
+- Add GitHub Actions CI for Python 3.10, 3.11, and 3.12.
+- Add contributor guidance, PR template, and issue forms.
+- Tighten README quick start with expected output landmarks and repo-surface links.
+
+## v0.3.0 — 2026-06-10
+
+- Add opt-in `script` assertions gated by `--allow-scripts`.
+- Add prompt/assertion leakage lint with non-fatal default warnings and `--strict-leakage` for failure mode.
+- Add `skill-benchmark judge` with `--judge-cmd`, repeated judge runs, transcript writing, and JSON result parsing.
+- Add ablation variant support in the Adewale Pi smoke runner.
+
+## v0.2.0 — 2026-06-10
+
+- Add Jetty adapter phase one: `export-jetty`, `run-jetty`, `import-jetty-results`, and dry-run support.
+- Ground Jetty request shape in Jetty docs and `jettyio/jettyio-skills` conventions.
+- Add mocked upload/submit/poll coverage and hidden-prompt placeholder safety.
+
+## v0.1.1 — 2026-06-09
+
+- Switch public installation instructions to `uv` / `uvx`.
+
+## v0.1.0 — 2026-06-09
+
+- Initial standalone shared skill eval harness.
+- Add manifest validation, answer-key-safe task preparation, deterministic grading, benchmarking, and reports.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing
+
+Thanks for improving Skill Eval Harness. Keep changes small and evidence-backed: this repo is a CLI used to score other repos, so silent behavior drift is expensive.
+
+## Local setup
+
+```sh
+git clone https://github.com/adewale/skill-eval-harness.git
+cd skill-eval-harness
+uv tool install --editable .
+skill-benchmark --help
+```
+
+The code has no runtime package dependencies beyond Python 3.10+.
+
+## Validation
+
+Run these before opening a PR:
+
+```sh
+python3 -m py_compile *.py examples/adewale-workspace/*.py
+python3 -m unittest discover tests -v
+```
+
+If you change manifest parsing, grading, Jetty export/import, trigger detection, script assertions, or judge handling, add or update `tests/test_skill_benchmark.py`.
+
+## Eval-safety rules
+
+- Do not put private holdout/holdback prompts or answer keys in public fixtures, issues, or PRs.
+- Do not include `expected_behavior` or `review_rubric` in generation payloads unless the command is explicitly a judge/debug path.
+- Keep `script` assertions opt-in through `--allow-scripts`; they execute repo-owned commands.
+- Keep live model/API calls out of unit tests. Use mocked fixtures unless a test is explicitly documented as live/opt-in.
+- Do not claim ablation benefit from declared metadata alone. Claim it only after `ablation:<id>` rows have run and been benchmarked.
+
+## PR checklist
+
+- State what command or report shape changed.
+- Include the focused validation command and result.
+- Update README/docs when CLI flags, manifest fields, output layout, or safety behavior changes.
+- For Jetty work, keep the manifest/grading model as the source of truth and isolate network behavior behind tests/mocks.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Skill Eval Harness
 
+[![CI](https://github.com/adewale/skill-eval-harness/actions/workflows/ci.yml/badge.svg)](https://github.com/adewale/skill-eval-harness/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 Skill Eval Harness is a Python CLI for testing whether an Agent Skill changes observable output. It reads `evals/shared-benchmark.json`, emits answer-key-safe task rows, grades files under `eval-runs/`, and writes benchmark reports you can diff across variants.
 
 The main question is narrow: **when the same case runs with and without the skill, what changed, what passed, and did the eval itself leak the answer?**
@@ -21,6 +24,17 @@ The main question is narrow: **when the same case runs with and without the skil
 - Interop: Anthropic-style exports, static HTML review pages, Pi trigger evals, and Jetty runbook-mode import/export.
 - Judge plumbing: `judge`/`rubric` assertions can be exported or run through a user-supplied `--judge-cmd`; the harness does not choose a model for you.
 
+## Contents
+
+- [Quick start](#quick-start)
+- [Installation](#installation)
+- [Manifest format](#manifest-format)
+- [Assertions](#assertions)
+- [Run output contract](#run-output-contract)
+- [Commands](#commands)
+- [Jetty adapter](#jetty-adapter)
+- [Contributing](#contributing)
+
 ## Quick start
 
 > Requires Python 3.10+ and [uv](https://docs.astral.sh/uv/). Install from GitHub first:
@@ -29,31 +43,43 @@ The main question is narrow: **when the same case runs with and without the skil
 > uv tool install git+https://github.com/adewale/skill-eval-harness.git@v0.3.0
 > ```
 
+Run these from a skill repo that has `evals/shared-benchmark.json`:
+
 ```bash
-# 1. Validate a skill manifest
+# 1. Check manifest shape and fixture paths.
 skill-benchmark validate evals/shared-benchmark.json
 
-# 2. Prepare paired tasks for an agent runner
+# 2. Emit answer-key-safe task rows for a runner.
 skill-benchmark prepare evals/shared-benchmark.json \
   --split tune \
   --runs-per-variant 3 \
   --out /tmp/tasks.jsonl
 
-# 3. Run each JSONL task with your agent runner and save outputs as:
-# runs/<case_id>/<variant>/run-<n>/output.md
-# runs/<case_id>/<variant>/run-<n>/metadata.json
+# 3. Run each task with your agent runner and save:
+# eval-runs/latest/<case_id>/<variant>/run-<n>/output.md
+# eval-runs/latest/<case_id>/<variant>/run-<n>/metadata.json
 
-# 4. Grade and benchmark saved outputs
+# 4. Grade saved outputs. Add --allow-scripts only if you trust repo-owned oracles.
 skill-benchmark benchmark evals/shared-benchmark.json \
   --runs eval-runs/latest \
   --split tune \
+  --allow-scripts \
   --out benchmark.json
 
-# 5. Open a static review page
+# 5. Open a static review page.
 skill-benchmark render-viewer \
   --benchmark benchmark.json \
   --runs eval-runs/latest \
   --out review.html
+```
+
+Expected landmarks:
+
+```text
+validate  -> OK: <skill-name> — <case-count> cases, <ablation-count> ablations
+prepare   -> /tmp/tasks.jsonl, one JSON object per case/variant/run
+benchmark -> benchmark.json with summary, results, and case_flags
+viewer    -> review.html with assertion evidence and output previews
 ```
 
 `benchmark.json` records one row per case/variant/run, plus aggregate pass rates, timing/token summaries, and flags for saturated, no-lift, flaky, or with-skill-failed cases.
@@ -71,6 +97,13 @@ skill-pi-trigger-eval --help
 uvx --from git+https://github.com/adewale/skill-eval-harness.git@v0.3.0 skill-benchmark --help
 ```
 
+The installed commands are:
+
+| Command | What it does |
+|---|---|
+| `skill-benchmark` | Validate manifests, prepare tasks, grade outputs, compare variants, run judges, and import/export runner formats. |
+| `skill-pi-trigger-eval` | Runs Pi without forced `--skill` and checks whether the model loads the skill from stream events. |
+
 ### Local development
 
 ```bash
@@ -85,6 +118,8 @@ skill-benchmark --help
 | File | Use it for |
 |---|---|
 | `README.md` | Manifest shape, run layout, and command contracts. |
+| `CHANGELOG.md` | Release history and unreleased repo-surface changes. |
+| `CONTRIBUTING.md` | Local setup, validation commands, and eval-safety rules. |
 | `LESSONS_LEARNED.md` | Design lessons from the multi-skill saturation work. |
 | `docs/jetty-support-spec.md` | Jetty payload/import contract and live-token unknowns. |
 | `TODO.md` | Remaining Jetty work: streaming, concurrency, live API validation, materialized ablations. |
@@ -426,6 +461,17 @@ Ablation task variants are named `ablation:<id>`. Trigger cases are skipped for 
 - **Other runners**: use `prepare` JSONL as the import format and write results back to the run output contract.
 - **Jetty**: use `export-jetty`, `run-jetty`, and `import-jetty-results` for REST runbook-mode execution. Live response shapes still need token-backed smoke validation before treating Jetty runs as production evidence.
 
+## Contributing
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for local setup, validation commands, and eval-safety rules. The short version:
+
+```bash
+python3 -m py_compile *.py examples/adewale-workspace/*.py
+python3 -m unittest discover tests -v
+```
+
+For manifest or grading changes, add or update `tests/test_skill_benchmark.py`. For docs-only changes, still run the same commands so CLI examples stay tied to current behavior.
+
 ## Non-goals
 
 - Local grading does not call a model. Model execution happens outside the harness, except for explicit runner commands such as `run-jetty`.
@@ -438,9 +484,15 @@ Ablation task variants are named `ablation:<id>`. Trigger cases are skipped for 
 ```text
 skill-eval-harness/
 ├── README.md
+├── CHANGELOG.md
+├── CONTRIBUTING.md
 ├── pyproject.toml
 ├── skill_benchmark.py
 ├── run_pi_trigger_eval.py
+├── .github/
+│   ├── PULL_REQUEST_TEMPLATE.md
+│   ├── ISSUE_TEMPLATE/
+│   └── workflows/ci.yml
 ├── examples/
 │   └── adewale-workspace/
 │       ├── all-manifests.txt
@@ -454,7 +506,7 @@ skill-eval-harness/
 ## Development
 
 ```bash
-python3 -m py_compile *.py
+python3 -m py_compile *.py examples/adewale-workspace/*.py
 python3 -m unittest discover tests -v
 ```
 
@@ -468,5 +520,7 @@ This README was written against:
 - `run_pi_trigger_eval.py` trigger runner
 - `pyproject.toml` package metadata
 - `tests/test_skill_benchmark.py` behavior coverage
+- `CHANGELOG.md`, `CONTRIBUTING.md`, and `.github/` contribution/CI surfaces
 - `anti-slop-writing/skills/anti-slop-writing/SKILL.md` for this prose pass
 - the `good-readme` skill guidance from `https://www.skills.sh/adewale/good-readme/good-readme`
+- the `good-repo` skill guidance from `good-repo/skills/good-repo/references/quality-checklist.md`


### PR DESCRIPTION
## Summary
- add CI, PR template, and issue forms for repo trust/contribution readiness
- add CONTRIBUTING.md and CHANGELOG.md
- tighten README quick start, expected outputs, command table, docs map, and development commands

## Validation
- python3 -m py_compile *.py examples/adewale-workspace/*.py
- python3 -m unittest discover tests -v
- python3 skill_benchmark.py --help
- python3 run_pi_trigger_eval.py --help