### PR TITLE
Add vocabulary glossary and evals-are-not-tests docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable public changes are listed here. Release tags are the source of truth
 
 ## Unreleased
 
+- Add `docs/vocabulary.md` glossary and `docs/evals-are-not-tests.md` conceptual page; link both from the README documentation map. Docs only; no behavior changes.
+
 ## v0.4.2 — 2026-06-12
 
 - Tighten README and trace-aware spec language after the v0.4.1 runner release; no behavior changes.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ skill-benchmark --help
 | `CHANGELOG.md` | Release history and unreleased repo-surface changes. |
 | `CONTRIBUTING.md` | Local setup, validation commands, and eval-safety rules. |
 | `LESSONS_LEARNED.md` | Design lessons from the multi-skill saturation work. |
+| `docs/vocabulary.md` | Glossary of harness terms: variants, splits, ablations, assertions, trace artifacts, and report flags. |
+| `docs/evals-are-not-tests.md` | Why a skill eval is not a unit test, and what that changes about reading results. |
 | `docs/jetty-support-spec.md` | Jetty payload/import contract and live-token unknowns. |
 | `docs/trace-aware-eval-spec.md` | Trace artifact contract, shipped v0.4.1 runner support, process/efficiency assertions, and remaining trace work. |
 | `docs/repo-effectiveness-audit.md` | `good-repo` audit, score, package metadata fixes, and manual GitHub settings checklist. |

--- a/docs/evals-are-not-tests.md
+++ b/docs/evals-are-not-tests.md
@@ -1,0 +1,53 @@
+# Evals Are Not Tests
+
+A unit test and a skill eval both end in pass or fail, which is why they get confused. The machinery underneath is different, and treating an eval like a test produces confident, wrong conclusions. This page explains the difference using the things this harness actually measures.
+
+The short version: a test asks whether one program is correct; an eval asks whether a change moved a model's behavior, and by how much, across many cases and repeated runs. Almost everything that follows is a consequence of that gap.
+
+## A test scores one program; an eval scores a difference
+
+A unit test runs one program and checks its output against a known answer. The program is the subject, and its pass is the whole result.
+
+An eval runs the *same* case twice — once `with_skill`, once `without_skill` — and the result that matters is the gap between them. The harness calls that gap **lift**. A `with_skill` run that passes tells you almost nothing on its own: the baseline might pass too. That is why the harness pairs variants and reports paired deltas rather than a single column of pass rates. If you read only the `with_skill` column, you are reading an eval as if it were a test, and you will credit the skill for behavior the model already had.
+
+## A passing test is the goal; a passing eval can mean the eval is too easy
+
+In a test suite, green is success. Make every test pass and ship.
+
+In an eval, green across both arms is a warning. The harness flags it two ways. **Saturated** means every `with_skill` run passes — pleasant, but weak evidence of lift. **No-lift** means `with_skill` and `without_skill` pass at the same rate, so the case measured nothing about the skill. A strong model saturates easy cases the way a strong student aces a placement test: the score is real and tells you little. The response is not to celebrate green; it is to add harder fixtures or artifact-level checks until the baseline starts to fail. A test you can always pass is finished. An eval you can always pass is broken.
+
+## A test is deterministic; an eval is a sample
+
+The same input gives a test the same output every time, so one run is a verdict. A flaky test is a bug to fix.
+
+Model output varies between runs, so one run of an eval is a sample, not a verdict. The harness repeats runs (`run-1`, `run-2`, …) and flags **flaky** when they disagree. Flakiness here is data about the case and the model, not a defect to suppress. This is also why a run that never happened is marked `missing_output` and excluded from comparisons: "not measured" and "measured and failed" are different facts, and collapsing them invents fake no-lift cases.
+
+## A test has one correct answer; an eval accepts equivalent good behavior
+
+`assertEqual(x, 5)` admits exactly one value. That precision is the point of a test.
+
+An eval grades open-ended output, where several phrasings are equally correct. An assertion that demanded `Decision: BLOCK` once failed a correct answer that wrote `**Decision: BLOCK.**`. The fix was not to loosen the standard but to assert the *behavior* — a semantically meaningful regex or `contains` variant — without calibrating away genuine misses. Objective assertions still grade deterministically and locally with no model call; the judgment is in choosing checks that track the property instead of one spelling of it. When string matching cannot reach the property, the work moves to a `script` oracle or a deferred `judge` assertion.
+
+## A test checks output; an eval also checks process
+
+A test inspects what a function returned. How it got there is invisible and usually irrelevant.
+
+For a skill, the path is part of the claim. Did the agent actually load the skill, or answer from general knowledge? Did it stay inside a tool or token budget? Final output cannot answer this, so the harness reads **trace artifacts** — `events.json` and `metrics.json` — for process assertions like `skill_invoked`, `command_order`, and `total_tokens_le`. These fail closed when the evidence is missing, because inferring "the skill loaded" from confident prose is exactly the mistake that lets a baseline masquerade as a skilled run. A skill that lifts pass rates while doubling token cost is a different verdict from one that lifts them for free, and **token overhead** reports lift per 1k extra tokens so you can see which one you have.
+
+## A test cannot leak its answer; an eval can
+
+A test holds the expected value in code the program under test never reads. There is no leak to worry about.
+
+An eval puts its prompt in front of the model, and if an assertion's keyword sits in that prompt, a weak answer passes by echoing the task. The harness has a **leakage** lint for exactly this, and `--strict-leakage` turns the warning into a failure once you have replaced the weak check with a scoped regex, a fixture-backed check, an oracle, or a judge. A green run from a leaked assertion looks identical to a green run from real skill behavior, which is why leakage is a property of the eval's design, not of the model.
+
+## A test does not overfit; an eval can be memorized
+
+Run a test a thousand times and it measures the same thing. There is nothing to overfit, because the answer was never hidden.
+
+An eval that stays visible while you tune against it stops measuring capability and starts measuring fit to that specific case. The **splits** exist to counter this: `tune` cases are for iteration, `holdout` is scored at end-of-round, and `holdback` stays out of the skill, docs, and eval descriptions until after scoring, so a suspiciously high score reveals memorization instead of hiding it. Tune saturation is not release proof; that claim waits on hidden prompts, private answer keys, and real fixtures being filled and scored.
+
+## What carries over
+
+Evals keep the test-suite habits worth keeping: deterministic local grading, fixtures checked into the repo, fast feedback, and assertions specific enough to mean something. The harness leans on all of them.
+
+The trap is importing the test-suite *mindset* — that green is the goal, that one run is a verdict, that the answer is fixed, that output is the whole story. An eval is a measurement instrument pointed at a stochastic system, and its job is to produce an honest difference between a world with the skill and a world without it. Read the [vocabulary](vocabulary.md) next for the precise terms, or the [README](../README.md) for the commands that compute these signals.

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -1,0 +1,90 @@
+# Vocabulary
+
+This page collects the terms the harness uses, with the place each one shows up in a manifest, a command, or a report. The README defines most of them inline where they first appear; this page is the single index so you do not have to hunt.
+
+Terms are grouped by what they describe: the units you evaluate, the comparison structure, the things you assert, the artifacts a run produces, and the signals a report flags.
+
+## Units of evaluation
+
+**Manifest** — the `evals/shared-benchmark.json` file a skill repo owns. It names the skill, declares variants and splits, and lists cases, assertions, and ablations. `validate` checks its shape; every other command reads it.
+
+**Case** — one scenario under test, identified by `id`. A case carries a `prompt`, optional fixture `files`, a `split`, taxonomy fields (`domain`, `difficulty`, `success_goals`, `trigger_type`), `expected_behavior`, and `assertions`.
+
+**Run** — one execution of one case under one variant. Repeated runs of the same case/variant pair produce `run-1`, `run-2`, and so on. Repetition exists because model output varies between runs; one run is not a measurement.
+
+**Fixture** — a real input file referenced by `case.files`, stored under the manifest's `evals/` directory. `prepare` emits fixtures as absolute `input_files` so the runner reads them before answering. Fixtures make a case harder to solve from generic knowledge or from echoing assertion keywords.
+
+## Comparison structure
+
+**Variant** — which arm of the comparison a run belongs to. The two defaults are `with_skill` and `without_skill`. Optional arms are `old_skill` (requires `old_skill_paths` and `--include-old-skill`) and `ablation:<id>`. The harness compares arms; a single arm in isolation says little.
+
+**Ablation** — an opt-in variant that simulates removing one component of a skill, declared under `manifest.ablations` and prepared with `--include-ablations`. Each entry names the `removed_component` and its `expected_regressions`. An ablation is a hypothesis about which instructions are load-bearing; it becomes evidence only once it is run on a discriminating case.
+
+**Split** — when a case is allowed to be seen.
+
+| Split | Visible | Used for |
+|---|---|---|
+| `tune` | While editing the skill and evals | Iteration |
+| `holdout` | At end-of-round or merge | Honest scoring |
+| `holdback` | Only after scoring | Detecting memorization |
+
+`holdout` and `holdback` prefer a private `prompt_ref` over an inline `prompt` so the answer is not exposed early. `prepare` fails on missing hidden prompts unless `--allow-missing-prompts` is passed for dry-run planning.
+
+## Things you assert
+
+**Assertion** — a single graded check on a run. Assertions fall into four groups.
+
+**Objective assertion** — a deterministic check on output text or files, graded locally with no model call: `contains`, `contains_any`, `contains_all`, `excludes_any`, `regex`, `not_regex`, `file_exists`, `json_field_equals`.
+
+**Oracle** — a `script` assertion: a deterministic command the repo owns, run against the candidate output directory. Use it when a keyword check is too weak for the property you care about. Oracles are blocked unless you pass `--allow-scripts`, because they execute repo-supplied commands.
+
+**Process assertion** — a check on *how* the run behaved, graded from trace artifacts rather than from the answer: `skill_invoked`, `command_ran` / `command_not_ran`, `command_order`, `tool_count_le`, `no_repeated_command_loop`. Process assertions fail closed when their evidence is missing, so `command_not_ran` cannot pass without `events.json`.
+
+**Efficiency assertion** — a budget check over `metrics.json` or `metadata.json`: `total_tokens_le`, `elapsed_seconds_le`, `command_count_le`.
+
+**Qualitative assertion** — a `judge` or `rubric` check that the harness cannot grade by string matching. These are deferred into `judge-tasks.jsonl` and resolved either by a user-supplied `--judge-cmd` or by merging `--judge-results`. The harness never picks a model for you.
+
+**Variant-scoped assertion** — an assertion restricted to specific arms via `variants` / `only_variants` / `except_variants`. Process checks need this: `skill_invoked=true` belongs to `with_skill`, and `skill_invoked=false` belongs to `without_skill`, so an unscoped skill-load requirement would wrongly penalize the baseline.
+
+## Run artifacts
+
+**`output.md`** — the final answer a run produced. Objective and qualitative assertions read it.
+
+**`metadata.json`** — optional per-run telemetry: elapsed time, token counts, model name.
+
+**Trace artifacts** — what a trace-aware runner writes so process and efficiency assertions have evidence:
+
+- `trace.jsonl` — the raw runner event stream, preserved before normalization.
+- `events.json` — normalized events that process assertions read.
+- `metrics.json` — tokens, command counts, tool calls, elapsed time, retries.
+- `environment.json` — runner, model, and sandbox details where available.
+
+The normalized shapes are an adapter boundary: Pi, Codex, and Jetty emit different raw events, so each shape gets fixture tests rather than an assumed common schema.
+
+## Report signals
+
+These are flags a `benchmark` report raises so you read pass rates correctly.
+
+**Lift** — the difference in objective pass rate between `with_skill` and `without_skill`. Lift, not a single arm's pass rate, is the evidence that a skill changed behavior.
+
+**Discrimination** — an assertion's ability to separate the arms. An assertion with identical with/without pass rates discriminates nothing, whatever its individual pass rate.
+
+**Saturated** — every `with_skill` run passes. That is not a skill failure, but it is weak evidence of lift, and it is a different measurement from skill quality.
+
+**No-lift** — `with_skill` and `without_skill` pass at the same rate, so the case shows no skill effect. Distinct from a failed run.
+
+**Flaky** — repeated runs of the same case/variant disagree. Flakiness is why runs repeat and why one pass is not a result.
+
+**Leakage** — an assertion value appears literally in the prompt, so a weak answer can pass by echoing the task. `validate` warns on this; `--strict-leakage` turns the warning into a failure once you have replaced the weak check.
+
+**Trigger / no-trigger** — whether a skill should load for a given query. A trigger case asserts autonomous skill *discovery*, detected from copied temp skill paths in the trace, not from the final answer and not from a bare skill name. Trigger behavior depends on frontmatter `description`, so ablations skip trigger cases.
+
+**Missing output** — a case/variant that was never run. It is marked `missing_output` and excluded from no-lift and saturation comparisons, because "not measured" is not "measured and failed."
+
+**Token overhead** — the static `SKILL.md` and reference footprint combined with the paired `with_skill - without_skill` token delta, reported as objective lift per 1k extra tokens. It answers whether the lift was worth the context the skill consumed.
+
+## See also
+
+- [`evals-are-not-tests.md`](evals-are-not-tests.md) — why these terms exist and why a test-suite vocabulary does not cover them.
+- [`../README.md`](../README.md) — manifest format, assertion reference, and command contracts.
+- [`../LESSONS_LEARNED.md`](../LESSONS_LEARNED.md) — the iteration history that produced several of these terms.


### PR DESCRIPTION
Fill two documentation gaps surfaced by the docs inventory:

- docs/vocabulary.md collects the harness terms (variants, splits,
  ablations, assertion types, trace artifacts, and report flags) into a
  single index, each tied to where it appears in a manifest, command, or
  report.
- docs/evals-are-not-tests.md explains why a skill eval is not a unit
  test, grounded in the signals the harness measures: lift, saturation,
  no-lift, flakiness, process/efficiency assertions, leakage, and splits.

Link both from the README documentation map and note the docs-only
change under CHANGELOG Unreleased.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FhKZ3AELHLRv6N57PdMXuD