### PR TITLE
Ground trace runners and process assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable public changes are listed here. Release tags are the source of truth
 
 - Nothing yet.
 
+## v0.4.1 — 2026-06-11
+
+- Add variant-scoped assertions with `variants` / `only_variants` / `except_variants`.
+- Ground trace import in live Pi and Codex event shapes: Pi `message_end` usage aliases and Codex `item.completed` / `command_execution` JSONL.
+- Add a shared trace artifact writer and use it for `import-trace`, `run-codex`, Jetty result import, Pi smoke runs, and optional Pi trigger traces.
+- Harden the Adewale Pi smoke runner by executing in an isolated temporary workspace with only allowed files for each variant.
+- Add `skill-pi-trigger-eval --trace-runs` for per-query trace artifacts.
+
 ## v0.4.0 — 2026-06-11
 
 - Add GitHub Actions CI for Python 3.10, 3.11, and 3.12.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The main question is narrow: **when the same case runs with and without the skil
 > Requires Python 3.10+ and [uv](https://docs.astral.sh/uv/). Install from GitHub first:
 >
 > ```bash
-> uv tool install git+https://github.com/adewale/skill-eval-harness.git@v0.4.0
+> uv tool install git+https://github.com/adewale/skill-eval-harness.git@v0.4.1
 > ```
 
 Run these from a skill repo that has `evals/shared-benchmark.json`:
@@ -89,12 +89,12 @@ viewer    -> review.html with assertion evidence and output previews
 ### From GitHub
 
 ```bash
-uv tool install git+https://github.com/adewale/skill-eval-harness.git@v0.4.0
+uv tool install git+https://github.com/adewale/skill-eval-harness.git@v0.4.1
 skill-benchmark --help
 skill-pi-trigger-eval --help
 
 # One-shot without installing globally:
-uvx --from git+https://github.com/adewale/skill-eval-harness.git@v0.4.0 skill-benchmark --help
+uvx --from git+https://github.com/adewale/skill-eval-harness.git@v0.4.1 skill-benchmark --help
 ```
 
 The installed commands are:
@@ -138,7 +138,7 @@ Each skill repo owns an `evals/shared-benchmark.json` manifest. Add a `harness` 
   "harness": {
     "name": "skill-eval-harness",
     "url": "https://github.com/adewale/skill-eval-harness",
-    "version": ">=0.4.0"
+    "version": ">=0.4.1"
   },
   "skill_paths": ["skills/good-pr/SKILL.md"],
   "variants": ["with_skill", "without_skill"],
@@ -225,6 +225,15 @@ Use `script` when a keyword check is too weak for the property you care about. T
 `command` runs with cwd set to the manifest directory. `{output_dir}` is replaced with the absolute run directory. The assertion passes when the command exits with `pass_exit_code` (default `0`); stdout and stderr are stored as evidence.
 
 Trace/process/efficiency assertions are optional and fail closed when declared evidence is missing. For example, `command_not_ran` cannot pass without `events.json`, and `total_tokens_le` cannot pass without token telemetry.
+
+Assertions can be scoped to variants when the expected process differs by arm:
+
+```json
+{"name":"with-skill-loaded","type":"skill_invoked","expected":true,"variants":["with_skill"]}
+{"name":"without-skill-clean","type":"skill_invoked","expected":false,"variants":["without_skill"]}
+```
+
+Use this for process checks such as `skill_invoked`; otherwise a with-skill requirement would incorrectly penalize the no-skill baseline.
 
 Qualitative assertion types:
 
@@ -326,7 +335,35 @@ skill-benchmark prepare ../repo/evals/shared-benchmark.json --split tune --out t
 skill-benchmark run-codex --tasks tasks.jsonl --runs ../repo/eval-runs/codex-tune
 ```
 
-Override `--codex-cmd` for local wrappers or tests.
+Override `--codex-cmd` for local wrappers or tests. A grounded smoke command is:
+
+```bash
+skill-benchmark run-codex \
+  --tasks tasks.jsonl \
+  --runs ../repo/eval-runs/codex-trace \
+  --codex-cmd 'codex exec --json --sandbox read-only --skip-git-repo-check --ephemeral'
+```
+
+### Pi trace runners
+
+The Adewale Pi smoke example writes the trace-aware run layout directly:
+
+```bash
+python3 examples/adewale-workspace/run_pi_smoke.py \
+  --run-name trace-smoke \
+  --selection /tmp/selection.json
+```
+
+It runs from an isolated temporary workspace. `with_skill` receives copied skill files and fixtures; `without_skill` receives fixtures only and `--no-skills`, preventing grep/find/read from discovering the source repo's `skills/*/SKILL.md` or public eval manifests.
+
+`skill-pi-trigger-eval` can also write per-query trace artifacts:
+
+```bash
+skill-pi-trigger-eval ../repo/evals/shared-benchmark.json \
+  --eval-set trigger-queries.json \
+  --out trigger-results.json \
+  --trace-runs trigger-traces
+```
 
 ### Grade
 

--- a/docs/trace-aware-eval-spec.md
+++ b/docs/trace-aware-eval-spec.md
@@ -1,6 +1,6 @@
 # Trace-Aware Skill Eval Spec
 
-Status: phase-1 implementation in progress. The first code slice implements trace import, a Codex JSONL runner adapter, process/efficiency assertions, telemetry-aware benchmark summaries, paired deltas/normalized gain, taxonomy slice summaries, taxonomy audit warnings, and skill-profile reporting. Remaining sections describe follow-on work. This plan integrates the subset of ideas from OpenAI's `eval-skills` article, SkillsBench, and Anthropic's `skill-creator` that fit the existing harness model.
+Status: phase-2 implementation in progress. The first code slice implemented trace import, a Codex JSONL runner adapter, process/efficiency assertions, telemetry-aware benchmark summaries, paired deltas/normalized gain, taxonomy slice summaries, taxonomy audit warnings, and skill-profile reporting. The next grounded slice adds variant-scoped assertions, live Pi/Codex event-shape support, Jetty trajectory trace import, isolated Pi smoke workspaces, and optional Pi trigger trace artifacts. Remaining sections describe follow-on work. This plan integrates the subset of ideas from OpenAI's `eval-skills` article, SkillsBench, and Anthropic's `skill-creator` that fit the existing harness model.
 
 ## Design principle
 
@@ -216,7 +216,7 @@ Process and efficiency assertions are objective assertions, but they grade `even
 {"name": "no-command-loop", "type": "no_repeated_command_loop", "max_repeats": 2}
 ```
 
-Process assertions fail when required trace evidence is missing. That fail-closed behavior prevents a runner without trace support from silently satisfying a process requirement.
+Process assertions fail when required trace evidence is missing. That fail-closed behavior prevents a runner without trace support from silently satisfying a process requirement. Use variant filters for asymmetric checks, for example `skill_invoked=true` on `with_skill` and `skill_invoked=false` on `without_skill`.
 
 ### Efficiency assertions
 
@@ -275,8 +275,8 @@ Expected behavior:
 
 ### Existing runners
 
-- **Pi trigger eval** already uses stream events for skill-load evidence; adapt that event parsing into normalized `skill_load` events where possible.
-- **Jetty** already imports trajectories and metadata; add `trace.jsonl`/`events.json` emission after live response shapes are validated.
+- **Pi smoke and trigger evals** use stream events for skill-load evidence and now write normalized `trace.jsonl`, `events.json`, and `metrics.json` artifacts where enabled. Pi smoke runs execute from isolated temporary workspaces so `without_skill` cannot discover source-repo skill files by grep/find/read.
+- **Jetty** imports trajectories and metadata into `trace.jsonl`, `events.json`, and `metrics.json` using documented/mocked trajectory shapes; live token validation is still needed for production response shape drift.
 - **OpenCode/Gemini CLI** can be added later if they provide stable machine-readable event streams.
 
 ## Report additions

--- a/examples/adewale-workspace/run_pi_smoke.py
+++ b/examples/adewale-workspace/run_pi_smoke.py
@@ -10,11 +10,18 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
+
+HARNESS_ROOT = Path(__file__).resolve().parents[2]
+if str(HARNESS_ROOT) not in sys.path:
+    sys.path.insert(0, str(HARNESS_ROOT))
+from skill_benchmark import write_trace_artifacts  # noqa: E402
 
 # Workspace-specific example: by default this assumes the harness directory is a
 # sibling of the skill repos. Override with SKILL_EVAL_WORKSPACE_ROOT.
@@ -88,38 +95,86 @@ def _text(value: Any) -> str:
     return str(value)
 
 
-def variant_runtime(manifest: dict[str, Any], repo_root: Path, variant: str) -> tuple[str, list[str]]:
-    skill_paths = [repo_root / p for p in manifest.get("skill_paths", [])]
+def copy_skill_source(src: Path, dest_root: Path, skill_name: str) -> Path:
+    """Copy only the installable skill surface into an isolated runner workspace."""
+    if src.is_dir():
+        dest = dest_root / src.name
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.copytree(src, dest)
+        return dest / "SKILL.md" if (dest / "SKILL.md").exists() else dest
+    dest = dest_root / skill_name
+    dest.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dest / "SKILL.md")
+    for sibling in ["references", "scripts", "assets"]:
+        s = src.parent / sibling
+        if s.exists() and s.is_dir():
+            d = dest / sibling
+            if d.exists():
+                shutil.rmtree(d)
+            shutil.copytree(s, d)
+    return dest / "SKILL.md"
+
+
+def materialize_runtime_workspace(manifest: dict[str, Any], repo_root: Path, case: dict[str, Any], variant: str, workspace: Path) -> tuple[str, list[str], list[Path], list[Path]]:
+    """Return instruction, Pi skill args, copied input files, copied skill paths.
+
+    The smoke runner intentionally does not execute from the source repo. It
+    copies only the files the variant is allowed to see. This prevents
+    `without_skill` runs from discovering `skills/*/SKILL.md` or public eval
+    answer keys by using grep/find/read from the repository root.
+    """
+    workspace.mkdir(parents=True, exist_ok=True)
+    copied_skill_paths: list[Path] = []
+    skill_args: list[str] = []
+    skill_sources = [(repo_root / p).resolve() for p in manifest.get("skill_paths", [])]
+    if variant != "without_skill":
+        skill_dest_root = workspace / "skills"
+        skill_dest_root.mkdir(parents=True, exist_ok=True)
+        for src in skill_sources:
+            copied = copy_skill_source(src, skill_dest_root, str(manifest.get("skill_name", "skill")))
+            copied_skill_paths.append(copied)
+            skill_args.extend(["--skill", str(copied)])
+    else:
+        skill_args = ["--no-skills"]
+
+    copied_inputs: list[Path] = []
+    for rel in case.get("files", []) or []:
+        src = (repo_root / "evals" / rel).resolve()
+        dest = workspace / "inputs" / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+        copied_inputs.append(dest.resolve())
+
     if variant == "with_skill":
-        skill_list = ", ".join(str(sp) for sp in skill_paths)
-        return (
+        skill_list = ", ".join(str(sp) for sp in copied_skill_paths)
+        instruction = (
             f"Use the loaded {manifest['skill_name']} skill where it applies. "
             f"Read and follow these skill path(s), including referenced files when relevant: {skill_list}. "
-            "If the skill defines a required output contract, follow it exactly rather than giving a shortcut answer.",
-            [arg for sp in skill_paths for arg in ("--skill", str(sp))],
+            "If the skill defines a required output contract, follow it exactly rather than giving a shortcut answer."
         )
-    if variant == "without_skill":
-        return (
+    elif variant == "without_skill":
+        instruction = (
             f"Do not use or read the {manifest['skill_name']} skill or its references. "
-            "Use only general assistant ability.",
-            ["--no-skills"],
+            "Use only general assistant ability. The skill files are intentionally not present in this workspace."
         )
-    if variant.startswith("ablation:"):
+    elif variant.startswith("ablation:"):
         aid = variant.split(":", 1)[1]
         ablation = next((a for a in manifest.get("ablations", []) if a.get("id") == aid), None)
         if not ablation:
             raise RuntimeError(f"unknown ablation variant: {variant}")
-        skill_list = ", ".join(str(sp) for sp in skill_paths)
+        skill_list = ", ".join(str(sp) for sp in copied_skill_paths)
         expected = "; ".join(ablation.get("expected_regressions", []))
-        return (
+        instruction = (
             f"Use the loaded {manifest['skill_name']} skill where it applies. "
             f"Read and follow these skill path(s), including referenced files when relevant: {skill_list}. "
             f"Ablation mode for this empirical run: ignore/remove this component from the skill guidance: {ablation.get('removed_component')}. "
             f"Expected regression to watch for: {expected}. "
-            "This is an instruction-simulated ablation, not a materialized alternate skill file.",
-            [arg for sp in skill_paths for arg in ("--skill", str(sp))],
+            "This is an instruction-simulated ablation, not a materialized alternate skill file."
         )
-    raise RuntimeError(f"unsupported variant: {variant}")
+    else:
+        raise RuntimeError(f"unsupported variant: {variant}")
+    return instruction, skill_args, copied_inputs, copied_skill_paths
 
 
 def run_case(repo: str, manifest: dict[str, Any], case: dict[str, Any], variant: str, run_name: str, timeout: int) -> dict[str, Any]:
@@ -127,62 +182,65 @@ def run_case(repo: str, manifest: dict[str, Any], case: dict[str, Any], variant:
     out_dir = repo_root / "eval-runs" / run_name / case["id"] / variant
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    instruction, skill_args = variant_runtime(manifest, repo_root, variant)
-
     prompt = case.get("prompt")
     if not prompt:
         raise RuntimeError(f"{repo}/{case['id']} has no inline prompt; smoke runner only handles tune inline prompts")
-    input_files = [(repo_root / "evals" / f).resolve() for f in case.get("files", [])]
-    fixture_note = ""
-    if input_files:
-        fixture_lines = []
-        for f in input_files:
-            fixture_lines.append(f"- {f}")
-        fixture_note = (
-            "\n\nINPUT FILES TO READ BEFORE ANSWERING:\n"
-            + "\n".join(fixture_lines)
-            + "\nUse the read tool to inspect these files; do not rely on their names alone."
-        )
-    full_prompt = (
-        f"{instruction}\n\n"
-        "You are producing a bounded smoke-run response. Do not mention the eval harness, scoring, hidden rubrics, or variants. "
-        "Answer the user task directly. Keep the final answer under 900 words. Use at most one bounded source pass; "
-        "if more information would be needed, state the exact missing files instead of continuing to search.\n\n"
-        f"USER TASK:\n{prompt}"
-        f"{fixture_note}"
-    )
 
-    cmd = [
-        "pi",
-        "--no-session",
-        "--tools", "read,grep,find,ls",
-        "--no-context-files",
-        "--no-prompt-templates",
-        "--no-extensions",
-        "--mode", "json",
-        "--thinking", "minimal",
-        *skill_args,
-        "-p", full_prompt,
-    ]
-    start = time.time()
-    timed_out = False
-    returncode = 0
-    stdout = ""
-    stderr = ""
-    try:
-        proc = subprocess.run(cmd, cwd=repo_root, text=True, capture_output=True, timeout=timeout)
-        stdout = _text(proc.stdout)
-        stderr = _text(proc.stderr)
-        returncode = proc.returncode
-    except subprocess.TimeoutExpired as exc:
-        timed_out = True
-        returncode = 124
-        stdout = _text(exc.stdout)
-        stderr = _text(exc.stderr)
+    with tempfile.TemporaryDirectory(prefix=f"skill-smoke-{repo}-{case['id']}-{variant.replace(':', '-')}-") as td:
+        workspace = Path(td)
+        instruction, skill_args, input_files, copied_skill_paths = materialize_runtime_workspace(manifest, repo_root, case, variant, workspace)
+        fixture_note = ""
+        if input_files:
+            fixture_lines = []
+            for f in input_files:
+                fixture_lines.append(f"- {f}")
+            fixture_note = (
+                "\n\nINPUT FILES TO READ BEFORE ANSWERING:\n"
+                + "\n".join(fixture_lines)
+                + "\nUse the read tool to inspect these files; do not rely on their names alone."
+            )
+        full_prompt = (
+            f"{instruction}\n\n"
+            "You are producing a bounded smoke-run response. Do not mention the eval harness, scoring, hidden rubrics, or variants. "
+            "Answer the user task directly. Keep the final answer under 900 words. Use at most one bounded source pass; "
+            "if more information would be needed, state the exact missing files instead of continuing to search.\n\n"
+            f"USER TASK:\n{prompt}"
+            f"{fixture_note}"
+        )
+
+        cmd = [
+            "pi",
+            "--no-session",
+            "--tools", "read,grep,find,ls",
+            "--no-context-files",
+            "--no-prompt-templates",
+            "--no-extensions",
+            "--mode", "json",
+            "--thinking", "minimal",
+            *skill_args,
+            "-p", full_prompt,
+        ]
+        start = time.time()
+        timed_out = False
+        returncode = 0
+        stdout = ""
+        stderr = ""
+        try:
+            proc = subprocess.run(cmd, cwd=workspace, text=True, capture_output=True, timeout=timeout)
+            stdout = _text(proc.stdout)
+            stderr = _text(proc.stderr)
+            returncode = proc.returncode
+        except subprocess.TimeoutExpired as exc:
+            timed_out = True
+            returncode = 124
+            stdout = _text(exc.stdout)
+            stderr = _text(exc.stderr)
     elapsed_ms = int((time.time() - start) * 1000)
     text, meta = output_from_events(stdout)
     if timed_out and not text:
         text = "[TIMEOUT: no final assistant message captured]"
+    runner_skill_invoked = variant != "without_skill"
+    copied_skill_evidence = [str(p) for p in locals().get("copied_skill_paths", [])]
     meta.update({
         "elapsed_ms": elapsed_ms,
         "returncode": returncode,
@@ -192,9 +250,35 @@ def run_case(repo: str, manifest: dict[str, Any], case: dict[str, Any], variant:
         "repo": repo,
         "run_name": run_name,
         "command": "pi --mode json ...",
+        "skill_invoked": runner_skill_invoked,
+        "skill_invocation_evidence": copied_skill_evidence if runner_skill_invoked else [],
     })
     (out_dir / "output.md").write_text(text, encoding="utf-8")
-    (out_dir / "metadata.json").write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+    trace_metrics = {
+        "elapsed_ms": elapsed_ms,
+        "returncode": returncode,
+        "timed_out": timed_out,
+        "skill_invoked": runner_skill_invoked,
+        "skill_invocation_evidence": copied_skill_evidence if runner_skill_invoked else [],
+    }
+    write_trace_artifacts(
+        out_dir,
+        stdout,
+        source="pi",
+        metadata=meta,
+        extra_metrics=trace_metrics,
+        environment={
+            "runner": "pi",
+            "mode": "json",
+            "tools": ["read", "grep", "find", "ls"],
+            "variant": variant,
+            "skill_args": locals().get("skill_args", []),
+            "workspace_strategy": "isolated-temp-allowed-files-only",
+            "cwd": "<temporary isolated workspace>",
+        },
+        write_metadata=True,
+    )
+    # Backward-compatible raw stream filename used by older local reports.
     (out_dir / "events.jsonl").write_text(stdout, encoding="utf-8")
     if stderr:
         (out_dir / "stderr.txt").write_text(stderr, encoding="utf-8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skill-eval-harness"
-version = "0.4.0"
+version = "0.4.1"
 description = "Repo-agnostic Agent Skill evaluation harness with paired variants, holdout splits, repeated-run stats, script assertions, judge command backends, Anthropic-compatible exports, Jetty adapter support, and static review output."
 requires-python = ">=3.10"
 readme = "README.md"

--- a/run_pi_trigger_eval.py
+++ b/run_pi_trigger_eval.py
@@ -22,6 +22,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
+from skill_benchmark import write_trace_artifacts
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -110,7 +112,25 @@ def _text(value: Any) -> str:
     return str(value)
 
 
-def run_query(manifest_path: Path, query: str, should_trigger: bool, timeout: int, model: str | None) -> dict[str, Any]:
+def write_trigger_trace_artifacts(run_dir: Path, stdout: str, result: dict[str, Any]) -> None:
+    write_trace_artifacts(
+        run_dir,
+        stdout,
+        source="pi",
+        metadata={k: v for k, v in result.items() if k not in {"stderr"}},
+        extra_metrics={
+            "elapsed_ms": result.get("elapsed_ms"),
+            "returncode": result.get("returncode"),
+            "timed_out": result.get("timed_out"),
+            "skill_invoked": result.get("triggered"),
+            "skill_invocation_evidence": result.get("evidence", []),
+        },
+        environment={"runner": "pi", "mode": "json", "trigger_eval": True},
+        write_metadata=True,
+    )
+
+
+def run_query(manifest_path: Path, query: str, should_trigger: bool, timeout: int, model: str | None, trace_dir: Path | None = None) -> dict[str, Any]:
     manifest = load_manifest(manifest_path)
     with tempfile.TemporaryDirectory(prefix="pi-trigger-") as td:
         config_dir = Path(td)
@@ -141,7 +161,7 @@ def run_query(manifest_path: Path, query: str, should_trigger: bool, timeout: in
             returncode = 124
         elapsed_ms = int((time.time() - start) * 1000)
         triggered, evidence = detect_trigger(stdout, skill_name_from_manifest(manifest), copied)
-        return {
+        result = {
             "query": query,
             "should_trigger": should_trigger,
             "triggered": triggered,
@@ -152,6 +172,9 @@ def run_query(manifest_path: Path, query: str, should_trigger: bool, timeout: in
             "evidence": evidence,
             "stderr": stderr[-1000:] if stderr else "",
         }
+        if trace_dir is not None:
+            write_trigger_trace_artifacts(trace_dir, stdout, result)
+        return result
 
 
 def trigger_query_from_case(case: dict[str, Any]) -> str:
@@ -188,6 +211,7 @@ def main() -> int:
     ap.add_argument("--timeout", type=int, default=120)
     ap.add_argument("--model")
     ap.add_argument("--out", required=True)
+    ap.add_argument("--trace-runs", help="optional directory for per-query trace.jsonl/events.json/metrics.json artifacts")
     args = ap.parse_args()
 
     manifest_path = Path(args.manifest)
@@ -201,9 +225,13 @@ def main() -> int:
     futures = []
     results = []
     with ThreadPoolExecutor(max_workers=args.workers) as ex:
-        for row in rows:
-            for _ in range(args.runs_per_query):
-                futures.append(ex.submit(run_query, manifest_path, str(row["query"]), bool(row["should_trigger"]), args.timeout, args.model))
+        for i, row in enumerate(rows, 1):
+            for run_number in range(1, args.runs_per_query + 1):
+                trace_dir = None
+                if args.trace_runs:
+                    label = re.sub(r"[^a-zA-Z0-9_.-]+", "-", str(row.get("query", f"query-{i}")))[:80].strip("-") or f"query-{i}"
+                    trace_dir = Path(args.trace_runs) / f"query-{i:03d}-{label}" / f"run-{run_number}"
+                futures.append(ex.submit(run_query, manifest_path, str(row["query"]), bool(row["should_trigger"]), args.timeout, args.model, trace_dir))
         for fut in as_completed(futures):
             results.append(fut.result())
     passed = sum(1 for r in results if r["pass"])

--- a/skill_benchmark.py
+++ b/skill_benchmark.py
@@ -113,6 +113,22 @@ def script_command_list(assertion: dict[str, Any]) -> list[str]:
     return []
 
 
+def validate_variant_filter(assertion: dict[str, Any], cid: str, index: int) -> None:
+    for key in ["variants", "only_variants", "except_variants"]:
+        if key in assertion and (not isinstance(assertion.get(key), list) or not all(isinstance(v, str) for v in assertion.get(key, []))):
+            die(f"{cid}: assertion #{index} {key} must be a list of strings")
+
+
+def assertion_applies_to_variant(assertion: dict[str, Any], variant: str) -> bool:
+    only = assertion.get("variants", assertion.get("only_variants"))
+    if isinstance(only, list) and variant not in only:
+        return False
+    excluded = assertion.get("except_variants")
+    if isinstance(excluded, list) and variant in excluded:
+        return False
+    return True
+
+
 def validate_script_assertion(assertion: dict[str, Any], manifest_path: Path, cid: str, index: int) -> None:
     command = script_command_list(assertion)
     if not command:
@@ -223,6 +239,7 @@ def validate_manifest(path: Path, allow_missing_holdback: bool = True) -> dict[s
         for j, assertion in enumerate(assertions):
             if not isinstance(assertion, dict):
                 die(f"{cid}: assertion #{j} must be an object")
+            validate_variant_filter(assertion, cid, j)
             atype = assertion.get("type")
             if atype not in OBJECTIVE_ASSERTIONS | QUALITATIVE_ASSERTIONS:
                 die(f"{cid}: assertion #{j} has unsupported type {atype!r}")
@@ -896,6 +913,43 @@ def artifact_metadata(artifacts: list[dict[str, Any]]) -> dict[str, Any]:
     return {}
 
 
+def jetty_trace_records(record: dict[str, Any], artifacts: list[dict[str, Any]], *, success: bool) -> list[dict[str, Any]]:
+    trajectory = record.get("trajectory", {}) if isinstance(record.get("trajectory"), dict) else {}
+    records: list[dict[str, Any]] = []
+    for key in ["events", "steps", "messages", "trace", "logs"]:
+        values = trajectory.get(key)
+        if isinstance(values, list):
+            for item in values:
+                if isinstance(item, dict):
+                    records.append(item)
+                else:
+                    records.append({"type": f"jetty.{key}", "content": str(item)})
+    usage = trajectory.get("usage") if isinstance(trajectory, dict) else None
+    metric_record: dict[str, Any] = {"type": "usage"}
+    if isinstance(usage, dict):
+        metric_record["usage"] = usage
+    for key in ["elapsed_ms", "duration_ms", "input_tokens", "output_tokens", "total_tokens", "total_tool_calls"]:
+        value = trajectory.get(key) if isinstance(trajectory, dict) else None
+        if isinstance(value, (int, float)):
+            metric_record[key] = value
+    if len(metric_record) > 1:
+        records.append(metric_record)
+    for artifact in artifacts:
+        rel = artifact_rel_path(artifact)
+        if rel:
+            records.append({"type": "file_write", "path": str(rel), "status": "completed"})
+    if not success:
+        error = record.get("error") or trajectory.get("error") if isinstance(trajectory, dict) else record.get("error")
+        records.append({"type": "error", "status": str(record.get("status") or "failed"), "message": str(error or "Jetty trajectory failed")})
+    if not records:
+        records.append({"type": "jetty_trajectory", "status": record.get("status"), "trajectory_id": record.get("trajectory_id")})
+    return records
+
+
+def jsonl_from_records(records: list[dict[str, Any]]) -> str:
+    return "".join(json.dumps(record, ensure_ascii=False) + "\n" for record in records)
+
+
 def normalized_jetty_metadata(record: dict[str, Any], *, success: bool) -> dict[str, Any]:
     jetty = record.get("jetty", {}) if isinstance(record.get("jetty"), dict) else {}
     trajectory = record.get("trajectory", {}) if isinstance(record.get("trajectory"), dict) else {}
@@ -959,7 +1013,15 @@ def import_jetty_results(args: argparse.Namespace) -> int:
             (base / "output.md").write_text("[JETTY FAILURE: trajectory failed before producing output]\n", encoding="utf-8")
         meta = artifact_metadata(artifacts)
         meta.update(normalized_jetty_metadata(record, success=success))
-        write_json(base / "metadata.json", meta)
+        trace_records = jetty_trace_records(record, artifacts, success=success)
+        write_trace_artifacts(
+            base,
+            jsonl_from_records(trace_records),
+            source="jetty",
+            metadata=meta,
+            environment={"runner": "jetty", "jetty": record.get("jetty", {}), "trajectory_id": record.get("trajectory_id")},
+            write_metadata=True,
+        )
     return 0
 
 
@@ -1091,7 +1153,15 @@ def command_text(event: dict[str, Any]) -> str:
 
 
 def command_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    return [e for e in events if e.get("type") == "command"]
+    # Codex and other runners can emit both start and completion records for the
+    # same command. Process assertions care about commands that actually ran, so
+    # ignore in-progress start notifications when a status is present.
+    return [e for e in events if e.get("type") == "command" and str(e.get("status", "completed")).casefold() not in {"in_progress", "started", "running"}]
+
+
+def event_mentions_skill_file(event: dict[str, Any]) -> bool:
+    hay = " ".join(str(event.get(key, "")) for key in ["input_summary", "output_summary", "name"])
+    return "SKILL.md" in hay or "/skills/" in hay or "\\skills\\" in hay
 
 
 def regex_hit(pattern: str, text: str, ci: bool = True) -> bool:
@@ -1150,7 +1220,7 @@ def process_or_efficiency_assertion_result(assertion: dict[str, Any], run_base: 
         invoked = bool(metrics.get("skill_invoked")) if has_metric else False
         evidence: list[str] = []
         if events is not None:
-            skill_events = [e for e in events if e.get("type") == "skill_load"]
+            skill_events = [e for e in events if e.get("type") == "skill_load" or event_mentions_skill_file(e)]
             if skill_events:
                 invoked = True
                 evidence.extend(command_text(e) or str(e.get("path", "skill_load")) for e in skill_events[:5])
@@ -1276,8 +1346,34 @@ def load_trace_jsonl(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
     return parse_trace_jsonl_text(path.read_text(encoding="utf-8", errors="replace"))
 
 
+def nested_item_type(record: dict[str, Any]) -> str:
+    item = record.get("item")
+    if isinstance(item, dict):
+        value = item.get("type") or item.get("kind") or item.get("name")
+        return str(value or "")
+    return ""
+
+
+def usage_number(usage: dict[str, Any], *keys: str) -> float | None:
+    aliases = {
+        "input_tokens": ["input_tokens", "input", "prompt_tokens", "cached_input_tokens"],
+        "output_tokens": ["output_tokens", "output", "completion_tokens"],
+        "total_tokens": ["total_tokens", "totalTokens", "total", "tokens"],
+    }
+    search: list[str] = []
+    for key in keys:
+        search.extend(aliases.get(key, [key]))
+    for key in search:
+        value = usage.get(key)
+        if isinstance(value, (int, float)):
+            return float(value)
+    return None
+
+
 def normalize_trace_record(record: dict[str, Any], *, source: str, index: int, line: int) -> dict[str, Any]:
-    raw_type = str(raw_trace_value(record, "type", "event", "name", "kind") or "").casefold()
+    top_type = str(raw_trace_value(record, "type", "event", "name", "kind") or "")
+    item_type = nested_item_type(record)
+    raw_type = f"{top_type} {item_type}".casefold()
     path = stringify_trace_value(raw_trace_value(record, "path", "file"))
     command = stringify_trace_value(raw_trace_value(record, "command", "cmd", "args"))
     content = stringify_trace_value(raw_trace_value(record, "content", "text", "message"))
@@ -1297,10 +1393,10 @@ def normalize_trace_record(record: dict[str, Any], *, source: str, index: int, l
         event_type = "file_read"
     elif "error" in raw_type or str(status).casefold() in {"failed", "error", "errored"}:
         event_type = "error"
-    elif "usage" in raw_type or "metric" in raw_type:
-        event_type = "metric"
-    elif raw_trace_value(record, "role") or content:
+    elif raw_trace_value(record, "role") or content or "agent_message" in raw_type:
         event_type = "message"
+    elif "usage" in raw_type or "metric" in raw_type or raw_trace_value(record, "usage", "tokens"):
+        event_type = "metric"
     input_summary = command or path or content[:500]
     output_summary = stringify_trace_value(raw_trace_value(record, "output", "stdout", "stderr", "result"))[:1000]
     event = {
@@ -1310,6 +1406,8 @@ def normalize_trace_record(record: dict[str, Any], *, source: str, index: int, l
         "raw_ref": {"file": "trace.jsonl", "line": line},
     }
     role = raw_trace_value(record, "role")
+    if not role and "agent_message" in raw_type:
+        role = "assistant"
     if role:
         event["role"] = str(role)
     if name:
@@ -1329,7 +1427,19 @@ def normalize_trace_record(record: dict[str, Any], *, source: str, index: int, l
         event["duration_ms"] = duration
     usage = raw_trace_value(record, "usage", "tokens")
     if isinstance(usage, dict):
-        event["tokens"] = {k: v for k, v in usage.items() if isinstance(v, (int, float))}
+        token_doc = {k: v for k, v in usage.items() if isinstance(v, (int, float))}
+        normalized_total = usage_number(usage, "total_tokens")
+        normalized_input = usage_number(usage, "input_tokens")
+        normalized_output = usage_number(usage, "output_tokens")
+        if normalized_total is None and normalized_input is not None and normalized_output is not None:
+            normalized_total = normalized_input + normalized_output
+        if normalized_input is not None:
+            token_doc["input_tokens"] = int(normalized_input)
+        if normalized_output is not None:
+            token_doc["output_tokens"] = int(normalized_output)
+        if normalized_total is not None:
+            token_doc["total_tokens"] = int(normalized_total)
+        event["tokens"] = token_doc
     event["source"] = source
     return event
 
@@ -1342,24 +1452,28 @@ def normalize_trace_records(records: list[dict[str, Any]], *, source: str = "gen
     for record, event in zip(records, events):
         usage = raw_trace_value(record, "usage", "tokens")
         if isinstance(usage, dict):
-            for key in token_totals:
-                value = usage.get(key)
+            input_tokens = usage_number(usage, "input_tokens")
+            output_tokens = usage_number(usage, "output_tokens")
+            total_tokens = usage_number(usage, "total_tokens")
+            if total_tokens is None and input_tokens is not None and output_tokens is not None:
+                total_tokens = input_tokens + output_tokens
+            for key, value in [("input_tokens", input_tokens), ("output_tokens", output_tokens), ("total_tokens", total_tokens)]:
                 if isinstance(value, (int, float)):
                     token_totals[key] += value
         duration = raw_trace_value(record, "duration_ms", "elapsed_ms")
         if isinstance(duration, (int, float)):
             elapsed_ms += float(duration)
         tokens = event.get("tokens")
-        if isinstance(tokens, dict):
+        if isinstance(tokens, dict) and not isinstance(usage, dict):
             for key in token_totals:
                 value = tokens.get(key)
-                if isinstance(value, (int, float)) and not any(isinstance(raw_trace_value(r, "usage", "tokens"), dict) for r in [record]):
+                if isinstance(value, (int, float)):
                     token_totals[key] += value
-    skill_events = [e for e in events if e.get("type") == "skill_load"]
+    skill_events = [e for e in events if e.get("type") == "skill_load" or event_mentions_skill_file(e)]
     metrics: dict[str, Any] = {
         "schema_version": 1,
         "source": source,
-        "tool_calls": sum(1 for e in events if e.get("type") in {"tool_call", "command"}),
+        "tool_calls": sum(1 for e in events if e.get("type") == "tool_call") + len(command_events(events)),
         "commands": len(commands),
         "file_reads": sum(1 for e in events if e.get("type") in {"file_read", "skill_load"}),
         "file_writes": sum(1 for e in events if e.get("type") == "file_write"),
@@ -1378,23 +1492,56 @@ def normalize_trace_records(records: list[dict[str, Any]], *, source: str = "gen
     return event_doc, metrics
 
 
-def import_trace(args: argparse.Namespace) -> int:
-    trace = Path(args.trace)
-    run_dir = Path(args.run_dir)
-    records, parse_errors = load_trace_jsonl(trace)
-    events, metrics = normalize_trace_records(records, source=getattr(args, "source", "generic"))
+def write_trace_artifacts(
+    run_dir: Path,
+    trace_text: str,
+    *,
+    source: str,
+    metadata: dict[str, Any] | None = None,
+    extra_metrics: dict[str, Any] | None = None,
+    environment: dict[str, Any] | None = None,
+    write_metadata: bool = True,
+    out_events: Path | None = None,
+    out_metrics: Path | None = None,
+    write_raw_trace: bool = True,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    if write_raw_trace:
+        (run_dir / "trace.jsonl").write_text(trace_text, encoding="utf-8")
+    records, parse_errors = parse_trace_jsonl_text(trace_text)
+    events, metrics = normalize_trace_records(records, source=source)
     if parse_errors:
         metrics["parse_errors"] = parse_errors[:20]
         metrics["errors"] = int(metrics.get("errors", 0) or 0) + len(parse_errors)
-    out_events = Path(args.out_events) if getattr(args, "out_events", None) else run_dir / "events.json"
-    out_metrics = Path(args.out_metrics) if getattr(args, "out_metrics", None) else run_dir / "metrics.json"
-    write_json(out_events, events)
-    write_json(out_metrics, metrics)
-    if getattr(args, "write_metadata", False):
+    if extra_metrics:
+        metrics.update(extra_metrics)
+    write_json(out_events or run_dir / "events.json", events)
+    write_json(out_metrics or run_dir / "metrics.json", metrics)
+    if environment:
+        write_json(run_dir / "environment.json", environment)
+    if write_metadata:
         existing = read_metadata_base(run_dir)
+        if metadata:
+            existing.update(metadata)
         existing.update({k: v for k, v in metrics.items() if k not in {"schema_version", "source"}})
-        existing["trace_source"] = getattr(args, "source", "generic")
+        existing["trace_source"] = source
         write_json(run_dir / "metadata.json", existing)
+    return events, metrics
+
+
+def import_trace(args: argparse.Namespace) -> int:
+    trace = Path(args.trace)
+    run_dir = Path(args.run_dir)
+    trace_text = trace.read_text(encoding="utf-8", errors="replace")
+    write_trace_artifacts(
+        run_dir,
+        trace_text,
+        source=getattr(args, "source", "generic"),
+        write_metadata=getattr(args, "write_metadata", False),
+        out_events=Path(args.out_events) if getattr(args, "out_events", None) else None,
+        out_metrics=Path(args.out_metrics) if getattr(args, "out_metrics", None) else None,
+        write_raw_trace=False,
+    )
     return 0
 
 
@@ -1446,25 +1593,24 @@ def run_codex(args: argparse.Namespace) -> int:
             elapsed_ms = int((time.time() - started) * 1000)
             trace_text = proc.stdout if proc.stdout.strip() else ""
             if trace_text:
-                (base / "trace.jsonl").write_text(trace_text, encoding="utf-8")
-                records, parse_errors = parse_trace_jsonl_text(trace_text)
-                events, metrics = normalize_trace_records(records, source="codex")
-                if parse_errors:
-                    metrics["parse_errors"] = parse_errors[:20]
-                    metrics["errors"] = int(metrics.get("errors", 0) or 0) + len(parse_errors)
+                events, metrics = write_trace_artifacts(
+                    base,
+                    trace_text,
+                    source="codex",
+                    metadata={"provider": "codex", "elapsed_ms": elapsed_ms, "stderr": proc.stderr[:4000] if proc.stderr else ""},
+                    extra_metrics={"elapsed_ms": elapsed_ms, "returncode": proc.returncode},
+                    environment={"runner": "codex", "command": cmd, "cwd": task.get("repo_root")},
+                    write_metadata=True,
+                )
             else:
-                events, metrics = {"schema_version": 1, "source": "codex", "events": []}, {"schema_version": 1, "source": "codex"}
-            metrics.setdefault("elapsed_ms", elapsed_ms)
-            metrics["returncode"] = proc.returncode
-            write_json(base / "events.json", events)
-            write_json(base / "metrics.json", metrics)
+                events, metrics = {"schema_version": 1, "source": "codex", "events": []}, {"schema_version": 1, "source": "codex", "elapsed_ms": elapsed_ms, "returncode": proc.returncode}
+                write_json(base / "events.json", events)
+                write_json(base / "metrics.json", metrics)
+                write_json(base / "metadata.json", {"provider": "codex", "elapsed_ms": elapsed_ms, "returncode": proc.returncode, "stderr": proc.stderr[:4000] if proc.stderr else "", "trace_source": "codex"})
             answer = final_answer_from_events(events) or proc.stdout.strip()
             if proc.returncode != 0:
                 answer = f"[CODEX FAILURE: returncode={proc.returncode}]\n\n{answer}\n\nstderr:\n{proc.stderr[:4000]}"
             (base / "output.md").write_text(answer or "[CODEX FAILURE: no output produced]\n", encoding="utf-8")
-            meta = dict(metrics)
-            meta.update({"provider": "codex", "elapsed_ms": elapsed_ms, "stderr": proc.stderr[:4000] if proc.stderr else ""})
-            write_json(base / "metadata.json", meta)
         except subprocess.TimeoutExpired as exc:
             elapsed_ms = int((time.time() - started) * 1000)
             (base / "output.md").write_text(f"[CODEX FAILURE: timed out after {timeout}s]\n", encoding="utf-8")
@@ -1748,6 +1894,8 @@ def grade_case_variant(
     text = text or ""
     judge_results = judge_results or {}
     for assertion in case.get("assertions", []):
+        if not assertion_applies_to_variant(assertion, variant):
+            continue
         atype = assertion.get("type")
         if atype in QUALITATIVE_ASSERTIONS:
             jid = judge_task_id(case["id"], variant, run_number, assertion)

--- a/tests/test_skill_benchmark.py
+++ b/tests/test_skill_benchmark.py
@@ -17,6 +17,10 @@ TRIGGER_SPEC = importlib.util.spec_from_file_location("run_pi_trigger_eval", ROO
 tr = importlib.util.module_from_spec(TRIGGER_SPEC)
 assert TRIGGER_SPEC.loader is not None
 TRIGGER_SPEC.loader.exec_module(tr)
+SMOKE_SPEC = importlib.util.spec_from_file_location("run_pi_smoke", ROOT / "examples" / "adewale-workspace" / "run_pi_smoke.py")
+smoke = importlib.util.module_from_spec(SMOKE_SPEC)
+assert SMOKE_SPEC.loader is not None
+SMOKE_SPEC.loader.exec_module(smoke)
 
 
 class SkillBenchmarkTests(unittest.TestCase):
@@ -258,6 +262,33 @@ class SkillBenchmarkTests(unittest.TestCase):
             without_task_json = next(f for f in without_row["upload_plan"]["files"] if f["role"] == "task")["content"]
             self.assertEqual(json.loads(without_task_json)["skill_files"], [])
 
+    def test_pi_message_end_trace_normalizes_usage_and_skill_load(self):
+        records = [
+            {"type": "tool_use", "tool_input": {"path": "/tmp/demo/skill/SKILL.md"}},
+            {"type": "message_end", "message": {"role": "assistant", "content": [{"type": "text", "text": "alpha beta"}], "usage": {"input": 10, "output": 5, "totalTokens": 15}}},
+        ]
+        events, metrics = sb.normalize_trace_records(records, source="pi")
+        self.assertEqual([e["type"] for e in events["events"]], ["skill_load", "message"])
+        self.assertEqual(metrics["total_tokens"], 15)
+        self.assertTrue(metrics["skill_invoked"])
+
+    def test_actual_codex_jsonl_shape_extracts_answer_and_tokens(self):
+        records = [
+            {"type": "thread.started", "thread_id": "thread_1"},
+            {"type": "turn.started"},
+            {"type": "item.started", "item": {"id": "item_1", "type": "command_execution", "command": "/bin/zsh -lc \"sed -n '1,80p' skills/good-pr/SKILL.md\"", "status": "in_progress"}},
+            {"type": "item.completed", "item": {"id": "item_1", "type": "command_execution", "command": "/bin/zsh -lc \"sed -n '1,80p' skills/good-pr/SKILL.md\"", "aggregated_output": "---", "exit_code": 0, "status": "completed"}},
+            {"type": "item.completed", "item": {"id": "item_0", "type": "agent_message", "text": "codex-trace-ok"}},
+            {"type": "turn.completed", "usage": {"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 9, "reasoning_output_tokens": 0}},
+        ]
+        events, metrics = sb.normalize_trace_records(records, source="codex")
+        self.assertEqual(sb.final_answer_from_events(events), "codex-trace-ok")
+        self.assertEqual(metrics["commands"], 1)
+        self.assertTrue(metrics["skill_invoked"])
+        self.assertEqual(metrics["input_tokens"], 100)
+        self.assertEqual(metrics["output_tokens"], 9)
+        self.assertEqual(metrics["total_tokens"], 109)
+
     def test_import_jetty_results_roundtrip_can_be_benchmarked(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -269,7 +300,14 @@ class SkillBenchmarkTests(unittest.TestCase):
                 "status": "completed",
                 "trajectory_id": "traj_1",
                 "jetty": {"collection": "skill-evals", "task": "demo-case-1-with-skill-1", "agent": "claude-code", "model": "claude-sonnet-4-6", "model_provider": "anthropic", "snapshot": "python312-uv"},
-                "trajectory": {"usage": {"total_tokens": 12}, "elapsed_ms": 34},
+                "trajectory": {
+                    "usage": {"input_tokens": 5, "output_tokens": 7, "total_tokens": 12},
+                    "elapsed_ms": 34,
+                    "events": [
+                        {"type": "tool_call", "tool_input": {"path": "/tmp/demo/skill/SKILL.md"}},
+                        {"type": "exec_command", "command": "python -m unittest"},
+                    ],
+                },
                 "artifacts": [
                     {"path": "/app/results/output.md", "content": "alpha beta"},
                     {"path": "/app/results/metadata.json", "content": {"total_tool_calls": 2}},
@@ -288,6 +326,12 @@ class SkillBenchmarkTests(unittest.TestCase):
             meta = json.loads((runs / "case-1" / "with_skill" / "metadata.json").read_text(encoding="utf-8"))
             self.assertEqual(meta["provider"], "jetty")
             self.assertEqual(meta["jetty_trajectory_id"], "traj_1")
+            self.assertTrue((runs / "case-1" / "with_skill" / "trace.jsonl").exists())
+            events = json.loads((runs / "case-1" / "with_skill" / "events.json").read_text(encoding="utf-8"))
+            metrics = json.loads((runs / "case-1" / "with_skill" / "metrics.json").read_text(encoding="utf-8"))
+            self.assertTrue(any(e["type"] == "skill_load" for e in events["events"]))
+            self.assertEqual(metrics["commands"], 1)
+            self.assertEqual(metrics["total_tokens"], 12)
             self.assertIn("JETTY FAILURE", (runs / "case-1" / "without_skill" / "output.md").read_text(encoding="utf-8"))
             report = sb.build_benchmark_report(manifest, runs, variants_arg=["with_skill"])
             self.assertEqual(report["summary"]["with_skill"]["mean_objective_pass_rate"], 1.0)
@@ -325,6 +369,45 @@ class SkillBenchmarkTests(unittest.TestCase):
             records = list(sb.execute_jetty_payloads([row], client=ShouldNotCallClient()))
             self.assertEqual(records[0]["status"], "failed")
             self.assertIn("non-executable", records[0]["error"])
+
+    def test_pi_smoke_workspace_omits_skill_for_without_skill(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            manifest = self.make_manifest(root)
+            repo = manifest.parent.parent
+            fixture = manifest.parent / "fixtures" / "input.txt"
+            fixture.parent.mkdir()
+            fixture.write_text("fixture", encoding="utf-8")
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            data["cases"][0]["files"] = ["fixtures/input.txt"]
+            with tempfile.TemporaryDirectory() as wd:
+                instruction, skill_args, inputs, skill_paths = smoke.materialize_runtime_workspace(data, repo, data["cases"][0], "without_skill", Path(wd))
+                self.assertEqual(skill_args, ["--no-skills"])
+                self.assertEqual(skill_paths, [])
+                self.assertEqual(len(inputs), 1)
+                self.assertTrue(str(inputs[0]).startswith(str(Path(wd).resolve())))
+                self.assertFalse((Path(wd) / "skills").exists())
+                self.assertIn("not present", instruction)
+            with tempfile.TemporaryDirectory() as wd:
+                _, skill_args, _, skill_paths = smoke.materialize_runtime_workspace(data, repo, data["cases"][0], "with_skill", Path(wd))
+                self.assertTrue(skill_paths)
+                self.assertIn("--skill", skill_args)
+                self.assertTrue(all(str(p.resolve()).startswith(str(Path(wd).resolve())) for p in skill_paths))
+
+    def test_pi_trigger_trace_artifact_writer_uses_detector_evidence(self):
+        with tempfile.TemporaryDirectory() as td:
+            run_dir = Path(td) / "trigger-run"
+            stdout = "\n".join([
+                json.dumps({"type": "tool_use", "tool_input": {"path": "/tmp/pi-trigger/skills/demo/SKILL.md"}}),
+                json.dumps({"type": "message_end", "message": {"role": "assistant", "content": [{"type": "text", "text": "done"}], "usage": {"input": 3, "output": 2, "totalTokens": 5}}}),
+            ]) + "\n"
+            result = {"query": "demo", "should_trigger": True, "triggered": True, "pass": True, "elapsed_ms": 50, "returncode": 0, "timed_out": False, "evidence": ["/tmp/pi-trigger/skills/demo/SKILL.md"]}
+            tr.write_trigger_trace_artifacts(run_dir, stdout, result)
+            metrics = json.loads((run_dir / "metrics.json").read_text(encoding="utf-8"))
+            meta = json.loads((run_dir / "metadata.json").read_text(encoding="utf-8"))
+            self.assertTrue(metrics["skill_invoked"])
+            self.assertEqual(metrics["total_tokens"], 5)
+            self.assertEqual(meta["query"], "demo")
 
     def test_script_assertion_requires_opt_in_and_executes_oracle(self):
         with tempfile.TemporaryDirectory() as td:
@@ -436,6 +519,29 @@ class SkillBenchmarkTests(unittest.TestCase):
             self.assertEqual(result["efficiency_pass_rate"], 1.0)
             self.assertEqual(report["summary"]["with_skill"]["telemetry_availability"]["events"], 1)
             self.assertEqual(report["slice_summary"]["domain"]["writing"]["with_skill"]["runs"], 1)
+
+    def test_variant_scoped_process_assertions_do_not_penalize_other_variants(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            manifest = self.make_manifest(root)
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            data["cases"][0]["assertions"] = [
+                {"name": "with-skill-load", "type": "skill_invoked", "expected": True, "variants": ["with_skill"]},
+                {"name": "without-skill-no-load", "type": "skill_invoked", "expected": False, "variants": ["without_skill"]},
+            ]
+            manifest.write_text(json.dumps(data), encoding="utf-8")
+            runs = root / "repo" / "eval-runs" / "latest"
+            for variant, invoked in [("with_skill", True), ("without_skill", False)]:
+                base = runs / "case-1" / variant
+                base.mkdir(parents=True)
+                (base / "output.md").write_text("alpha beta", encoding="utf-8")
+                sb.write_trace_artifacts(base, "", source="test", extra_metrics={"skill_invoked": invoked, "skill_invocation_evidence": [variant] if invoked else []}, write_metadata=True)
+            report = sb.build_benchmark_report(manifest, runs)
+            by_variant = {r["variant"]: r for r in report["results"]}
+            self.assertEqual(by_variant["with_skill"]["objective_total"], 1)
+            self.assertEqual(by_variant["without_skill"]["objective_total"], 1)
+            self.assertEqual(by_variant["with_skill"]["objective_pass_rate"], 1.0)
+            self.assertEqual(by_variant["without_skill"]["objective_pass_rate"], 1.0)
 
     def test_process_and_efficiency_assertions_fail_closed_without_evidence(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary
- add variant-scoped assertions for process checks that differ between with_skill and without_skill
- normalize actual Pi and Codex JSONL event shapes, including Pi usage aliases and Codex item.completed/command_execution records
- add shared trace artifact writing and use it from import-trace, run-codex, Jetty result import, Pi smoke, and Pi trigger traces
- harden the Adewale Pi smoke runner to execute in isolated temp workspaces with only variant-allowed files
- add skill-pi-trigger-eval --trace-runs

## Grounding
- live Codex JSONL smoke emitted thread.started, item.completed/agent_message, command_execution, and turn.completed usage
- live Pi smoke showed without_skill could read skills/good-pr/SKILL.md from the repo before isolation; the isolated runner fixes that boundary
- live Pi trigger smoke wrote trace.jsonl/events.json/metrics.json and preserved trigger evidence
- Jetty remains mocked/unit-grounded because live JETTY_API_TOKEN is not available

## Validation
- python3 -m py_compile *.py examples/adewale-workspace/*.py
- python3 -m unittest discover tests -v
- python3 skill_benchmark.py --help
- python3 run_pi_trigger_eval.py --help
- git diff --check