### PR TITLE
Release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable public changes are listed here. Release tags are the source of truth
 
 ## Unreleased
 
+## v0.4.2 — 2026-06-12
+
 - Tighten README and trace-aware spec language after the v0.4.1 runner release; no behavior changes.
 - Add trace-runner lessons on no-skill workspace isolation, trace-backed process assertions, runner-shape normalization, and post-release spec tense.
 - Add a `good-repo` effectiveness audit, package keywords/classifiers, and project URLs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skill-eval-harness"
-version = "0.4.1"
+version = "0.4.2"
 description = "Repo-agnostic Agent Skill evaluation harness with paired variants, holdout splits, repeated-run stats, script assertions, judge command backends, Anthropic-compatible exports, Jetty adapter support, and static review output."
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- bump package version to 0.4.2
- move token-overhead changelog entry under v0.4.2

## Validation
- python3 -m py_compile *.py examples/adewale-workspace/*.py
- python3 -m unittest discover tests -v
- uv build