### PR TITLE
Update install commands to v0.4.2 and re-audit repo effectiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The main question is narrow: **when the same case runs with and without the skil
 > Requires Python 3.10+ and [uv](https://docs.astral.sh/uv/). Install from GitHub first:
 >
 > ```bash
-> uv tool install git+https://github.com/adewale/skill-eval-harness.git@v0.4.1
+> uv tool install git+https://github.com/adewale/skill-eval-harness.git@v0.4.2
 > ```
 
 Run these from a skill repo that has `evals/shared-benchmark.json`:
@@ -89,12 +89,12 @@ viewer    -> review.html with assertion evidence and output previews
 ### From GitHub
 
 ```bash
-uv tool install git+https://github.com/adewale/skill-eval-harness.git@v0.4.1
+uv tool install git+https://github.com/adewale/skill-eval-harness.git@v0.4.2
 skill-benchmark --help
 skill-pi-trigger-eval --help
 
 # One-shot without installing globally:
-uvx --from git+https://github.com/adewale/skill-eval-harness.git@v0.4.1 skill-benchmark --help
+uvx --from git+https://github.com/adewale/skill-eval-harness.git@v0.4.2 skill-benchmark --help
 ```
 
 The installed commands are:

--- a/docs/repo-effectiveness-audit.md
+++ b/docs/repo-effectiveness-audit.md
@@ -1,8 +1,16 @@
 # Repo Effectiveness Audit
 
-Date: 2026-06-11
+Date: 2026-06-18 (re-audit; baseline 2026-06-11)
 
 This audit applies the `good-repo` skill to `adewale/skill-eval-harness` as a public Python CLI/package repo for Agent Skill evaluation.
+
+## Re-audit delta (2026-06-18)
+
+Re-run after `v0.4.2` and the `token-overhead` command shipped. Score is unchanged at 86/100; the substantive surfaces remain strong.
+
+- **Fixed:** README install commands pinned the stale `@v0.4.1` tag while the current release is `v0.4.2`. Quick start and Installation now pin `@v0.4.2` (`README.md`). Historical "shipped v0.4.1 runner support" references are intentionally left as-is.
+- **Verified:** all 31 unit tests pass locally via `python3 -m unittest discover tests`.
+- **Still pending (owner-only):** GitHub description, topics, and homepage URL remain empty on the repo page despite being present in `pyproject.toml`. See the manual settings checklist below.
 
 ## Snapshot
 


### PR DESCRIPTION
## Summary

- Updated README install commands from `@v0.4.1` to `@v0.4.2` to reflect the current release
- Added re-audit documentation for 2026-06-18 showing score remains at 86/100
- Documented verification that all 31 unit tests pass locally
- Noted pending owner-only GitHub metadata settings (description, topics, homepage URL)

## Validation

- [x] `python3 -m unittest discover tests` — all 31 unit tests pass locally
- [x] README install commands updated consistently across Quick Start and Installation sections

## Eval / docs impact

- [x] README updated with current release tag (`v0.4.2`)
- [x] Repo effectiveness audit documentation updated with re-audit findings
- [x] No CLI behavior changes; no test updates needed

## Notes / risks

- Historical references to "v0.4.1 runner support" in audit docs intentionally left unchanged as they document past state
- GitHub repo metadata (description, topics, homepage) remain empty on the repo page despite being in `pyproject.toml`—this is a known limitation requiring owner-level GitHub settings access and is documented for future resolution

https://claude.ai/code/session_01G18eQHLCDviJPgSW7UTGxL