### PR TITLE
Add Codex trigger-matrix parity and agent capability registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ skill-benchmark --help
 | `docs/ablation-study-walkthrough.md` + `examples/skill-pins.json` | A worked ablation study across ten real skills, pinned to exact commit SHAs (+ canonical tree hashes) so it reproduces against the evaluated versions **without vendoring** any skill content. Includes the replication lesson (2 of 3 single-shot findings refuted at n=5). |
 | `docs/repo-effectiveness-audit.md` | `good-repo` audit, score, package metadata fixes, and manual GitHub settings checklist. |
 | `TODO.md` | Status tracker: the eval-framework roadmap (implemented, bar two `(TODO-native)` items) and the remaining Jetty adapter work — streaming/concurrency, live API validation, judge export, per-variant overrides, and the `swap:<id>` ablation follow-on. |
-| `examples/demo-skill/` | Self-contained, **offline** end-to-end example: a tiny synthetic skill, two materialized ablations, and a deterministic stub runner (no model/API). `prepare → run-codex → benchmark` confirms a regression per ablation; exercised by `tests/test_example_demo.py`. Also carries should-fire/should-not-fire trigger cases for `skill-trigger-matrix` (offline via `--agent stub`; live smoke via `RUN_TRIGGER_SMOKE=1`). Start here. |
+| `examples/demo-skill/` | Self-contained, **offline** end-to-end example: a tiny synthetic skill, two answer-path materialized ablations, one discovery ablation for trigger examples, and a deterministic stub runner (no model/API). `prepare → run-codex → benchmark` confirms a regression per answer-path ablation; exercised by `tests/test_example_demo.py`. Also carries should-fire/should-not-fire trigger cases for `skill-trigger-matrix` (offline via `--agent stub`; live smoke via `RUN_TRIGGER_SMOKE=1`). Start here. |
 | `examples/adewale-workspace/` | Adewale-specific Pi smoke runner and cross-repo aggregate report (the trigger runners are the top-level `skill-pi-trigger-eval` and `skill-trigger-matrix`). |
 | `tests/test_skill_benchmark.py` | Executable examples for grading, leakage lint, script assertions, judge commands, Jetty export/import, trace artifacts, and trigger detection. |
 
@@ -617,7 +617,7 @@ skill-benchmark profile-skill ../repo/evals/shared-benchmark.json \
 Cost is a first-class eval signal (issue #21). Every runner path — Pi smoke, Pi trigger, `run-codex`, `run-claude`, `run-subagent`, the judge wrapper, and the Jetty importer — writes two normalized blocks into run metadata beside the raw provider fields (which are preserved unchanged for audit):
 
 - `usage_normalized`: alias-normalized token counts (`input`/`prompt_tokens`/`totalTokens`/cache/reasoning variants) with a `source` — `provider_reported` (relayed from the provider), `trace_normalized` (summed from normalized trace events), `estimated`, `missing`, or `not_applicable`.
-- `cost_normalized`: dollar cost with `currency`, per-part costs when reported, and a `source` — `provider_reported` vs `price_table_estimated` are never conflated, and **missing cost is marked `missing`, never written as zero**. Provider-reported blocks always beat trace-derived ones; offline/stub runs carry explicit `missing` markers.
+- `cost_normalized`: dollar cost with `currency`, per-part costs when reported, and a `source` — `provider_reported`, `trace_normalized`, and `price_table_estimated` are never conflated, and **missing cost is marked `missing`, never written as zero**. Provider-reported blocks always beat trace-derived ones; offline/stub runs carry explicit `missing` markers.
 
 Consumers of the blocks:
 
@@ -626,7 +626,7 @@ Consumers of the blocks:
 - `suite-run` projects spend **before any model call** from previous ledgers (`--cost-history <dir>`, per-run medians) or a static assumption (`--assumed-tokens-per-run`), and gates on `--max-estimated-tokens` / `--max-estimated-cost-usd` — failing closed when a dollar cap is set but no dollar estimate exists — unless `--allow-over-budget`.
 - `audit-manifest --runs` adds cost-quality findings above `--expensive-case-usd` (default $1): `expensive-saturated-case`, `expensive-no-lift-case`, `high-cost-judge-only-case`, `ablation-high-spend-no-structured-regression`, and `high-footprint-low-lift-skill`.
 
-Interpretation rule: `provider_reported` numbers are the bill; `trace_normalized` reconstructs usage from events (good for tokens, silent on dollars); `missing` means the run truly carried no telemetry — fix the runner path rather than treating it as free.
+Interpretation rule: `provider_reported` numbers are a direct provider envelope; `trace_normalized` reconstructs usage or cost from event streams; `missing` means the run truly carried no telemetry — fix the runner path rather than treating it as free.
 
 ### Token overhead
 
@@ -720,7 +720,7 @@ skill-trigger-matrix ../repo/evals/shared-benchmark.json \
   --out trigger-matrix.json
 ```
 
-For each (agent, model) cell this mounts the skill where that agent discovers skills autonomously (never forcing the load), runs the manifest's `kind: "trigger"` cases the requested number of times, and reports per-cell trigger rates split by should-fire / should-not-fire polarity. The `claude` adapter spawns headless Claude Code subagents and defaults to haiku, sonnet, and opus; `--agent codex`, `--agent pi`, and the offline `--agent stub` are included. Additional agents register through an `AgentAdapter` subclass plus an `AGENT_CAPABILITIES` row. The tuning loop that consumes these rates is [`docs/tuning-skill-activation.md`](docs/tuning-skill-activation.md); manual live smoke tests wrap the same path (`RUN_TRIGGER_SMOKE=1` for Claude, `RUN_CODEX_TRIGGER_SMOKE=1` for Codex). For a cheaper auth/network/process check that invokes every supported live adapter/model without asserting trigger behavior, run `RUN_AGENT_INVOKE_SMOKE=1 python3 -m unittest tests.test_trigger_matrix.AgentInvokeSmokeTests -v`.
+For each (agent, model) cell this mounts the skill where that agent discovers skills autonomously (never forcing the load), runs the manifest's `kind: "trigger"` cases the requested number of times, and reports per-cell trigger rates split by should-fire / should-not-fire polarity. The `claude` adapter spawns headless Claude Code subagents and defaults to haiku, sonnet, and opus; `--agent codex`, `--agent pi`, and the offline `--agent stub` are included. Additional agents register through an `AgentAdapter` subclass plus an `AGENT_CAPABILITIES` row. The tuning loop that consumes these rates is [`docs/tuning-skill-activation.md`](docs/tuning-skill-activation.md); manual live smoke tests wrap the same path (`RUN_TRIGGER_SMOKE=1` for Claude, `RUN_CODEX_TRIGGER_SMOKE=1` for Codex, `RUN_PI_TRIGGER_SMOKE=1` for Pi). For a cheaper auth/network/process check that invokes every supported live adapter/model without asserting trigger behavior, run `RUN_AGENT_INVOKE_SMOKE=1 python3 -m unittest tests.test_trigger_matrix.AgentInvokeSmokeTests -v`.
 
 ### Pi trigger evals
 

--- a/README.md
+++ b/README.md
@@ -374,13 +374,13 @@ skill-benchmark prepare ../repo/evals/shared-benchmark.json --split tune --out t
 skill-benchmark run-codex --tasks tasks.jsonl --runs ../repo/eval-runs/codex-tune
 ```
 
-Override `--codex-cmd` for local wrappers or tests. A concrete Codex smoke command is:
+Override `--codex-cmd` for local wrappers or tests:
 
 ```bash
 skill-benchmark run-codex \
   --tasks tasks.jsonl \
   --runs ../repo/eval-runs/codex-trace \
-  --codex-cmd 'codex exec --json --sandbox read-only --skip-git-repo-check --ephemeral'
+  --codex-cmd ./bin/codex-jsonl-wrapper
 ```
 
 ### Run Claude tasks (with cost capture)
@@ -720,7 +720,7 @@ skill-trigger-matrix ../repo/evals/shared-benchmark.json \
   --out trigger-matrix.json
 ```
 
-For each (agent, model) cell this mounts the skill where that agent discovers skills autonomously (never forcing the load), runs the manifest's `kind: "trigger"` cases the requested number of times, and reports per-cell trigger rates split by should-fire / should-not-fire polarity. The `claude` adapter spawns headless Claude Code subagents and defaults to haiku, sonnet, and opus; `--agent pi` and the offline `--agent stub` are included, and other agents (Codex, …) register through an `AgentAdapter` subclass. The tuning loop that consumes these rates is [`docs/tuning-skill-activation.md`](docs/tuning-skill-activation.md); a manual live smoke test wraps the same path (`RUN_TRIGGER_SMOKE=1 python3 -m unittest tests.test_trigger_matrix -v`).
+For each (agent, model) cell this mounts the skill where that agent discovers skills autonomously (never forcing the load), runs the manifest's `kind: "trigger"` cases the requested number of times, and reports per-cell trigger rates split by should-fire / should-not-fire polarity. The `claude` adapter spawns headless Claude Code subagents and defaults to haiku, sonnet, and opus; `--agent codex`, `--agent pi`, and the offline `--agent stub` are included. Additional agents register through an `AgentAdapter` subclass plus an `AGENT_CAPABILITIES` row. The tuning loop that consumes these rates is [`docs/tuning-skill-activation.md`](docs/tuning-skill-activation.md); manual live smoke tests wrap the same path (`RUN_TRIGGER_SMOKE=1` for Claude, `RUN_CODEX_TRIGGER_SMOKE=1` for Codex). For a cheaper auth/network/process check that invokes every supported live adapter/model without asserting trigger behavior, run `RUN_AGENT_INVOKE_SMOKE=1 python3 -m unittest tests.test_trigger_matrix.AgentInvokeSmokeTests -v`.
 
 ### Pi trigger evals
 

--- a/TODO.md
+++ b/TODO.md
@@ -59,7 +59,7 @@ Jetty runbooks emit a standardized machine-readable `validation_report.json` per
 (`jettyio/jettyio-skills`, `skills/create-runbook/SKILL.md`). Rubric evaluation scores 3-7
 dimensions on a 1-5 scale; programmatic evaluation returns `PASS` / `PARTIAL` / `FAIL`. The
 items below map that report onto the harness judge-result row `{judge_task_id, passed, score,
-threshold, evidence}` (`load_judge_results:4233`, merged in `grade_case_variant:5237`).
+threshold, evidence}` (`load_judge_results:4296`, merged in `grade_case_variant:5300`).
 
 - [ ] Export qualitative judge tasks to Jetty workflows using `simple_judge` where useful.
       Carry `judge_task_id` (`case::variant::run-n::assertion`) into the Jetty task so the

--- a/TODO.md
+++ b/TODO.md
@@ -59,7 +59,7 @@ Jetty runbooks emit a standardized machine-readable `validation_report.json` per
 (`jettyio/jettyio-skills`, `skills/create-runbook/SKILL.md`). Rubric evaluation scores 3-7
 dimensions on a 1-5 scale; programmatic evaluation returns `PASS` / `PARTIAL` / `FAIL`. The
 items below map that report onto the harness judge-result row `{judge_task_id, passed, score,
-threshold, evidence}` (`load_judge_results:4296`, merged in `grade_case_variant:5300`).
+threshold, evidence}` (`load_judge_results:4328`, merged in `grade_case_variant:5332`).
 
 - [ ] Export qualitative judge tasks to Jetty workflows using `simple_judge` where useful.
       Carry `judge_task_id` (`case::variant::run-n::assertion`) into the Jetty task so the

--- a/agent_capabilities.py
+++ b/agent_capabilities.py
@@ -1,0 +1,106 @@
+"""Single registry for runner/agent feature parity.
+
+The harness used to describe agent support piecemeal in README prose, trigger
+runner code, and adapter docs. This registry is the code-side truth table: a new
+agent or a newly supported surface must update one row, and tests/docs can check
+against it instead of relying on stale paragraphs.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Literal
+
+CostSupport = Literal["provider", "stream", "imported", "estimated", "missing", "not_applicable"]
+
+
+@dataclass(frozen=True)
+class AgentCapabilities:
+    answer_runner: bool
+    autonomous_trigger: bool
+    trigger_ablation: bool
+    trace_artifacts: bool
+    token_usage: bool
+    dollar_cost: CostSupport
+    judge_backend: bool
+    tool_replay: bool
+    live_smoke_env: str | None
+    notes: str = ""
+
+    def as_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+AGENT_CAPABILITIES: dict[str, AgentCapabilities] = {
+    "claude": AgentCapabilities(
+        answer_runner=True,
+        autonomous_trigger=True,
+        trigger_ablation=True,
+        trace_artifacts=True,
+        token_usage=True,
+        dollar_cost="provider",
+        judge_backend=True,
+        tool_replay=True,
+        live_smoke_env="RUN_TRIGGER_SMOKE",
+        notes="run-claude captures the Claude CLI cost envelope; trigger matrix detects Skill tool-use plus path evidence.",
+    ),
+    "codex": AgentCapabilities(
+        answer_runner=True,
+        autonomous_trigger=True,
+        trigger_ablation=True,
+        trace_artifacts=True,
+        token_usage=True,
+        dollar_cost="missing",
+        judge_backend=False,
+        tool_replay=False,
+        live_smoke_env="RUN_CODEX_TRIGGER_SMOKE",
+        notes="Codex trigger support uses codex exec --json and path evidence; dollar cost remains explicit missing unless a wrapper emits cost.",
+    ),
+    "pi": AgentCapabilities(
+        answer_runner=False,
+        autonomous_trigger=True,
+        trigger_ablation=True,
+        trace_artifacts=True,
+        token_usage=True,
+        dollar_cost="stream",
+        judge_backend=False,
+        tool_replay=False,
+        live_smoke_env="RUN_PI_TRIGGER_SMOKE",
+        notes="Pi trigger support is shared by skill-pi-trigger-eval and skill-trigger-matrix; cost is parsed when the JSON stream reports it.",
+    ),
+    "jetty": AgentCapabilities(
+        answer_runner=True,
+        autonomous_trigger=False,
+        trigger_ablation=False,
+        trace_artifacts=True,
+        token_usage=True,
+        dollar_cost="imported",
+        judge_backend=False,
+        tool_replay=False,
+        live_smoke_env="RUN_JETTY_SMOKE",
+        notes="Jetty supports answer-path export/run/import; autonomous trigger and judge export/import remain separate Jetty TODOs.",
+    ),
+    "subagent": AgentCapabilities(
+        answer_runner=True,
+        autonomous_trigger=False,
+        trigger_ablation=False,
+        trace_artifacts=True,
+        token_usage=True,
+        dollar_cost="missing",
+        judge_backend=False,
+        tool_replay=True,
+        live_smoke_env=None,
+        notes="Generic in-process/shell seam for answer runs and tool replay; not an autonomous discovery adapter.",
+    ),
+    "stub": AgentCapabilities(
+        answer_runner=True,
+        autonomous_trigger=True,
+        trigger_ablation=True,
+        trace_artifacts=True,
+        token_usage=False,
+        dollar_cost="not_applicable",
+        judge_backend=False,
+        tool_replay=False,
+        live_smoke_env=None,
+        notes="Offline deterministic demo/CI adapter; never spends model tokens.",
+    ),
+}

--- a/agent_capabilities.py
+++ b/agent_capabilities.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 from typing import Literal
 
-CostSupport = Literal["provider", "stream", "imported", "estimated", "missing", "not_applicable"]
+CostSupport = Literal["provider_reported", "trace_normalized", "price_table_estimated", "missing", "not_applicable"]
 
 
 @dataclass(frozen=True)
@@ -37,7 +37,7 @@ AGENT_CAPABILITIES: dict[str, AgentCapabilities] = {
         trigger_ablation=True,
         trace_artifacts=True,
         token_usage=True,
-        dollar_cost="provider",
+        dollar_cost="provider_reported",
         judge_backend=True,
         tool_replay=True,
         live_smoke_env="RUN_TRIGGER_SMOKE",
@@ -61,7 +61,7 @@ AGENT_CAPABILITIES: dict[str, AgentCapabilities] = {
         trigger_ablation=True,
         trace_artifacts=True,
         token_usage=True,
-        dollar_cost="stream",
+        dollar_cost="trace_normalized",
         judge_backend=False,
         tool_replay=False,
         live_smoke_env="RUN_PI_TRIGGER_SMOKE",
@@ -73,10 +73,10 @@ AGENT_CAPABILITIES: dict[str, AgentCapabilities] = {
         trigger_ablation=False,
         trace_artifacts=True,
         token_usage=True,
-        dollar_cost="imported",
+        dollar_cost="provider_reported",
         judge_backend=False,
         tool_replay=False,
-        live_smoke_env="RUN_JETTY_SMOKE",
+        live_smoke_env=None,
         notes="Jetty supports answer-path export/run/import; autonomous trigger and judge export/import remain separate Jetty TODOs.",
     ),
     "subagent": AgentCapabilities(

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,9 @@ exists, so writing the journey is documentation work, not feature work.
 [`architecture.md`](architecture.md) (how the pipeline fits together),
 [`abstractions.md`](abstractions.md) (what each core object is),
 [`vocabulary.md`](vocabulary.md) (glossary),
-[`evals-are-not-tests.md`](evals-are-not-tests.md) (how to read results).
+[`evals-are-not-tests.md`](evals-are-not-tests.md) (how to read results),
+[`agent-parity.md`](agent-parity.md) (which agent surfaces are supported by Codex,
+Claude, Pi, Jetty, subagent, and stub).
 
 ## Specs
 

--- a/docs/abstractions.md
+++ b/docs/abstractions.md
@@ -130,9 +130,9 @@ editor. This boundary is the main extension seam in the codebase.
 
 A runner consumes task rows and produces the contract. The repo ships six paths plus a
 generic one: Pi smoke (`examples/adewale-workspace/run_pi_smoke.py`), Pi trigger
-(`run_pi_trigger_eval.py`), Codex (`run_codex:3661`), Claude (`run_claude:3809`, capturing real
-per-run cost), the in-process subagent runner (`run_subagent:4831`, which hosts record/replay
-tool I/O via `ToolReplayStore`), Jetty (`JettyClient:2192` and the export/run/import commands),
+(`run_pi_trigger_eval.py`), Codex (`run_codex:3724`), Claude (`run_claude:3872`, capturing real
+per-run cost), the in-process subagent runner (`run_subagent:4894`, which hosts record/replay
+tool I/O via `ToolReplayStore`), Jetty (`JettyClient:2207` and the export/run/import commands),
 and any runner that writes the contract directly. Each runner registers a workspace builder so
 one cross-runner invariant proves its `without_skill` arm is skill-free (CF.2). The harness
 calls no model itself; it reads what the runner left behind.

--- a/docs/abstractions.md
+++ b/docs/abstractions.md
@@ -130,9 +130,9 @@ editor. This boundary is the main extension seam in the codebase.
 
 A runner consumes task rows and produces the contract. The repo ships six paths plus a
 generic one: Pi smoke (`examples/adewale-workspace/run_pi_smoke.py`), Pi trigger
-(`run_pi_trigger_eval.py`), Codex (`run_codex:3724`), Claude (`run_claude:3872`, capturing real
-per-run cost), the in-process subagent runner (`run_subagent:4894`, which hosts record/replay
-tool I/O via `ToolReplayStore`), Jetty (`JettyClient:2207` and the export/run/import commands),
+(`run_pi_trigger_eval.py`), Codex (`run_codex:3756`), Claude (`run_claude:3904`, capturing real
+per-run cost), the in-process subagent runner (`run_subagent:4926`, which hosts record/replay
+tool I/O via `ToolReplayStore`), Jetty (`JettyClient:2208` and the export/run/import commands),
 and any runner that writes the contract directly. Each runner registers a workspace builder so
 one cross-runner invariant proves its `without_skill` arm is skill-free (CF.2). The harness
 calls no model itself; it reads what the runner left behind.
@@ -174,7 +174,7 @@ a re-grade cheap and deterministic.
 normalized gain, and a flag when the skill hurts). `build_slice_summary` breaks results down
 by domain, difficulty, trigger type, and success goal. Case flags mark saturated, no-lift,
 flaky, and with-skill-failed cases. These flags, the leakage lint
-(`prompt_assertion_leakage_findings:359`), and the split discipline are the part of the tool
+(`prompt_assertion_leakage_findings:360`), and the split discipline are the part of the tool
 no surveyed eval framework copies.
 
 ## What changes when you extend the tool

--- a/docs/agent-parity.md
+++ b/docs/agent-parity.md
@@ -7,7 +7,7 @@ The harness supports several agent surfaces, but not every agent supports every 
 | `claude` | yes (`run-claude`) | yes (`skill-trigger-matrix --agent claude`) | yes | yes | yes | provider-reported | yes (`--judge-model`) | yes through `run-subagent` | `RUN_TRIGGER_SMOKE` |
 | `codex` | yes (`run-codex`) | yes (`skill-trigger-matrix --agent codex`) | yes | yes | yes, when stream reports it | explicit `missing` unless a wrapper emits cost | no native backend; use `--judge-cmd` | no native replay | `RUN_CODEX_TRIGGER_SMOKE` |
 | `pi` | no core answer runner | yes (`skill-pi-trigger-eval`, `skill-trigger-matrix --agent pi`) | yes | yes | yes, when stream reports it | stream-reported when available | no | no | `RUN_PI_TRIGGER_SMOKE` |
-| `jetty` | yes (`export-jetty` / `run-jetty` / `import-jetty-results`) | no | answer-path ablations only | imported | imported | imported | planned in Jetty TODO | no | `RUN_JETTY_SMOKE` |
+| `jetty` | yes (`export-jetty` / `run-jetty` / `import-jetty-results`) | no | answer-path ablations only | imported | imported | imported | planned in Jetty TODO | no | n/a |
 | `subagent` | yes (`run-subagent`) | no | no | yes | yes, when backend returns it | explicit `missing` unless backend emits cost | no | yes | n/a |
 | `stub` | yes, demo/offline only | yes | yes | yes | not applicable | not applicable | no | no | n/a |
 
@@ -32,4 +32,4 @@ skill-trigger-matrix examples/demo-skill/evals/shared-benchmark.json \
   --out /tmp/trigger-codex-ablation.json
 ```
 
-Every row remains stamped `raw_autonomous_trigger_measurement`. These are rates for tuning descriptions, not provenance-confirmed causal lift claims.
+The report-level evidence class is `raw_autonomous_trigger_measurement`; individual result rows use the shared `raw_measurement` enum value. These are rates for tuning descriptions, not provenance-confirmed causal lift claims.

--- a/docs/agent-parity.md
+++ b/docs/agent-parity.md
@@ -18,7 +18,6 @@ Codex is no longer only an answer runner. The trigger matrix now accepts `--agen
 ```bash
 skill-trigger-matrix examples/demo-skill/evals/shared-benchmark.json \
   --agent codex \
-  --codex-cmd 'codex exec --json --sandbox read-only --skip-git-repo-check --ephemeral' \
   --runs-per-query 3 \
   --out /tmp/trigger-codex.json
 ```

--- a/docs/agent-parity.md
+++ b/docs/agent-parity.md
@@ -1,0 +1,36 @@
+# Agent parity matrix
+
+The harness supports several agent surfaces, but not every agent supports every surface. This table is the reader-facing copy of `agent_capabilities.AGENT_CAPABILITIES`; when an agent gains a surface, update the registry, this table, and the tests together.
+
+| Agent | Answer runs | Autonomous trigger | Trigger ablation | Trace artifacts | Token usage | Dollar cost | Judge backend | Tool replay | Live smoke |
+|---|---:|---:|---:|---:|---:|---|---:|---:|---|
+| `claude` | yes (`run-claude`) | yes (`skill-trigger-matrix --agent claude`) | yes | yes | yes | provider-reported | yes (`--judge-model`) | yes through `run-subagent` | `RUN_TRIGGER_SMOKE` |
+| `codex` | yes (`run-codex`) | yes (`skill-trigger-matrix --agent codex`) | yes | yes | yes, when stream reports it | explicit `missing` unless a wrapper emits cost | no native backend; use `--judge-cmd` | no native replay | `RUN_CODEX_TRIGGER_SMOKE` |
+| `pi` | no core answer runner | yes (`skill-pi-trigger-eval`, `skill-trigger-matrix --agent pi`) | yes | yes | yes, when stream reports it | stream-reported when available | no | no | `RUN_PI_TRIGGER_SMOKE` |
+| `jetty` | yes (`export-jetty` / `run-jetty` / `import-jetty-results`) | no | answer-path ablations only | imported | imported | imported | planned in Jetty TODO | no | `RUN_JETTY_SMOKE` |
+| `subagent` | yes (`run-subagent`) | no | no | yes | yes, when backend returns it | explicit `missing` unless backend emits cost | no | yes | n/a |
+| `stub` | yes, demo/offline only | yes | yes | yes | not applicable | not applicable | no | no | n/a |
+
+## What changed for Codex
+
+Codex is no longer only an answer runner. The trigger matrix now accepts `--agent codex`, mounts the same canonical or materialized skill tree used by Claude/Pi/stub, runs the raw trigger query through `codex exec --json`, and detects activation through the same path-evidence detector. The raw query is appended to the command prefix:
+
+```bash
+skill-trigger-matrix examples/demo-skill/evals/shared-benchmark.json \
+  --agent codex \
+  --codex-cmd 'codex exec --json --sandbox read-only --skip-git-repo-check --ephemeral' \
+  --runs-per-query 3 \
+  --out /tmp/trigger-codex.json
+```
+
+The same command can write per-run traces and run a materialized discovery/trigger-population ablation for any matrix agent:
+
+```bash
+skill-trigger-matrix examples/demo-skill/evals/shared-benchmark.json \
+  --agent codex \
+  --trace-runs /tmp/trigger-traces \
+  --ablation weaker-description \
+  --out /tmp/trigger-codex-ablation.json
+```
+
+Every row remains stamped `raw_autonomous_trigger_measurement`. These are rates for tuning descriptions, not provenance-confirmed causal lift claims.

--- a/docs/eval-framework-roadmap-spec.md
+++ b/docs/eval-framework-roadmap-spec.md
@@ -17,7 +17,7 @@ One invariant governs every item: core grading stays local and deterministic and
 model, and the harness never picks a model for the user. Anything that needs a model lives
 behind an opt-in command or the external `--judge-cmd`. Two abstractions absorb most of the
 work, so the spec returns to them often: the assertion result shape in `assertion_result`
-(`skill_benchmark.py:4085`) and the fan-out in `prepared_task_rows` (`:734`).
+(`skill_benchmark.py:4117`) and the fan-out in `prepared_task_rows` (`:735`).
 
 ## Testing baseline
 
@@ -40,7 +40,7 @@ tests are where that claim is checked rather than trusted.
 
 The buckets below extend what the harness can measure. This floor decides whether the number it
 already prints can be believed. The harness reports one thing: lift, `with_skill` minus
-`without_skill` on the same case (`build_paired_summary` (`:5918`)). That number is believable only
+`without_skill` on the same case (`build_paired_summary` (`:5950`)). That number is believable only
 when three preconditions hold, each intended today, none enforced, and each restating a claim from
 `evals-are-not-tests.md`:
 
@@ -60,22 +60,22 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
   hiding the quantity the tool exists to measure.
 - **Abstractions used or changed:** none in the engine. Adds
   `tests/fixtures/detectors/<detector_id>/should-fire.*` and `should-pass.*` that exercise
-  `assertion_result` (`:4085`) directly. That function has no direct unit test today, and its
+  `assertion_result` (`:4117`) directly. That function has no direct unit test today, and its
   `contains_any`, `excludes_any`, and `not_regex` branches go unexercised even though their types
-  are declared in the assertion registries (`TEXT_ASSERTIONS:63`).
+  are declared in the assertion registries (`TEXT_ASSERTIONS:64`).
 - **Design:** one table-driven test loads every pair and asserts the detector fires on `should-fire`
   and stays silent on `should-pass`. A `should-pass` twin is mandatory: it enforces the
   false-positive bar `authoring-evals.md` already sets for skill authors ("check both presence and
   absence"). Each `should-pass` set includes a case where the baseline echoes the prompt, because a
   detector that passes on echoed prompt text is a false oracle; this ties the fixtures to leakage
-  lint (`prompt_assertion_leakage_findings` (`:359`)). Every detector bug then becomes a permanent
+  lint (`prompt_assertion_leakage_findings` (`:360`)). Every detector bug then becomes a permanent
   fixture pair, and `test_command_assertions_match_command_inputs_not_outputs` is the first.
 - **Why it is the keystone:** the fixture pair is also the registration contract. It is what lets a
   harvested or third-party detector be trusted on entry, so it gates the exapted detector library
   (TODO, end of 2026), and it raises the oracle-strength ladder (1.7) so that "strong" means
   fixture-verified, not only deterministic.
 - **Testing:** the fixtures are the test. A meta-test asserts every name in `OBJECTIVE_ASSERTIONS`
-  (`:91`) has a fixture pair, so a new detector cannot land unverified.
+  (`:92`) has a fixture pair, so a new detector cannot land unverified.
 
 ### CF.2 — One cross-runner baseline-isolation invariant
 - **Goal:** prove the baseline is skill-free by construction, so a measured lift is the skill's
@@ -101,7 +101,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 ### CF.4 — A guard that the core grade path calls no model and no network
 - **Goal:** make the governing invariant — "core grading stays local and deterministic and never
   calls a model" — executable rather than aspirational.
-- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:5300`).
+- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:5332`).
 - **Design:** patch `urllib` and `subprocess` to raise, then grade a fixture covering every
   objective family (text, process, efficiency) and assert it completes. The sanctioned exceptions —
   `script` oracles and `judge` plumbing — are excluded from this path by design and keep their own
@@ -111,7 +111,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 
 ### Boundary
 The set stops here deliberately. Report-level correctness — whether the saturation, no-lift, flaky,
-and negative-delta flags (`build_benchmark_report` (`:6595`)) are computed right — sits a layer
+and negative-delta flags (`build_benchmark_report` (`:6627`)) are computed right — sits a layer
 above the raw measurement, where the golden-report tests the buckets already plan (1.2, 2.6) cover
 it. CF.1–CF.4 are the floor underneath that work: once they pass, a printed lift carries a checked
 measurement, and every feature in the buckets builds on a number that has been verified rather than
@@ -125,9 +125,9 @@ assumed.
 - **Goal:** ship graders authors reach for often, so they stop hand-rolling rubrics.
 - **Abstractions used or changed:** `tool_call` and `structured_output` are deterministic, so
   they become new types in `TEXT_ASSERTIONS` / `PROCESS_ASSERTIONS` and gain a branch in
-  `assertion_result`. `tool_call` reuses `command_events` (`:2804`) and the `command_order`
+  `assertion_result`. `tool_call` reuses `command_events` (`:2805`) and the `command_order`
   logic; `structured_output` extends `json_field_equals` with JSON-Schema validation.
-  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:4346`) renders
+  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:4378`) renders
   and still runs through `--judge-cmd`.
 - **Design:** a preset expands to either a deterministic objective assertion or a `judge`
   assertion with a canned rubric and threshold. No new execution path.
@@ -146,7 +146,7 @@ assumed.
 ### 1.3 Judge config slot and the "judge is not the model under test" guard
 - **Goal:** make an existing convention enforceable.
 - **Abstractions used or changed:** read an optional `judge` block in the manifest; add a check
-  in `audit_manifest_report` (`:8238`) comparing the declared judge model against `jetty.model`
+  in `audit_manifest_report` (`:8270`) comparing the declared judge model against `jetty.model`
   or the run metadata `model`.
 - **Design:** warn by default, error under `--strict-judge`.
 - **Testing:** unit tests for matching and differing model ids.
@@ -163,7 +163,7 @@ assumed.
 - **Status:** `docs/authoring-evals.md` shipped, alongside `architecture.md` and
   `abstractions.md`.
 - **Follow-on:** surface the guide's rules where they are checkable. Extend the messaging in
-  `prompt_assertion_leakage_findings` (`:359`) and `fixture_recommendations` (`:7980`) to point
+  `prompt_assertion_leakage_findings` (`:360`) and `fixture_recommendations` (`:8012`) to point
   at the relevant section.
 - **Testing:** assert the new hint strings appear for crafted manifests.
 
@@ -172,8 +172,8 @@ assumed.
   In `adewale/pythonbyexample` and `adewale/xampler` an example *is* an eval case: an input, an
   expected output, and a check that the output still matches. The harness has no equivalent of
   "this output equals this reference."
-- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:63`), implemented in
-  `assertion_result` (`:4085`). It reads `output.md` (or a named artifact), applies an optional
+- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:64`), implemented in
+  `assertion_result` (`:4117`). It reads `output.md` (or a named artifact), applies an optional
   normalization (trim, collapse whitespace, or a named normalizer), and compares to a reference
   file under the manifest dir. Evidence is a unified diff on mismatch.
 - **Design:** normalization is the whole game, so it is explicit and per-assertion, never
@@ -188,9 +188,9 @@ assumed.
   not name it.
 - **Abstractions used or changed:** an optional `oracle` tier on an assertion
   (`strong` / `demo` / `live`), defaulting by type (deterministic text/process are `strong`,
-  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:6595`)
+  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:6627`)
   reports, per case, the share of its pass rate carried by `strong` oracles;
-  `audit_manifest_report` (`:8238`) warns when a case passes only on weak ones. This extends
+  `audit_manifest_report` (`:8270`) warns when a case passes only on weak ones. This extends
   leakage lint (`:164`) from prompts to oracles.
 - **Strongest tier — the rendered-artifact oracle:** the top of the ladder is an oracle that
   builds or renders the artifact and inspects the result, not the source text.
@@ -205,8 +205,8 @@ assumed.
   splits "good poster" into seven `script` oracles, but each is forced all-or-nothing by the
   exit-code-only contract: a poster with six of seven drama carriers fails `drama_oracle` exactly
   like one with zero. That is the binary-saturation problem inside a single oracle.
-- **Abstractions used or changed:** extend `run_script_assertion` (`:3982`) and
-  `assertion_result` (`:4085`) to optionally parse a score from the oracle's stdout — a JSON line
+- **Abstractions used or changed:** extend `run_script_assertion` (`:4014`) and
+  `assertion_result` (`:4117`) to optionally parse a score from the oracle's stdout — a JSON line
   such as `{"score": 6, "max_score": 7}` (normalized to 0-1) — beside the existing
   `pass_exit_code`. The parsed score flows into the `score`/`severity` channel from 2.2, so a
   script oracle becomes a graded dimension while staying fully deterministic and model-free.
@@ -223,9 +223,9 @@ assumed.
   past it — either way, question it. This is the inverse of the saturation flag: saturation marks
   a case as too easy *now*; staleness marks a case that has never discriminated *over time*.
 - **Abstractions used or changed:** reads the cross-run history from 2.6. A `prune` report (or a
-  flag in `build_benchmark_report` (`:6595`)) marks a case a removal candidate when, across the
+  flag in `build_benchmark_report` (`:6627`)) marks a case a removal candidate when, across the
   last N runs, it never failed and never showed lift (`with_skill` == `without_skill` every time).
-  `audit_manifest_report` (`:8238`) lists the candidates; removal stays a human decision.
+  `audit_manifest_report` (`:8270`) lists the candidates; removal stays a human decision.
 - **Design:** the harness suggests, never deletes. A case may be kept deliberately as a
   regression guard even when stale; the report says so rather than acting.
 - **Depends on:** 2.6 (needs run history to judge "never failed over time").
@@ -239,12 +239,12 @@ assumed.
 ### 2.1 Multi-model fan-out (priority)
 - **Goal:** run the same cases across several models and compare lift per model. No surveyed
   framework does this; vitest-evals, eve, and viteval all push it onto the test runner.
-- **Abstractions used or changed:** `prepared_task_rows` (`:734`) gains a `model` dimension
+- **Abstractions used or changed:** `prepared_task_rows` (`:735`) gains a `model` dimension
   beside `variant` and `run_number`. Each row carries its target `model`, and `run_dir` gains a
   model segment (`<case>/<model>/<variant>/run-<n>`), kept backward-compatible when one model
   runs. Runners pass the row `model` through; per-run `model` already lands in `metadata.json`,
-  so grading needs no change. `build_benchmark_report` (`:6595`) groups `by_variant` within
-  `by_model`, and `build_paired_summary` (`:5918`) computes lift per (case, model).
+  so grading needs no change. `build_benchmark_report` (`:6627`) groups `by_variant` within
+  `by_model`, and `build_paired_summary` (`:5950`) computes lift per (case, model).
 - **Design:** model is a third axis, not a new variant. Variants stay orthogonal, giving a
   model-by-variant grid. CLI: `--models a,b,c` on `prepare`.
 - **Testing:** a fan-out test asserting row count equals cases × variants × runs × models with
@@ -261,7 +261,7 @@ assumed.
   no-regression floor. This spec ports those shapes into the harness rather than inventing new
   ones.
 - **Abstractions used or changed:**
-  - `assertion_result` (`:4085`) gains an optional `score` (0-1 or a normalized 1-5) and
+  - `assertion_result` (`:4117`) gains an optional `score` (0-1 or a normalized 1-5) and
     `severity` (`critical` / `gate` / `soft`), read from `critical`/`gate`/`soft`/`atLeast` on the
     assertion.
   - **`critical` (absorbing-barrier) tier — valley-dodging.** From the Jetty "valley-dodging"
@@ -276,13 +276,13 @@ assumed.
   - **Anchored `graded_dimensions`** as a `judge` assertion shape:
     `{name, scale: "1-5", rubric: "5 = …observable…; 1 = …observable…"}`. Anchors name what each
     score level looks like, so a judge scores against criteria, not a vibe. `judge_prompt`
-    (`:4346`) renders the dimensions; the result carries per-dimension scores in `evidence`.
+    (`:4378`) renders the dimensions; the result carries per-dimension scores in `evidence`.
   - **`dynamic_rubric`** as a second `judge` shape: `{instruction, minimum_criteria}`. The judge
     drafts 3-5 case-specific criteria before grading and must meet at least `minimum_criteria`.
-  - `grade_case_variant` (`:5300`) splits totals into critical, gated, and soft. A `critical`
+  - `grade_case_variant` (`:5332`) splits totals into critical, gated, and soft. A `critical`
     failure vetoes the case; a `gate` failure lowers the pass rate; a `soft` failure lowers
     neither and fills a `scored` bucket. A `--strict` flag promotes soft to gate.
-  - **Statistical lift** in `build_paired_summary` (`:5918`): alongside the raw delta, compute a
+  - **Statistical lift** in `build_paired_summary` (`:5950`): alongside the raw delta, compute a
     significance test over the per-case graded scores (paired bootstrap or sign-flip
     permutation, mirroring `score_delta.py`), so lift is tested, not eyeballed.
   - **Reference-anchor floor:** an optional `reference_score` / `reference_graded_score` on a
@@ -315,7 +315,7 @@ assumed.
 - **Goal:** deterministic re-runs that pay nothing for external dependencies, by recording tool
   inputs and outputs.
 - **Abstractions used or changed:** this lives in the runner, not core grading. Recording sits
-  beside `write_trace_artifacts` (`:3542`): a `tool-replay.json` keyed per tool, with
+  beside `write_trace_artifacts` (`:3574`): a `tool-replay.json` keyed per tool, with
   `sanitize` and `version`. Modes (`auto`, `record`, `off`, `strict`) come from an environment
   variable that `run_codex` and the Pi and subagent runners read.
 - **Design:** orthogonal to the disk re-grade the harness already does. Replay makes the agent
@@ -326,8 +326,8 @@ assumed.
 
 ### 2.4 OpenTelemetry GenAI normalization target
 - **Goal:** make the trace adapter boundary a standard rather than a bespoke schema.
-- **Abstractions used or changed:** `normalize_trace_record` (`:3313`) and
-  `normalize_trace_records` (`:3423`) keep their inputs but emit OTel GenAI semantic-key
+- **Abstractions used or changed:** `normalize_trace_record` (`:3327`) and
+  `normalize_trace_records` (`:3437`) keep their inputs but emit OTel GenAI semantic-key
   attributes; the `events.json` schema version bumps. Process and efficiency assertions read the
   new keys with backward-compatible fallbacks.
 - **Design:** additive schema. An old `events.json` still grades.
@@ -337,7 +337,7 @@ assumed.
 ### 2.5 Dataset abstraction
 - **Goal:** fan one case template over many rows instead of hand-authoring each case.
 - **Abstractions used or changed:** a new optional manifest construct (`datasets`, plus a case
-  `template` referencing a dataset id). `iter_cases` (`:256`) materializes template by row into
+  `template` referencing a dataset id). `iter_cases` (`:257`) materializes template by row into
   concrete cases before fan-out; `validate_manifest` validates rows and runs leakage lint per
   materialized case.
 - **Design:** materialization happens early, so prepare, grade, and report stay unchanged.
@@ -351,7 +351,7 @@ assumed.
 - **Goal:** watch lift, saturation, and token drift over time.
 - **Abstractions used or changed:** a consumer of `build_benchmark_report`. Add an append-only
   history store and a `trend` subcommand that diffs successive `benchmark.json` files, reusing
-  the `compare_results` (`:7027`) logic.
+  the `compare_results` (`:7059`) logic.
 - **Severity-weighted ranking (from the macro-evals notebook):** when surfacing recurring
   failures across runs, rank them by `prevalence × severity`, not raw count, so a rare but severe
   failure outranks a common trivial one. This is the floor-raising principle made quantitative;
@@ -377,8 +377,8 @@ assumed.
   it dispatches a subagent with a rubric whose "criteria [are] deliberately absent from
   generation rules."
 - **Abstractions used or changed:** mostly a discipline made first-class, not new machinery.
-  `prepared_task_rows` (`:734`) already omits `review_rubric` from generation payloads unless
-  `--include-answer-key`; extend `validate_manifest` (`:513`) to require that a `holdout`/
+  `prepared_task_rows` (`:735`) already omits `review_rubric` from generation payloads unless
+  `--include-answer-key`; extend `validate_manifest` (`:514`) to require that a `holdout`/
   `holdback` case's rubric stays out of the skill and public eval text, and pair it with the
   subagent judge from 2.7 and the graded scoring from 2.2. Track which rubrics were held out so
   the report can separate held-out scores from tune-visible ones.
@@ -390,7 +390,7 @@ assumed.
 ### 2.8 Interactive served report and richer artifacts
 - **Goal:** capture feedback in the browser and render image, PDF, and xlsx artifacts, beyond the
   static `render_viewer`.
-- **Abstractions used or changed:** extend `render_viewer` (`:7625`) with a `serve` mode and
+- **Abstractions used or changed:** extend `render_viewer` (`:7657`) with a `serve` mode and
   artifact encoders. Anthropic's `eval-viewer/generate_review.py` is the blueprint, including
   `feedback.json` persistence and a `--previous-workspace` diff.
 - **Testing:** unit-test the artifact embedding and categorization and the feedback round trip;
@@ -422,7 +422,7 @@ assumed.
 - **Goal:** evaluate conversational skills across a send/respond sequence.
 - **Abstractions changed (core contract):** a case gains an optional `turns` list. The
   run-output contract grows from one `output.md` to a turn-indexed transcript, so
-  `read_output_base` (`:2710`) and `discover_run_bases` learn the turn layout; runners drive the
+  `read_output_base` (`:2711`) and `discover_run_bases` learn the turn layout; runners drive the
   sequence; `grade_case_variant` grades per turn and aggregates.
 - **Design:** single-shot stays the default, so existing manifests are untouched.
 - **Testing:** a fixture multi-turn run asserting per-turn grading and aggregate, plus a
@@ -435,7 +435,7 @@ assumed.
   the model axis, plus a viewer panel.
 - **Slice-lift concentration (from the macro-evals notebook):** compute, per slice, where lift (or
   a failure) concentrates — `slice share ÷ overall share`, the macro-eval `lift` metric one level
-  up from per-case lift. `build_slice_summary` (`:6053`) already groups by domain/difficulty/
+  up from per-case lift. `build_slice_summary` (`:6085`) already groups by domain/difficulty/
   trigger/goal, so this is a ratio over groups it already forms, not new plumbing.
 - **Testing:** a report test over a two-model by two-variant fixture grid, plus a concentration
   test asserting a failure confined to one slice scores a high ratio there.
@@ -548,7 +548,7 @@ and upgrading to the new features should be something an agent can drive.
 
 ### Abstractions used or changed
 
-- `version` on the manifest (`validate_manifest:513`) becomes meaningful: `validate` accepts both
+- `version` on the manifest (`validate_manifest:514`) becomes meaningful: `validate` accepts both
   1 and 2, and warns (not errors) on a `version: 1` manifest once 2.2 has landed, pointing at
   `migrate`.
 - No grading abstraction changes for migration itself; it is a source-rewrite plus a guide.

--- a/docs/eval-framework-roadmap-spec.md
+++ b/docs/eval-framework-roadmap-spec.md
@@ -17,7 +17,7 @@ One invariant governs every item: core grading stays local and deterministic and
 model, and the harness never picks a model for the user. Anything that needs a model lives
 behind an opt-in command or the external `--judge-cmd`. Two abstractions absorb most of the
 work, so the spec returns to them often: the assertion result shape in `assertion_result`
-(`skill_benchmark.py:4022`) and the fan-out in `prepared_task_rows` (`:734`).
+(`skill_benchmark.py:4085`) and the fan-out in `prepared_task_rows` (`:734`).
 
 ## Testing baseline
 
@@ -40,7 +40,7 @@ tests are where that claim is checked rather than trusted.
 
 The buckets below extend what the harness can measure. This floor decides whether the number it
 already prints can be believed. The harness reports one thing: lift, `with_skill` minus
-`without_skill` on the same case (`build_paired_summary` (`:5855`)). That number is believable only
+`without_skill` on the same case (`build_paired_summary` (`:5918`)). That number is believable only
 when three preconditions hold, each intended today, none enforced, and each restating a claim from
 `evals-are-not-tests.md`:
 
@@ -60,7 +60,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
   hiding the quantity the tool exists to measure.
 - **Abstractions used or changed:** none in the engine. Adds
   `tests/fixtures/detectors/<detector_id>/should-fire.*` and `should-pass.*` that exercise
-  `assertion_result` (`:4022`) directly. That function has no direct unit test today, and its
+  `assertion_result` (`:4085`) directly. That function has no direct unit test today, and its
   `contains_any`, `excludes_any`, and `not_regex` branches go unexercised even though their types
   are declared in the assertion registries (`TEXT_ASSERTIONS:63`).
 - **Design:** one table-driven test loads every pair and asserts the detector fires on `should-fire`
@@ -101,7 +101,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 ### CF.4 — A guard that the core grade path calls no model and no network
 - **Goal:** make the governing invariant — "core grading stays local and deterministic and never
   calls a model" — executable rather than aspirational.
-- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:5237`).
+- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:5300`).
 - **Design:** patch `urllib` and `subprocess` to raise, then grade a fixture covering every
   objective family (text, process, efficiency) and assert it completes. The sanctioned exceptions —
   `script` oracles and `judge` plumbing — are excluded from this path by design and keep their own
@@ -111,7 +111,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 
 ### Boundary
 The set stops here deliberately. Report-level correctness — whether the saturation, no-lift, flaky,
-and negative-delta flags (`build_benchmark_report` (`:6532`)) are computed right — sits a layer
+and negative-delta flags (`build_benchmark_report` (`:6595`)) are computed right — sits a layer
 above the raw measurement, where the golden-report tests the buckets already plan (1.2, 2.6) cover
 it. CF.1–CF.4 are the floor underneath that work: once they pass, a printed lift carries a checked
 measurement, and every feature in the buckets builds on a number that has been verified rather than
@@ -125,9 +125,9 @@ assumed.
 - **Goal:** ship graders authors reach for often, so they stop hand-rolling rubrics.
 - **Abstractions used or changed:** `tool_call` and `structured_output` are deterministic, so
   they become new types in `TEXT_ASSERTIONS` / `PROCESS_ASSERTIONS` and gain a branch in
-  `assertion_result`. `tool_call` reuses `command_events` (`:2789`) and the `command_order`
+  `assertion_result`. `tool_call` reuses `command_events` (`:2804`) and the `command_order`
   logic; `structured_output` extends `json_field_equals` with JSON-Schema validation.
-  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:4283`) renders
+  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:4346`) renders
   and still runs through `--judge-cmd`.
 - **Design:** a preset expands to either a deterministic objective assertion or a `judge`
   assertion with a canned rubric and threshold. No new execution path.
@@ -146,7 +146,7 @@ assumed.
 ### 1.3 Judge config slot and the "judge is not the model under test" guard
 - **Goal:** make an existing convention enforceable.
 - **Abstractions used or changed:** read an optional `judge` block in the manifest; add a check
-  in `audit_manifest_report` (`:8175`) comparing the declared judge model against `jetty.model`
+  in `audit_manifest_report` (`:8238`) comparing the declared judge model against `jetty.model`
   or the run metadata `model`.
 - **Design:** warn by default, error under `--strict-judge`.
 - **Testing:** unit tests for matching and differing model ids.
@@ -163,7 +163,7 @@ assumed.
 - **Status:** `docs/authoring-evals.md` shipped, alongside `architecture.md` and
   `abstractions.md`.
 - **Follow-on:** surface the guide's rules where they are checkable. Extend the messaging in
-  `prompt_assertion_leakage_findings` (`:359`) and `fixture_recommendations` (`:7917`) to point
+  `prompt_assertion_leakage_findings` (`:359`) and `fixture_recommendations` (`:7980`) to point
   at the relevant section.
 - **Testing:** assert the new hint strings appear for crafted manifests.
 
@@ -173,7 +173,7 @@ assumed.
   expected output, and a check that the output still matches. The harness has no equivalent of
   "this output equals this reference."
 - **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:63`), implemented in
-  `assertion_result` (`:4022`). It reads `output.md` (or a named artifact), applies an optional
+  `assertion_result` (`:4085`). It reads `output.md` (or a named artifact), applies an optional
   normalization (trim, collapse whitespace, or a named normalizer), and compares to a reference
   file under the manifest dir. Evidence is a unified diff on mismatch.
 - **Design:** normalization is the whole game, so it is explicit and per-assertion, never
@@ -188,9 +188,9 @@ assumed.
   not name it.
 - **Abstractions used or changed:** an optional `oracle` tier on an assertion
   (`strong` / `demo` / `live`), defaulting by type (deterministic text/process are `strong`,
-  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:6532`)
+  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:6595`)
   reports, per case, the share of its pass rate carried by `strong` oracles;
-  `audit_manifest_report` (`:8175`) warns when a case passes only on weak ones. This extends
+  `audit_manifest_report` (`:8238`) warns when a case passes only on weak ones. This extends
   leakage lint (`:164`) from prompts to oracles.
 - **Strongest tier — the rendered-artifact oracle:** the top of the ladder is an oracle that
   builds or renders the artifact and inspects the result, not the source text.
@@ -205,8 +205,8 @@ assumed.
   splits "good poster" into seven `script` oracles, but each is forced all-or-nothing by the
   exit-code-only contract: a poster with six of seven drama carriers fails `drama_oracle` exactly
   like one with zero. That is the binary-saturation problem inside a single oracle.
-- **Abstractions used or changed:** extend `run_script_assertion` (`:3919`) and
-  `assertion_result` (`:4022`) to optionally parse a score from the oracle's stdout — a JSON line
+- **Abstractions used or changed:** extend `run_script_assertion` (`:3982`) and
+  `assertion_result` (`:4085`) to optionally parse a score from the oracle's stdout — a JSON line
   such as `{"score": 6, "max_score": 7}` (normalized to 0-1) — beside the existing
   `pass_exit_code`. The parsed score flows into the `score`/`severity` channel from 2.2, so a
   script oracle becomes a graded dimension while staying fully deterministic and model-free.
@@ -223,9 +223,9 @@ assumed.
   past it — either way, question it. This is the inverse of the saturation flag: saturation marks
   a case as too easy *now*; staleness marks a case that has never discriminated *over time*.
 - **Abstractions used or changed:** reads the cross-run history from 2.6. A `prune` report (or a
-  flag in `build_benchmark_report` (`:6532`)) marks a case a removal candidate when, across the
+  flag in `build_benchmark_report` (`:6595`)) marks a case a removal candidate when, across the
   last N runs, it never failed and never showed lift (`with_skill` == `without_skill` every time).
-  `audit_manifest_report` (`:8175`) lists the candidates; removal stays a human decision.
+  `audit_manifest_report` (`:8238`) lists the candidates; removal stays a human decision.
 - **Design:** the harness suggests, never deletes. A case may be kept deliberately as a
   regression guard even when stale; the report says so rather than acting.
 - **Depends on:** 2.6 (needs run history to judge "never failed over time").
@@ -243,8 +243,8 @@ assumed.
   beside `variant` and `run_number`. Each row carries its target `model`, and `run_dir` gains a
   model segment (`<case>/<model>/<variant>/run-<n>`), kept backward-compatible when one model
   runs. Runners pass the row `model` through; per-run `model` already lands in `metadata.json`,
-  so grading needs no change. `build_benchmark_report` (`:6532`) groups `by_variant` within
-  `by_model`, and `build_paired_summary` (`:5855`) computes lift per (case, model).
+  so grading needs no change. `build_benchmark_report` (`:6595`) groups `by_variant` within
+  `by_model`, and `build_paired_summary` (`:5918`) computes lift per (case, model).
 - **Design:** model is a third axis, not a new variant. Variants stay orthogonal, giving a
   model-by-variant grid. CLI: `--models a,b,c` on `prepare`.
 - **Testing:** a fan-out test asserting row count equals cases × variants × runs × models with
@@ -261,7 +261,7 @@ assumed.
   no-regression floor. This spec ports those shapes into the harness rather than inventing new
   ones.
 - **Abstractions used or changed:**
-  - `assertion_result` (`:4022`) gains an optional `score` (0-1 or a normalized 1-5) and
+  - `assertion_result` (`:4085`) gains an optional `score` (0-1 or a normalized 1-5) and
     `severity` (`critical` / `gate` / `soft`), read from `critical`/`gate`/`soft`/`atLeast` on the
     assertion.
   - **`critical` (absorbing-barrier) tier — valley-dodging.** From the Jetty "valley-dodging"
@@ -276,13 +276,13 @@ assumed.
   - **Anchored `graded_dimensions`** as a `judge` assertion shape:
     `{name, scale: "1-5", rubric: "5 = …observable…; 1 = …observable…"}`. Anchors name what each
     score level looks like, so a judge scores against criteria, not a vibe. `judge_prompt`
-    (`:4283`) renders the dimensions; the result carries per-dimension scores in `evidence`.
+    (`:4346`) renders the dimensions; the result carries per-dimension scores in `evidence`.
   - **`dynamic_rubric`** as a second `judge` shape: `{instruction, minimum_criteria}`. The judge
     drafts 3-5 case-specific criteria before grading and must meet at least `minimum_criteria`.
-  - `grade_case_variant` (`:5237`) splits totals into critical, gated, and soft. A `critical`
+  - `grade_case_variant` (`:5300`) splits totals into critical, gated, and soft. A `critical`
     failure vetoes the case; a `gate` failure lowers the pass rate; a `soft` failure lowers
     neither and fills a `scored` bucket. A `--strict` flag promotes soft to gate.
-  - **Statistical lift** in `build_paired_summary` (`:5855`): alongside the raw delta, compute a
+  - **Statistical lift** in `build_paired_summary` (`:5918`): alongside the raw delta, compute a
     significance test over the per-case graded scores (paired bootstrap or sign-flip
     permutation, mirroring `score_delta.py`), so lift is tested, not eyeballed.
   - **Reference-anchor floor:** an optional `reference_score` / `reference_graded_score` on a
@@ -315,7 +315,7 @@ assumed.
 - **Goal:** deterministic re-runs that pay nothing for external dependencies, by recording tool
   inputs and outputs.
 - **Abstractions used or changed:** this lives in the runner, not core grading. Recording sits
-  beside `write_trace_artifacts` (`:3479`): a `tool-replay.json` keyed per tool, with
+  beside `write_trace_artifacts` (`:3542`): a `tool-replay.json` keyed per tool, with
   `sanitize` and `version`. Modes (`auto`, `record`, `off`, `strict`) come from an environment
   variable that `run_codex` and the Pi and subagent runners read.
 - **Design:** orthogonal to the disk re-grade the harness already does. Replay makes the agent
@@ -326,8 +326,8 @@ assumed.
 
 ### 2.4 OpenTelemetry GenAI normalization target
 - **Goal:** make the trace adapter boundary a standard rather than a bespoke schema.
-- **Abstractions used or changed:** `normalize_trace_record` (`:3280`) and
-  `normalize_trace_records` (`:3390`) keep their inputs but emit OTel GenAI semantic-key
+- **Abstractions used or changed:** `normalize_trace_record` (`:3313`) and
+  `normalize_trace_records` (`:3423`) keep their inputs but emit OTel GenAI semantic-key
   attributes; the `events.json` schema version bumps. Process and efficiency assertions read the
   new keys with backward-compatible fallbacks.
 - **Design:** additive schema. An old `events.json` still grades.
@@ -351,7 +351,7 @@ assumed.
 - **Goal:** watch lift, saturation, and token drift over time.
 - **Abstractions used or changed:** a consumer of `build_benchmark_report`. Add an append-only
   history store and a `trend` subcommand that diffs successive `benchmark.json` files, reusing
-  the `compare_results` (`:6964`) logic.
+  the `compare_results` (`:7027`) logic.
 - **Severity-weighted ranking (from the macro-evals notebook):** when surfacing recurring
   failures across runs, rank them by `prevalence × severity`, not raw count, so a rare but severe
   failure outranks a common trivial one. This is the floor-raising principle made quantitative;
@@ -390,7 +390,7 @@ assumed.
 ### 2.8 Interactive served report and richer artifacts
 - **Goal:** capture feedback in the browser and render image, PDF, and xlsx artifacts, beyond the
   static `render_viewer`.
-- **Abstractions used or changed:** extend `render_viewer` (`:7562`) with a `serve` mode and
+- **Abstractions used or changed:** extend `render_viewer` (`:7625`) with a `serve` mode and
   artifact encoders. Anthropic's `eval-viewer/generate_review.py` is the blueprint, including
   `feedback.json` persistence and a `--previous-workspace` diff.
 - **Testing:** unit-test the artifact embedding and categorization and the feedback round trip;
@@ -422,7 +422,7 @@ assumed.
 - **Goal:** evaluate conversational skills across a send/respond sequence.
 - **Abstractions changed (core contract):** a case gains an optional `turns` list. The
   run-output contract grows from one `output.md` to a turn-indexed transcript, so
-  `read_output_base` (`:2695`) and `discover_run_bases` learn the turn layout; runners drive the
+  `read_output_base` (`:2710`) and `discover_run_bases` learn the turn layout; runners drive the
   sequence; `grade_case_variant` grades per turn and aggregates.
 - **Design:** single-shot stays the default, so existing manifests are untouched.
 - **Testing:** a fixture multi-turn run asserting per-turn grading and aggregate, plus a
@@ -435,7 +435,7 @@ assumed.
   the model axis, plus a viewer panel.
 - **Slice-lift concentration (from the macro-evals notebook):** compute, per slice, where lift (or
   a failure) concentrates — `slice share ÷ overall share`, the macro-eval `lift` metric one level
-  up from per-case lift. `build_slice_summary` (`:5990`) already groups by domain/difficulty/
+  up from per-case lift. `build_slice_summary` (`:6053`) already groups by domain/difficulty/
   trigger/goal, so this is a ratio over groups it already forms, not new plumbing.
 - **Testing:** a report test over a two-model by two-variant fixture grid, plus a concentration
   test asserting a failure confined to one slice scores a high ratio there.

--- a/docs/skill-ablation-spec.md
+++ b/docs/skill-ablation-spec.md
@@ -37,7 +37,7 @@ Internal — the contracts this builds on:
 
 - `validate_manifest` ablation block (`skill_benchmark.py:513`) — today checks only non-empty `id` + `removed_component`.
 - `variant_instruction` (`skill_benchmark.py:646`) / `task_variants` (`:689`) / `prepared_task_rows` (`:734`) — `skill_paths` is currently the manifest's, identical for every variant.
-- `safe_task_json` (`skill_benchmark.py:1903`) / `build_jetty_payload` (`:1945`) — Jetty export; ablation reads `task["skill_paths"]`, uploads flat files via `JettyClient.upload` with a basename-only `remote_path_hint`.
+- `safe_task_json` (`skill_benchmark.py:1918`) / `build_jetty_payload` (`:1960`) — Jetty export; ablation reads `task["skill_paths"]`, uploads flat files via `JettyClient.upload` with a basename-only `remote_path_hint`.
 - `copy_skill_to_config` (`skill_benchmark.py:47`) and `copy_skill_source` (`run_pi_smoke.py:103`) — both collapse a file-valued path to `<dir>/SKILL.md`, `rmtree` the destination, and whitelist only `references`/`scripts`/`assets`.
 - `run_pi_trigger_eval.py` — the autonomous-trigger runner; copies from the manifest and takes no variant input.
 

--- a/docs/skill-ablation-spec.md
+++ b/docs/skill-ablation-spec.md
@@ -35,9 +35,9 @@ list evolves, so handling is data-driven, never a hardcoded list):
 
 Internal — the contracts this builds on:
 
-- `validate_manifest` ablation block (`skill_benchmark.py:513`) — today checks only non-empty `id` + `removed_component`.
-- `variant_instruction` (`skill_benchmark.py:646`) / `task_variants` (`:689`) / `prepared_task_rows` (`:734`) — `skill_paths` is currently the manifest's, identical for every variant.
-- `safe_task_json` (`skill_benchmark.py:1918`) / `build_jetty_payload` (`:1960`) — Jetty export; ablation reads `task["skill_paths"]`, uploads flat files via `JettyClient.upload` with a basename-only `remote_path_hint`.
+- `validate_manifest` ablation block (`skill_benchmark.py:514`) — today checks only non-empty `id` + `removed_component`.
+- `variant_instruction` (`skill_benchmark.py:647`) / `task_variants` (`:690`) / `prepared_task_rows` (`:735`) — `skill_paths` is currently the manifest's, identical for every variant.
+- `safe_task_json` (`skill_benchmark.py:1919`) / `build_jetty_payload` (`:1961`) — Jetty export; ablation reads `task["skill_paths"]`, uploads flat files via `JettyClient.upload` with a basename-only `remote_path_hint`.
 - `copy_skill_to_config` (`skill_benchmark.py:47`) and `copy_skill_source` (`run_pi_smoke.py:103`) — both collapse a file-valued path to `<dir>/SKILL.md`, `rmtree` the destination, and whitelist only `references`/`scripts`/`assets`.
 - `run_pi_trigger_eval.py` — the autonomous-trigger runner; copies from the manifest and takes no variant input.
 
@@ -358,7 +358,7 @@ Opt in with `"invalid_skill": true` on the ablation: the run is tagged
 
 ## Validation additions
 
-`validate_manifest` (`skill_benchmark.py:513`), per ablation:
+`validate_manifest` (`skill_benchmark.py:514`), per ablation:
 
 - `id` unique and slug-formatted; keep `removed_component`.
 - If a removal is declared: exactly one of `mechanism`+`target` or `components`;

--- a/docs/tuning-skill-activation.md
+++ b/docs/tuning-skill-activation.md
@@ -76,7 +76,6 @@ and uses the same mounted-path evidence detector as Pi/stub:
 ```bash
 skill-trigger-matrix examples/demo-skill/evals/shared-benchmark.json \
   --agent codex \
-  --codex-cmd 'codex exec --json --sandbox read-only --skip-git-repo-check --ephemeral' \
   --runs-per-query 3 \
   --out /tmp/trigger-codex.json
 ```
@@ -136,9 +135,11 @@ evidence in its event stream. Claude Code, Codex, Pi, and the offline stub ship 
 adapters. `docs/agent-parity.md` is the capability table for which surfaces each
 agent currently supports.
 
-Adding another agent is one subclass plus one registry row:
+Adding another agent is one subclass plus one capability registry row:
 
 ```python
+from agent_capabilities import AGENT_CAPABILITIES, AgentCapabilities
+
 class MyAgentAdapter(AgentAdapter):
     name = "my-agent"
 
@@ -150,13 +151,26 @@ class MyAgentAdapter(AgentAdapter):
         return self._run_argv(argv, cwd=workspace, env=os.environ.copy(), timeout=timeout)
 
 ADAPTERS["my-agent"] = MyAgentAdapter
+AGENT_CAPABILITIES["my-agent"] = AgentCapabilities(
+    answer_runner=False,
+    autonomous_trigger=True,
+    trigger_ablation=True,
+    trace_artifacts=True,
+    token_usage=True,
+    dollar_cost="stream",
+    judge_backend=False,
+    tool_replay=False,
+    live_smoke_env=None,
+)
 ```
 
 The default `detect()` already scans any JSON event stream for reads of the mounted
 skill paths; override it only when an agent reports skill loads some other way, as
 Claude Code does. Once registered, `--agent my-agent` joins the same matrix, and the
 report's cells stay comparable because every adapter mounts the identical canonical
-or materialized skill tree and the same detector rules decide "triggered."
+or materialized skill tree and the same detector rules decide "triggered." The
+matrix validates the capability row before starting runs so a new adapter cannot
+finish live calls and then fail during report assembly.
 
 For Pi specifically, `skill-pi-trigger-eval` remains a compatibility entry point for
 older scripts. The matrix now has the shared surfaces that matter for parity: per-run

--- a/docs/tuning-skill-activation.md
+++ b/docs/tuning-skill-activation.md
@@ -69,6 +69,22 @@ it):
 RUN_TRIGGER_SMOKE=1 python3 -m unittest tests.test_trigger_matrix -v
 ```
 
+Codex is now a shipped matrix adapter too. It mounts the same canonical skill tree
+under the Codex project skill directory, runs the raw query through `codex exec --json`,
+and uses the same mounted-path evidence detector as Pi/stub:
+
+```bash
+skill-trigger-matrix examples/demo-skill/evals/shared-benchmark.json \
+  --agent codex \
+  --codex-cmd 'codex exec --json --sandbox read-only --skip-git-repo-check --ephemeral' \
+  --runs-per-query 3 \
+  --out /tmp/trigger-codex.json
+```
+
+Use `--trace-runs DIR` to write `trace.jsonl`/`events.json`/`metrics.json` per run, and
+`--ablation ID` to measure a materialized discovery/trigger-population ablation through
+any selected adapter, including Codex.
+
 ## Reading the matrix
 
 - **Positives fail on some model** → the description omits the invocation language
@@ -116,33 +132,36 @@ Each rule below exists because its violation produced a wrong number at least on
 
 `run_trigger_matrix.py` treats an agent as three operations: mount the skill tree
 where that agent discovers skills, run it headless on the raw query, detect load
-evidence in its event stream. Claude Code, Pi, and the offline stub ship as
-adapters; adding Codex (or anything else) is one subclass:
+evidence in its event stream. Claude Code, Codex, Pi, and the offline stub ship as
+adapters. `docs/agent-parity.md` is the capability table for which surfaces each
+agent currently supports.
+
+Adding another agent is one subclass plus one registry row:
 
 ```python
-class CodexAdapter(AgentAdapter):
-    name = "codex"
+class MyAgentAdapter(AgentAdapter):
+    name = "my-agent"
 
     def mount(self, tree_dir, workspace):
-        # wherever Codex discovers skills on its own
-        return self._mount_tree(tree_dir, workspace / ".codex" / "skills")
+        return self._mount_tree(tree_dir, workspace / ".my-agent" / "skills")
 
     def invoke(self, query, model, workspace, timeout):
-        argv = ["codex", "exec", "--json", query] + (["--model", model] if model else [])
+        argv = ["my-agent", "run", "--json", query] + (["--model", model] if model else [])
         return self._run_argv(argv, cwd=workspace, env=os.environ.copy(), timeout=timeout)
 
-ADAPTERS["codex"] = CodexAdapter
+ADAPTERS["my-agent"] = MyAgentAdapter
 ```
 
 The default `detect()` already scans any JSON event stream for reads of the mounted
 skill paths; override it only when an agent reports skill loads some other way, as
-Claude Code does. Once registered, `--agent codex` joins the same matrix, and the
+Claude Code does. Once registered, `--agent my-agent` joins the same matrix, and the
 report's cells stay comparable because every adapter mounts the identical canonical
-skill tree and the same detector rules decide "triggered."
+or materialized skill tree and the same detector rules decide "triggered."
 
-For Pi specifically, `run_pi_trigger_eval.py` remains the deeper tool — it adds
-discovery-population ablation arms, per-query trace artifacts, and cost telemetry
-on top of the same mount-and-detect approach.
+For Pi specifically, `skill-pi-trigger-eval` remains a compatibility entry point for
+older scripts. The matrix now has the shared surfaces that matter for parity: per-run
+trace artifacts, materialized trigger ablations, cost/usage parsing where the stream
+reports it, and the same evidence-class stamp.
 
 The demo's Haiku cell is the method in miniature: one run said the description was
 fine, three runs put its Haiku trigger rate at 1-in-3, and only the matrix made the

--- a/docs/tuning-skill-activation.md
+++ b/docs/tuning-skill-activation.md
@@ -67,6 +67,9 @@ it):
 
 ```bash
 RUN_TRIGGER_SMOKE=1 python3 -m unittest tests.test_trigger_matrix -v
+RUN_CODEX_TRIGGER_SMOKE=1 python3 -m unittest tests.test_trigger_matrix.CodexMatrixSmokeTests -v
+RUN_PI_TRIGGER_SMOKE=1 python3 -m unittest tests.test_trigger_matrix.PiMatrixSmokeTests -v
+RUN_AGENT_INVOKE_SMOKE=1 python3 -m unittest tests.test_trigger_matrix.AgentInvokeSmokeTests -v
 ```
 
 Codex is now a shipped matrix adapter too. It mounts the same canonical skill tree
@@ -157,7 +160,7 @@ AGENT_CAPABILITIES["my-agent"] = AgentCapabilities(
     trigger_ablation=True,
     trace_artifacts=True,
     token_usage=True,
-    dollar_cost="stream",
+    dollar_cost="trace_normalized",
     judge_backend=False,
     tool_replay=False,
     live_smoke_env=None,

--- a/examples/demo-skill/README.md
+++ b/examples/demo-skill/README.md
@@ -5,13 +5,15 @@ API key**: a deterministic stub stands in for the model, so the whole
 prepare → run → report → ablation-confirmation loop is reproducible (and runs in
 CI via `tests/test_example_demo.py`).
 
-The skill (`skills/demo/`) has exactly two load-bearing pieces, each targeted by one
-**materialized** ablation in `evals/shared-benchmark.json`:
+The skill (`skills/demo/`) has two answer-path load-bearing pieces, each targeted by one
+**materialized** ablation in `evals/shared-benchmark.json`. It also has a
+discovery-population ablation for autonomous trigger examples.
 
 | ablation | mechanism | removes | confirms a regression on |
 |---|---|---|---|
 | `no-severity` | `section` | the `## Severity rules` section of SKILL.md | the `severity-label` assertion |
 | `no-checklist` | `reference` (`remove: content`) | the body of `references/checklist.md` | the `cite-checklist` assertion |
+| `weaker-description` | `frontmatter_field` | the extra `when_to_use` trigger hints | measured by `skill-trigger-matrix --ablation weaker-description` |
 
 `stub_runner.py` answers by reading the skill that the harness actually mounted into
 the isolated workspace, so removing a piece really changes the output — the
@@ -69,6 +71,8 @@ python3 ../../run_trigger_matrix.py evals/shared-benchmark.json \
 
 The loop for acting on the resulting per-model trigger rates is
 [`docs/tuning-skill-activation.md`](../../docs/tuning-skill-activation.md).
+To exercise the bundled discovery ablation, add
+`--ablation weaker-description --trace-runs /tmp/demo-trigger-traces`.
 
 ## What it teaches
 

--- a/examples/demo-skill/evals/shared-benchmark.json
+++ b/examples/demo-skill/evals/shared-benchmark.json
@@ -3,7 +3,7 @@
   "skill_name": "demo-reviewer",
   "skill_paths": ["skills/demo/SKILL.md"],
   "variants": ["with_skill", "without_skill"],
-  "notes": "Self-contained harness demo. Runs fully offline with examples/demo-skill/stub_runner.py as the 'model'. The two ablations each remove one load-bearing piece of the skill and confirm a regression on a distinct assertion.",
+  "notes": "Self-contained harness demo. Runs fully offline with examples/demo-skill/stub_runner.py as the 'model'. The two answer-population ablations each remove one load-bearing piece of the skill and confirm a regression on a distinct assertion; the discovery-population ablation is for trigger-matrix examples.",
   "cases": [
     {
       "id": "c-review",
@@ -67,6 +67,16 @@
       "target": {"path": "references/checklist.md", "remove": "content"},
       "expected_regressions": [
         {"summary": "with the checklist content gone the reviewer stops citing file/line", "cases": ["c-review"], "assertions": ["cite-checklist"]}
+      ]
+    },
+    {
+      "id": "weaker-description",
+      "removed_component": "extra discovery trigger phrases",
+      "mechanism": "frontmatter_field",
+      "class": "discovery",
+      "target": {"field": "when_to_use"},
+      "expected_regressions": [
+        {"summary": "without the extra discovery hints the skill may load less often for trigger queries", "cases": ["trig-pos-review-change"]}
       ]
     }
   ]

--- a/examples/demo-skill/skills/demo/SKILL.md
+++ b/examples/demo-skill/skills/demo/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: demo-reviewer
 description: Demo skill for the Skill Eval Harness example. Use it to review a proposed change and label the severity of each finding.
+when_to_use: Use this skill when asked to review a proposed code change, inspect a diff, or label how serious a finding is.
 ---
 
 # Demo Reviewer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ skill-pi-trigger-eval = "run_pi_trigger_eval:main"
 skill-trigger-matrix = "run_trigger_matrix:main"
 
 [tool.setuptools]
-py-modules = ["skill_benchmark", "run_pi_trigger_eval", "run_trigger_matrix", "ablation_model"]
+py-modules = ["skill_benchmark", "run_pi_trigger_eval", "run_trigger_matrix", "ablation_model", "agent_capabilities"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/run_pi_trigger_eval.py
+++ b/run_pi_trigger_eval.py
@@ -24,23 +24,22 @@ from typing import Any
 from skill_benchmark import (
     VALID_SPLITS,
     is_trigger_case,
-    ablation_by_id,
-    ablation_components,
     build_canonical_skill_tree,
     canonical_skill_tree_hash,
-    derived_population,
     detect_trigger,
     event_texts_for_tool_input,  # noqa: F401  (re-exported for adapters/tests)
     expected_trigger_polarity,
     iter_cases,
     load_manifest_source,
-    materialize_ablation,
+    materialize_trigger_ablation,
     mount_skill_tree,
     repo_root_for_manifest,
     run_argv_with_timeout,
+    safe_trace_label,
     stream_usage_and_cost,
     write_json,
     write_trace_artifacts,
+    AblationError,
 )
 from ablation_model import TRIGGER_MEASUREMENT_EVIDENCE_CLASS, EvidenceClass, Provenance
 
@@ -74,14 +73,10 @@ def copy_skill_to_config(manifest_path: Path, manifest: dict[str, Any], config_d
     if ablation_id:
         # Mount a real, altered skill (e.g. a weakened description) so the trigger
         # test measures whether the ablated skill still autonomously loads.
-        ablation = ablation_by_id(manifest, ablation_id)
-        if ablation is None:
-            raise RuntimeError(f"unknown ablation: {ablation_id}")
-        if not ablation_components(ablation):
-            raise RuntimeError(f"ablation {ablation_id} is instruction-simulated; a trigger ablation must declare a removal")
-        if derived_population(ablation_components(ablation)) != "trigger":
-            raise RuntimeError(f"ablation {ablation_id} is an answer-population ablation; the trigger eval only measures discovery (trigger-population) ablations. Run it through the benchmark / Pi-smoke path.")
-        res = materialize_ablation(repo_root, manifest, ablation, config_dir / "_materialized")
+        try:
+            res = materialize_trigger_ablation(repo_root, manifest, ablation_id, config_dir / "_materialized")
+        except AblationError as exc:
+            raise RuntimeError(str(exc)) from exc
         return mount_skill_tree(Path(res["dir"]), skills_dir), res
     # Baseline (no ablation): build the SAME canonical tree the ablation arm starts
     # from, so the two arms are file-for-file identical apart from the declared
@@ -245,7 +240,7 @@ def main() -> int:
             for run_number in range(1, args.runs_per_query + 1):
                 trace_dir = None
                 if args.trace_runs:
-                    label = re.sub(r"[^a-zA-Z0-9_.-]+", "-", str(row.get("query", f"query-{i}")))[:80].strip("-") or f"query-{i}"
+                    label = safe_trace_label(str(row.get("query", f"query-{i}")), f"query-{i}")
                     trace_dir = Path(args.trace_runs) / f"query-{i:03d}-{label}" / f"run-{run_number}"
                 futures.append(ex.submit(run_query, manifest_path, str(row["query"]), bool(row["should_trigger"]), args.timeout, args.model, trace_dir, args.ablation))
         for fut in as_completed(futures):

--- a/run_trigger_matrix.py
+++ b/run_trigger_matrix.py
@@ -10,7 +10,7 @@ runs every (agent, model, query) cell `--runs-per-query` times, and reports a
 per-cell trigger rate. You tune the skill description against that matrix; see
 docs/tuning-skill-activation.md for the loop.
 
-Three adapters ship:
+Four adapters ship:
 
 - `claude`  — Claude Code CLI subagents (`claude -p`), defaulting to the
               haiku / sonnet / opus aliases. The skill mounts as a project
@@ -19,20 +19,24 @@ Three adapters ship:
               SKILL.md. A fresh CLAUDE_CONFIG_DIR per run keeps your personal
               skills out; Claude Code's built-in skills stay, because your
               users run against them too.
+- `codex`   — Codex CLI (`codex exec --json` by default), mounted in the
+              Codex project-skill directory and detected through the shared
+              path-evidence detector. Override the command with `--codex-cmd`
+              when a local wrapper or a newer CLI surface is needed.
 - `pi`      — the Pi coding agent, same mount/detect approach as
-              run_pi_trigger_eval.py (which remains the full-featured Pi
-              runner: ablation arms, trace artifacts, cost telemetry).
+              run_pi_trigger_eval.py (which remains a compatibility wrapper
+              for the Pi-only entry point).
 - `stub`    — offline and deterministic: "triggers" iff the query shares
               enough words with the mounted description, and emits the same
               stream shape the detector reads. It exists so the whole matrix
               pipeline runs in CI with no model, and so a weakened description
               measurably under-triggers even offline.
 
-To add Codex (or any agent): subclass AgentAdapter, implement mount() (copy
-the canonical tree where that agent discovers skills) and invoke() (run the
-agent headless on the raw query, return its JSON event stream), then register
-it in ADAPTERS. detect() only needs overriding when load evidence is not a
-file path in the stream.
+To add another agent: subclass AgentAdapter, implement mount() (copy the
+canonical tree where that agent discovers skills) and invoke() (run the agent
+headless on the raw query, return its JSON event stream), then register it in
+ADAPTERS and agent_capabilities.AGENT_CAPABILITIES. detect() only needs
+overriding when load evidence is not a file path in the stream.
 
 Every number this emits is a RAW autonomous-trigger measurement (the same
 evidence class as run_pi_trigger_eval.py) — a rate to steer description edits,
@@ -44,6 +48,7 @@ import argparse
 import json
 import os
 import re
+import shlex
 import shutil
 import tempfile
 import time
@@ -51,17 +56,24 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
+from agent_capabilities import AGENT_CAPABILITIES
 from skill_benchmark import (
     VALID_SPLITS,
+    ablation_by_id,
+    ablation_components,
     build_canonical_skill_tree,
     canonical_skill_tree_hash,
     detect_trigger,
+    derived_population,
     frontmatter_value,
     iter_json_objects,
+    materialize_ablation,
     mount_skill_tree,
     repo_root_for_manifest,
     run_argv_with_timeout,
+    stream_usage_and_cost,
     write_json,
+    write_trace_artifacts,
 )
 from run_pi_trigger_eval import cases_from_manifest, eval_rows_from_args, load_manifest, pi_argv, skill_name_from_manifest, seed_config_dir
 from ablation_model import TRIGGER_MEASUREMENT_EVIDENCE_CLASS
@@ -86,12 +98,17 @@ def mounted_skill_names(copied: list[Path]) -> list[str]:
     return names
 
 
+def safe_trace_label(text: str, fallback: str) -> str:
+    label = re.sub(r"[^a-zA-Z0-9_.-]+", "-", text)[:80].strip("-")
+    return label or fallback
+
+
 class AgentAdapter:
     """One agent harness in the matrix. Subclass and register in ADAPTERS.
 
-    mount(tree_dir, workspace)  -> copy the canonical skill tree to wherever
-        THIS agent discovers skills autonomously; return the copied SKILL.md
-        (or root dir) paths — they become the detection needles.
+    mount(tree_dir, workspace)  -> copy the canonical or materialized skill tree
+        to wherever THIS agent discovers skills autonomously; return the copied
+        SKILL.md (or root dir) paths — they become the detection needles.
     invoke(query, model, workspace, timeout) -> run the agent headless on the
         RAW user query (no skill mention, no forced load) and return
         {stdout, stderr, returncode, timed_out, elapsed_ms,
@@ -186,11 +203,37 @@ class ClaudeAdapter(AgentAdapter):
         return super().detect(stdout, skill_names, copied)
 
 
+class CodexAdapter(AgentAdapter):
+    """Codex CLI trigger adapter. It deliberately runs the raw query through
+    `codex exec --json` instead of the answer-run prompt builder: trigger
+    measurement is about autonomous discovery, not task scaffolding."""
+
+    name = "codex"
+    default_models: list[str | None] = [None]
+
+    def __init__(self, codex_cmd: str = "codex exec --json --sandbox read-only --skip-git-repo-check --ephemeral") -> None:
+        self.codex_cmd = codex_cmd
+
+    def mount(self, tree_dir: Path, workspace: Path) -> list[Path]:
+        # The documented Codex adapter seam uses project-local skills. Keeping
+        # this in one method makes CLI churn a single adapter change, not a
+        # trigger-runner fork.
+        return self._mount_tree(tree_dir, workspace / ".codex" / "skills")
+
+    def invoke(self, query: str, model: str | None, workspace: Path, timeout: int) -> dict[str, Any]:
+        argv = shlex.split(self.codex_cmd)
+        if model:
+            argv += ["--model", model]
+        argv.append(query)
+        env = os.environ.copy()
+        env["CODEX_HOME"] = str(workspace / ".codex")
+        return self._run_argv(argv, cwd=workspace, env=env, timeout=timeout)
+
+
 class PiAdapter(AgentAdapter):
     """The Pi coding agent, mounted and detected exactly like
-    run_pi_trigger_eval.py (which stays the full-featured Pi runner —
-    ablation arms, traces, cost telemetry; this adapter exists so Pi can sit
-    in the same matrix as the Claude models)."""
+    run_pi_trigger_eval.py (which stays as the compatibility entry point for
+    people already using `skill-pi-trigger-eval`)."""
 
     name = "pi"
 
@@ -236,32 +279,104 @@ class StubAdapter(AgentAdapter):
                 "elapsed_ms": 0, "observation_complete": True}
 
 
-ADAPTERS: dict[str, type[AgentAdapter]] = {"claude": ClaudeAdapter, "pi": PiAdapter, "stub": StubAdapter}
+ADAPTERS: dict[str, type[AgentAdapter]] = {"claude": ClaudeAdapter, "codex": CodexAdapter, "pi": PiAdapter, "stub": StubAdapter}
+
+
+def adapter_instance(name: str, *, claude_bin: str = "claude", codex_cmd: str | None = None, max_turns: int = 6) -> AgentAdapter:
+    if name == "claude":
+        return ClaudeAdapter(claude_bin=claude_bin, max_turns=max_turns)
+    if name == "codex":
+        return CodexAdapter(codex_cmd=codex_cmd or "codex exec --json --sandbox read-only --skip-git-repo-check --ephemeral")
+    return ADAPTERS[name]()
+
+
+def matrix_capabilities() -> dict[str, Any]:
+    """Capability rows for exactly the agents accepted by this command."""
+    return {name: AGENT_CAPABILITIES[name] for name in sorted(ADAPTERS)}
+
+
+def trigger_tree_for_manifest(repo_root: Path, manifest: dict[str, Any], work_dir: Path, ablation: str | None) -> tuple[Path, str, dict[str, Any] | None]:
+    """Build the skill tree every cell will mount. Without --ablation it is the
+    canonical tree; with --ablation it is a real materialized trigger-population
+    ablation, so Claude/Pi/Codex all measure the same altered bytes."""
+    if not ablation:
+        tree_dir = Path(build_canonical_skill_tree(repo_root, manifest, work_dir / "canonical"))
+        return tree_dir, canonical_skill_tree_hash(repo_root, manifest), {"mode": "baseline"}
+
+    ablation_doc = ablation_by_id(manifest, ablation)
+    if ablation_doc is None:
+        raise SystemExit(f"unknown ablation: {ablation}")
+    components = ablation_components(ablation_doc)
+    if not components:
+        raise SystemExit(f"ablation {ablation} is instruction-simulated; trigger matrix ablations must declare a materialized removal")
+    if derived_population(components) != "trigger":
+        raise SystemExit(f"ablation {ablation} is an answer-population ablation; trigger matrix ablations must target discovery/trigger behavior")
+    provenance = materialize_ablation(repo_root, manifest, ablation_doc, work_dir / "materialized" / str(ablation))
+    tree_hash = str(((provenance.get("identity") or {}).get("canonical")) or canonical_skill_tree_hash(repo_root, manifest))
+    return Path(provenance["dir"]), tree_hash, provenance
 
 
 def run_cell_query(adapter: AgentAdapter, tree_dir: Path, query: str, should_trigger: bool,
-                   model: str | None, timeout: int) -> dict[str, Any]:
+                   model: str | None, timeout: int, trace_dir: Path | None = None,
+                   metadata: dict[str, Any] | None = None) -> dict[str, Any]:
     """One run of one query in one (agent, model) cell, in a fresh workspace."""
     with tempfile.TemporaryDirectory(prefix=f"trigger-{adapter.name}-") as td:
         workspace = Path(td)
         copied = adapter.mount(tree_dir, workspace)
         names = mounted_skill_names(copied)
         result = adapter.invoke(query, model, workspace, timeout)
-        triggered, evidence = adapter.detect(result["stdout"], names, copied)
-    return {
+        stdout = str(result.get("stdout") or "")
+        triggered, evidence = adapter.detect(stdout, names, copied)
+    usage, cost = stream_usage_and_cost(stdout)
+    observation_complete = bool(result.get("observation_complete"))
+    row = {
         "agent": adapter.name,
         "model": model,
         "query": query,
         "should_trigger": should_trigger,
         "triggered": triggered,
-        "pass": result["observation_complete"] and triggered == should_trigger,
-        "observation_complete": result["observation_complete"],
-        "returncode": result["returncode"],
-        "timed_out": result["timed_out"],
-        "elapsed_ms": result["elapsed_ms"],
+        "pass": observation_complete and triggered == should_trigger,
+        "observation_complete": observation_complete,
+        "returncode": result.get("returncode"),
+        "timed_out": bool(result.get("timed_out")),
+        "elapsed_ms": result.get("elapsed_ms"),
         "evidence": evidence,
-        "stderr": (result["stderr"] or "")[-1000:],
+        "usage_normalized": usage,
+        "cost_normalized": cost,
+        "stderr": (str(result.get("stderr") or ""))[-1000:],
     }
+    if metadata:
+        row.update({k: v for k, v in metadata.items() if k not in row})
+    if trace_dir is not None:
+        row["trace_dir"] = str(trace_dir)
+        trace_metadata = {
+            "provider": adapter.name,
+            "model": model,
+            "returncode": row["returncode"],
+            "timed_out": row["timed_out"],
+            "observation_complete": observation_complete,
+            "triggered": triggered,
+            "evidence": evidence,
+            "usage_normalized": usage,
+            "cost_normalized": cost,
+            **(metadata or {}),
+        }
+        write_trace_artifacts(
+            trace_dir,
+            stdout,
+            source=adapter.name,
+            metadata=trace_metadata,
+            extra_metrics={
+                "elapsed_ms": row["elapsed_ms"],
+                "returncode": row["returncode"],
+                "timed_out": row["timed_out"],
+                "skill_invoked": triggered,
+                "skill_invocation_evidence": evidence,
+            },
+            environment={"runner": adapter.name, "model": model, "trigger_eval": True},
+            write_metadata=True,
+        )
+    return row
 
 
 def summarize_matrix(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -284,6 +399,7 @@ def summarize_matrix(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "triggered_runs": triggered, "trigger_rate": triggered / len(runs),
                 "passed_runs": sum(1 for r in runs if r["pass"]),
             })
+
         def polarity(should: bool) -> dict[str, Any]:
             pol = [r for r in rows if r["should_trigger"] is should]
             return {"total": len(pol), "passed": sum(1 for r in pol if r["pass"]),
@@ -305,6 +421,7 @@ def print_matrix(matrix: list[dict[str, Any]]) -> None:
     print("-" * len(header))
     for cell in matrix:
         s = cell["summary"]
+
         def frac(block: dict[str, Any]) -> str:
             return f"{block['passed']}/{block['total']}" if block["total"] else "-"
         print(f"{cell['agent']:<8} {str(cell['model'] or 'default'):<10} "
@@ -314,28 +431,40 @@ def print_matrix(matrix: list[dict[str, Any]]) -> None:
 
 def run_matrix(manifest_path: Path, rows: list[dict[str, Any]], agents: list[str],
                models: list[str] | None, runs_per_query: int, timeout: int, workers: int,
-               claude_bin: str = "claude", max_turns: int = 6) -> dict[str, Any]:
+               claude_bin: str = "claude", codex_cmd: str | None = None,
+               max_turns: int = 6, trace_runs: Path | None = None,
+               ablation: str | None = None) -> dict[str, Any]:
     manifest = load_manifest(manifest_path)
     repo_root = repo_root_for_manifest(manifest_path)
     adapters: list[AgentAdapter] = []
     for name in agents:
         if name not in ADAPTERS:
             raise SystemExit(f"unknown agent {name!r}; known: {sorted(ADAPTERS)} (subclass AgentAdapter to add one)")
-        adapters.append(ClaudeAdapter(claude_bin=claude_bin, max_turns=max_turns) if name == "claude" else ADAPTERS[name]())
+        adapters.append(adapter_instance(name, claude_bin=claude_bin, codex_cmd=codex_cmd, max_turns=max_turns))
     with tempfile.TemporaryDirectory(prefix="trigger-tree-") as td:
-        # One canonical tree for the whole matrix: every cell mounts the exact
-        # same bytes, and the recorded hash proves which revision was measured.
-        tree_dir = Path(build_canonical_skill_tree(repo_root, manifest, Path(td) / "canonical"))
-        tree_hash = canonical_skill_tree_hash(repo_root, manifest)
+        # One skill tree for the whole matrix: every cell mounts the exact same
+        # bytes, and the recorded hash/provenance proves which revision was measured.
+        tree_dir, tree_hash, provenance = trigger_tree_for_manifest(repo_root, manifest, Path(td), ablation)
         futures, results = [], []
         with ThreadPoolExecutor(max_workers=workers) as ex:
             for adapter in adapters:
                 for model in (models if models is not None else adapter.default_models):
-                    for row in rows:
-                        for _ in range(runs_per_query):
+                    for row_index, row in enumerate(rows, 1):
+                        query = str(row["query"])
+                        for run_number in range(1, runs_per_query + 1):
+                            trace_dir = None
+                            if trace_runs is not None:
+                                trace_dir = (trace_runs / adapter.name / str(model or "default") /
+                                             f"query-{row_index:03d}-{safe_trace_label(query, f'query-{row_index}')}" /
+                                             f"run-{run_number}")
+                            metadata = {
+                                "measurement": TRIGGER_MEASUREMENT_EVIDENCE_CLASS,
+                                "ablation": ablation,
+                                "skill_tree_hash": tree_hash,
+                            }
                             futures.append(ex.submit(run_cell_query, adapter, tree_dir,
-                                                     str(row["query"]), bool(row["should_trigger"]),
-                                                     model, timeout))
+                                                     query, bool(row["should_trigger"]),
+                                                     model, timeout, trace_dir, metadata))
             for fut in as_completed(futures):
                 results.append(fut.result())
     matrix = summarize_matrix(results)
@@ -347,6 +476,9 @@ def run_matrix(manifest_path: Path, rows: list[dict[str, Any]], agents: list[str
         # rates that steer description edits, not confirmed causal effects.
         "evidence_class": TRIGGER_MEASUREMENT_EVIDENCE_CLASS,
         "skill_tree_hash": tree_hash,
+        "ablation": ablation,
+        "provenance": provenance,
+        "agents": {name: AGENT_CAPABILITIES[name].as_dict() for name in sorted({r["agent"] for r in results})},
         "runs_per_query": runs_per_query,
         "summary": {"total": len(results), "passed": passed,
                     "pass_rate": (passed / len(results)) if results else None},
@@ -369,6 +501,10 @@ def build_arg_parser() -> argparse.ArgumentParser:
     ap.add_argument("--workers", type=int, default=4)
     ap.add_argument("--max-turns", type=int, default=6, help="claude adapter: turns the model gets to load the skill (its observation window)")
     ap.add_argument("--claude-bin", default="claude")
+    ap.add_argument("--codex-cmd", default="codex exec --json --sandbox read-only --skip-git-repo-check --ephemeral",
+                    help="codex adapter command prefix; the raw query is appended as the final argv item")
+    ap.add_argument("--trace-runs", help="optional directory for per-run trace.jsonl/events.json/metrics.json artifacts for every selected agent")
+    ap.add_argument("--ablation", help="materialize this discovery/trigger-population ablation id and trigger-test the altered skill")
     ap.add_argument("--out", required=True)
     return ap
 
@@ -384,7 +520,10 @@ def main() -> int:
 
     report = run_matrix(manifest_path, rows, agents=args.agent or ["claude"], models=args.model,
                         runs_per_query=args.runs_per_query, timeout=args.timeout, workers=args.workers,
-                        claude_bin=args.claude_bin, max_turns=args.max_turns)
+                        claude_bin=args.claude_bin, codex_cmd=args.codex_cmd,
+                        max_turns=args.max_turns,
+                        trace_runs=Path(args.trace_runs) if args.trace_runs else None,
+                        ablation=args.ablation)
     write_json(Path(args.out), report)
     print_matrix(report["matrix"])
     print(f"\nreport: {args.out}")

--- a/run_trigger_matrix.py
+++ b/run_trigger_matrix.py
@@ -16,9 +16,9 @@ Four adapters ship:
               haiku / sonnet / opus aliases. The skill mounts as a project
               skill; loading is detected from the Skill tool-use event and,
               as a fallback, path evidence of the model reading the mounted
-              SKILL.md. A fresh CLAUDE_CONFIG_DIR per run keeps your personal
-              skills out; Claude Code's built-in skills stay, because your
-              users run against them too.
+              SKILL.md. It uses an isolated CLAUDE_CONFIG_DIR when auth can be
+              copied, otherwise preserves the normal Claude config so
+              OAuth/keychain logins still work.
 - `codex`   — Codex CLI (`codex exec --json` by default), mounted in the
               Codex project-skill directory and detected through the shared
               path-evidence detector. Override the command with `--codex-cmd`
@@ -59,26 +59,29 @@ from typing import Any
 from agent_capabilities import AGENT_CAPABILITIES
 from skill_benchmark import (
     VALID_SPLITS,
-    ablation_by_id,
-    ablation_components,
+    AblationError,
     build_canonical_skill_tree,
     canonical_skill_tree_hash,
     detect_trigger,
-    derived_population,
     frontmatter_value,
     iter_json_objects,
-    materialize_ablation,
+    materialize_trigger_ablation,
     mount_skill_tree,
     repo_root_for_manifest,
     run_argv_with_timeout,
+    safe_trace_label,
     stream_usage_and_cost,
     write_json,
     write_trace_artifacts,
 )
 from run_pi_trigger_eval import cases_from_manifest, eval_rows_from_args, load_manifest, pi_argv, skill_name_from_manifest, seed_config_dir
-from ablation_model import TRIGGER_MEASUREMENT_EVIDENCE_CLASS
+from ablation_model import TRIGGER_MEASUREMENT_EVIDENCE_CLASS, Provenance
 
 STOPWORDS = {"this", "that", "with", "have", "what", "your", "from", "each", "then", "them", "were", "will", "would", "should", "could", "please", "give", "tell"}
+DEFAULT_CODEX_CMD = "codex exec --json --sandbox read-only --skip-git-repo-check --ephemeral"
+INVOKE_RESULT_KEYS = ("stdout", "stderr", "returncode", "timed_out", "elapsed_ms", "observation_complete")
+CODEX_HOME_FILES = ("auth.json", "config.toml")
+CLAUDE_PORTABLE_AUTH_FILES = (".credentials.json",)
 
 
 def mounted_skill_names(copied: list[Path]) -> list[str]:
@@ -98,9 +101,48 @@ def mounted_skill_names(copied: list[Path]) -> list[str]:
     return names
 
 
-def safe_trace_label(text: str, fallback: str) -> str:
-    label = re.sub(r"[^a-zA-Z0-9_.-]+", "-", text)[:80].strip("-")
-    return label or fallback
+def require_agent_capabilities(name: str) -> Any:
+    try:
+        return AGENT_CAPABILITIES[name]
+    except KeyError as exc:
+        raise SystemExit(f"agent {name!r} is registered in ADAPTERS but missing agent_capabilities.AGENT_CAPABILITIES[{name!r}]") from exc
+
+
+def validate_invoke_result(agent: str, result: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(result, dict):
+        raise TypeError(f"{agent}.invoke must return a dict, got {type(result).__name__}")
+    missing = [key for key in INVOKE_RESULT_KEYS if key not in result]
+    if missing:
+        raise KeyError(f"{agent}.invoke missing required result key(s): {', '.join(missing)}")
+    return result
+
+
+def seed_codex_home(codex_home: Path) -> None:
+    """Copy Codex auth/config into an isolated CODEX_HOME, but not user skills."""
+    codex_home.mkdir(parents=True, exist_ok=True)
+    source = Path(os.environ.get("CODEX_HOME", str(Path.home() / ".codex")))
+    for name in CODEX_HOME_FILES:
+        src = source / name
+        dst = codex_home / name
+        if not src.is_file():
+            continue
+        if src.resolve() == dst.resolve():
+            continue
+        shutil.copy2(src, dst)
+
+
+def seed_claude_config_dir(config_dir: Path, source_config: Path | None = None) -> bool:
+    """Copy portable Claude CLI auth into an isolated config dir when present."""
+    source = Path(source_config or os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude")))
+    copied = False
+    for name in CLAUDE_PORTABLE_AUTH_FILES:
+        src = source / name
+        if not src.is_file():
+            continue
+        config_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, config_dir / name)
+        copied = True
+    return copied
 
 
 class AgentAdapter:
@@ -154,23 +196,20 @@ class ClaudeAdapter(AgentAdapter):
         return self._mount_tree(tree_dir, workspace / ".claude" / "skills")
 
     def invoke(self, query: str, model: str | None, workspace: Path, timeout: int) -> dict[str, Any]:
-        # A fresh config dir keeps the experimenter's personal ~/.claude/skills
-        # out of the sandbox (the Pi runner's isolation lesson); auth is carried
-        # over by copying .credentials.json when it exists, and env-based auth
-        # (ANTHROPIC_API_KEY / OAuth) passes through untouched.
+        # Use a fresh config dir when auth is portable, so personal config does
+        # not bleed into the run. Claude Code's current OAuth/keychain login is
+        # not file-seedable; pointing CLAUDE_CONFIG_DIR at an empty directory
+        # turns a valid login into "not logged in", so preserve the normal CLI
+        # config path in that case.
         config_dir = workspace / ".trigger-config"
-        config_dir.mkdir(parents=True, exist_ok=True)
-        default_config = Path(os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude")))
-        creds = default_config / ".credentials.json"
-        if creds.is_file():
-            shutil.copy2(creds, config_dir / ".credentials.json")
         argv = [self.claude_bin, "-p", query, "--output-format", "stream-json", "--verbose",
                 "--max-turns", str(self.max_turns),
                 "--allowedTools", "Skill", "Read", "Glob", "Grep"]
         if model:
             argv += ["--model", model]
         env = os.environ.copy()
-        env["CLAUDE_CONFIG_DIR"] = str(config_dir)
+        if os.environ.get("ANTHROPIC_API_KEY") or seed_claude_config_dir(config_dir):
+            env["CLAUDE_CONFIG_DIR"] = str(config_dir)
         result = self._run_argv(argv, cwd=workspace, env=env, timeout=timeout)
         # Hitting --max-turns exits nonzero, but the model HAD its window to
         # load the skill — that is a completed observation, not a broken run.
@@ -211,7 +250,7 @@ class CodexAdapter(AgentAdapter):
     name = "codex"
     default_models: list[str | None] = [None]
 
-    def __init__(self, codex_cmd: str = "codex exec --json --sandbox read-only --skip-git-repo-check --ephemeral") -> None:
+    def __init__(self, codex_cmd: str = DEFAULT_CODEX_CMD) -> None:
         self.codex_cmd = codex_cmd
 
     def mount(self, tree_dir: Path, workspace: Path) -> list[Path]:
@@ -226,7 +265,9 @@ class CodexAdapter(AgentAdapter):
             argv += ["--model", model]
         argv.append(query)
         env = os.environ.copy()
-        env["CODEX_HOME"] = str(workspace / ".codex")
+        codex_home = workspace / ".codex"
+        seed_codex_home(codex_home)
+        env["CODEX_HOME"] = str(codex_home)
         return self._run_argv(argv, cwd=workspace, env=env, timeout=timeout)
 
 
@@ -283,16 +324,17 @@ ADAPTERS: dict[str, type[AgentAdapter]] = {"claude": ClaudeAdapter, "codex": Cod
 
 
 def adapter_instance(name: str, *, claude_bin: str = "claude", codex_cmd: str | None = None, max_turns: int = 6) -> AgentAdapter:
-    if name == "claude":
+    adapter_cls = ADAPTERS[name]
+    if adapter_cls is ClaudeAdapter:
         return ClaudeAdapter(claude_bin=claude_bin, max_turns=max_turns)
-    if name == "codex":
-        return CodexAdapter(codex_cmd=codex_cmd or "codex exec --json --sandbox read-only --skip-git-repo-check --ephemeral")
-    return ADAPTERS[name]()
+    if adapter_cls is CodexAdapter:
+        return CodexAdapter(codex_cmd=codex_cmd or DEFAULT_CODEX_CMD)
+    return adapter_cls()
 
 
 def matrix_capabilities() -> dict[str, Any]:
     """Capability rows for exactly the agents accepted by this command."""
-    return {name: AGENT_CAPABILITIES[name] for name in sorted(ADAPTERS)}
+    return {name: require_agent_capabilities(name) for name in sorted(ADAPTERS)}
 
 
 def trigger_tree_for_manifest(repo_root: Path, manifest: dict[str, Any], work_dir: Path, ablation: str | None) -> tuple[Path, str, dict[str, Any] | None]:
@@ -303,16 +345,11 @@ def trigger_tree_for_manifest(repo_root: Path, manifest: dict[str, Any], work_di
         tree_dir = Path(build_canonical_skill_tree(repo_root, manifest, work_dir / "canonical"))
         return tree_dir, canonical_skill_tree_hash(repo_root, manifest), {"mode": "baseline"}
 
-    ablation_doc = ablation_by_id(manifest, ablation)
-    if ablation_doc is None:
-        raise SystemExit(f"unknown ablation: {ablation}")
-    components = ablation_components(ablation_doc)
-    if not components:
-        raise SystemExit(f"ablation {ablation} is instruction-simulated; trigger matrix ablations must declare a materialized removal")
-    if derived_population(components) != "trigger":
-        raise SystemExit(f"ablation {ablation} is an answer-population ablation; trigger matrix ablations must target discovery/trigger behavior")
-    provenance = materialize_ablation(repo_root, manifest, ablation_doc, work_dir / "materialized" / str(ablation))
-    tree_hash = str(((provenance.get("identity") or {}).get("canonical")) or canonical_skill_tree_hash(repo_root, manifest))
+    try:
+        provenance = materialize_trigger_ablation(repo_root, manifest, ablation, work_dir / "materialized" / str(ablation))
+    except AblationError as exc:
+        raise SystemExit(str(exc)) from exc
+    tree_hash = Provenance.from_dict(provenance).identity.canonical
     return Path(provenance["dir"]), tree_hash, provenance
 
 
@@ -324,11 +361,11 @@ def run_cell_query(adapter: AgentAdapter, tree_dir: Path, query: str, should_tri
         workspace = Path(td)
         copied = adapter.mount(tree_dir, workspace)
         names = mounted_skill_names(copied)
-        result = adapter.invoke(query, model, workspace, timeout)
-        stdout = str(result.get("stdout") or "")
+        result = validate_invoke_result(adapter.name, adapter.invoke(query, model, workspace, timeout))
+        stdout = str(result["stdout"])
         triggered, evidence = adapter.detect(stdout, names, copied)
     usage, cost = stream_usage_and_cost(stdout)
-    observation_complete = bool(result.get("observation_complete"))
+    observation_complete = bool(result["observation_complete"])
     row = {
         "agent": adapter.name,
         "model": model,
@@ -337,13 +374,13 @@ def run_cell_query(adapter: AgentAdapter, tree_dir: Path, query: str, should_tri
         "triggered": triggered,
         "pass": observation_complete and triggered == should_trigger,
         "observation_complete": observation_complete,
-        "returncode": result.get("returncode"),
-        "timed_out": bool(result.get("timed_out")),
-        "elapsed_ms": result.get("elapsed_ms"),
+        "returncode": result["returncode"],
+        "timed_out": bool(result["timed_out"]),
+        "elapsed_ms": result["elapsed_ms"],
         "evidence": evidence,
         "usage_normalized": usage,
         "cost_normalized": cost,
-        "stderr": (str(result.get("stderr") or ""))[-1000:],
+        "stderr": (str(result["stderr"] or ""))[-1000:],
     }
     if metadata:
         row.update({k: v for k, v in metadata.items() if k not in row})
@@ -437,10 +474,15 @@ def run_matrix(manifest_path: Path, rows: list[dict[str, Any]], agents: list[str
     manifest = load_manifest(manifest_path)
     repo_root = repo_root_for_manifest(manifest_path)
     adapters: list[AgentAdapter] = []
+    capability_rows: dict[str, Any] = {}
     for name in agents:
         if name not in ADAPTERS:
             raise SystemExit(f"unknown agent {name!r}; known: {sorted(ADAPTERS)} (subclass AgentAdapter to add one)")
-        adapters.append(adapter_instance(name, claude_bin=claude_bin, codex_cmd=codex_cmd, max_turns=max_turns))
+        capability_rows[name] = require_agent_capabilities(name)
+        adapter = adapter_instance(name, claude_bin=claude_bin, codex_cmd=codex_cmd, max_turns=max_turns)
+        if adapter.name != name:
+            raise SystemExit(f"ADAPTERS[{name!r}] returned adapter with name {adapter.name!r}; set the adapter's name to {name!r}")
+        adapters.append(adapter)
     with tempfile.TemporaryDirectory(prefix="trigger-tree-") as td:
         # One skill tree for the whole matrix: every cell mounts the exact same
         # bytes, and the recorded hash/provenance proves which revision was measured.
@@ -478,7 +520,7 @@ def run_matrix(manifest_path: Path, rows: list[dict[str, Any]], agents: list[str
         "skill_tree_hash": tree_hash,
         "ablation": ablation,
         "provenance": provenance,
-        "agents": {name: AGENT_CAPABILITIES[name].as_dict() for name in sorted({r["agent"] for r in results})},
+        "agents": {name: capability_rows[name].as_dict() for name in sorted(capability_rows)},
         "runs_per_query": runs_per_query,
         "summary": {"total": len(results), "passed": passed,
                     "pass_rate": (passed / len(results)) if results else None},
@@ -501,7 +543,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     ap.add_argument("--workers", type=int, default=4)
     ap.add_argument("--max-turns", type=int, default=6, help="claude adapter: turns the model gets to load the skill (its observation window)")
     ap.add_argument("--claude-bin", default="claude")
-    ap.add_argument("--codex-cmd", default="codex exec --json --sandbox read-only --skip-git-repo-check --ephemeral",
+    ap.add_argument("--codex-cmd", default=DEFAULT_CODEX_CMD,
                     help="codex adapter command prefix; the raw query is appended as the final argv item")
     ap.add_argument("--trace-runs", help="optional directory for per-run trace.jsonl/events.json/metrics.json artifacts for every selected agent")
     ap.add_argument("--ablation", help="materialize this discovery/trigger-population ablation id and trigger-test the altered skill")

--- a/run_trigger_matrix.py
+++ b/run_trigger_matrix.py
@@ -75,13 +75,22 @@ from skill_benchmark import (
     write_trace_artifacts,
 )
 from run_pi_trigger_eval import cases_from_manifest, eval_rows_from_args, load_manifest, pi_argv, skill_name_from_manifest, seed_config_dir
-from ablation_model import TRIGGER_MEASUREMENT_EVIDENCE_CLASS, Provenance
+from ablation_model import TRIGGER_MEASUREMENT_EVIDENCE_CLASS, EvidenceClass, Provenance
 
 STOPWORDS = {"this", "that", "with", "have", "what", "your", "from", "each", "then", "them", "were", "will", "would", "should", "could", "please", "give", "tell"}
 DEFAULT_CODEX_CMD = "codex exec --json --sandbox read-only --skip-git-repo-check --ephemeral"
 INVOKE_RESULT_KEYS = ("stdout", "stderr", "returncode", "timed_out", "elapsed_ms", "observation_complete")
+INVOKE_RESULT_METADATA_KEYS = ("config_isolated", "config_isolation_warning")
 CODEX_HOME_FILES = ("auth.json", "config.toml")
 CLAUDE_PORTABLE_AUTH_FILES = (".credentials.json",)
+SENSITIVE_WORKSPACE_FILES = (
+    ".trigger-config/.credentials.json",
+    ".codex/auth.json",
+    ".codex/config.toml",
+    ".pi-config/auth.json",
+    ".pi-config/settings.json",
+    ".pi-config/APPEND_SYSTEM.md",
+)
 
 
 def mounted_skill_names(copied: list[Path]) -> list[str]:
@@ -143,6 +152,63 @@ def seed_claude_config_dir(config_dir: Path, source_config: Path | None = None) 
         shutil.copy2(src, config_dir / name)
         copied = True
     return copied
+
+
+def reject_duplicates(values: list[Any], label: str) -> None:
+    seen: set[Any] = set()
+    duplicates: list[str] = []
+    for value in values:
+        key = value if value is not None else "<default>"
+        if key in seen and str(key) not in duplicates:
+            duplicates.append(str(key))
+        seen.add(key)
+    if duplicates:
+        raise SystemExit(f"duplicate {label} value(s): {', '.join(duplicates)}; use --runs-per-query for repeated measurements")
+
+
+def _json_secret_values(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value] if len(value) >= 8 else []
+    if isinstance(value, dict):
+        out: list[str] = []
+        for child in value.values():
+            out.extend(_json_secret_values(child))
+        return out
+    if isinstance(value, list):
+        out: list[str] = []
+        for child in value:
+            out.extend(_json_secret_values(child))
+        return out
+    return []
+
+
+def workspace_secret_values(workspace: Path) -> list[str]:
+    secrets: list[str] = []
+    for rel in SENSITIVE_WORKSPACE_FILES:
+        path = workspace / rel
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if len(text.strip()) >= 8:
+            secrets.append(text)
+        try:
+            secrets.extend(_json_secret_values(json.loads(text)))
+        except json.JSONDecodeError:
+            secrets.extend(m.group(1) for m in re.finditer(r"""["']([^"']{8,})["']""", text))
+    # Longest first handles whole-file redaction before nested token values.
+    return sorted({s for s in secrets if s}, key=len, reverse=True)
+
+
+def redact_sensitive_text(text: str, secrets: list[str]) -> str:
+    redacted = text
+    for secret in secrets:
+        redacted = redacted.replace(secret, "[REDACTED]")
+    return redacted
+
+
+def safe_trace_segment(text: str, fallback: str) -> str:
+    label = safe_trace_label(text, fallback).strip(".-")
+    return label if label and label not in {".", ".."} else fallback
 
 
 class AgentAdapter:
@@ -208,9 +274,17 @@ class ClaudeAdapter(AgentAdapter):
         if model:
             argv += ["--model", model]
         env = os.environ.copy()
+        config_isolated = False
         if os.environ.get("ANTHROPIC_API_KEY") or seed_claude_config_dir(config_dir):
             env["CLAUDE_CONFIG_DIR"] = str(config_dir)
+            config_isolated = True
         result = self._run_argv(argv, cwd=workspace, env=env, timeout=timeout)
+        result["config_isolated"] = config_isolated
+        if not config_isolated:
+            result["config_isolation_warning"] = (
+                "Claude OAuth/keychain auth was not portable; preserved the normal Claude config, "
+                "so personal config may influence this measurement"
+            )
         # Hitting --max-turns exits nonzero, but the model HAD its window to
         # load the skill — that is a completed observation, not a broken run.
         if result["returncode"] != 0 and self._result_subtype(result["stdout"]) == "error_max_turns":
@@ -343,28 +417,64 @@ def trigger_tree_for_manifest(repo_root: Path, manifest: dict[str, Any], work_di
     ablation, so Claude/Pi/Codex all measure the same altered bytes."""
     if not ablation:
         tree_dir = Path(build_canonical_skill_tree(repo_root, manifest, work_dir / "canonical"))
-        return tree_dir, canonical_skill_tree_hash(repo_root, manifest), {"mode": "baseline"}
+        tree_hash = canonical_skill_tree_hash(repo_root, manifest)
+        return tree_dir, tree_hash, {"mode": "baseline", "skill_tree_hash": tree_hash}
 
     try:
         provenance = materialize_trigger_ablation(repo_root, manifest, ablation, work_dir / "materialized" / str(ablation))
     except AblationError as exc:
         raise SystemExit(str(exc)) from exc
-    tree_hash = Provenance.from_dict(provenance).identity.canonical
-    return Path(provenance["dir"]), tree_hash, provenance
+    prov = Provenance.from_dict(provenance)
+    return Path(provenance["dir"]), prov.identity.canonical, prov.as_dict()
+
+
+def matrix_failure_row(agent: str, model: str | None, query: str, should_trigger: bool,
+                       exc: BaseException, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+    message = f"{type(exc).__name__}: {exc}"
+    row: dict[str, Any] = {
+        "agent": agent,
+        "model": model,
+        "query": query,
+        "should_trigger": should_trigger,
+        "triggered": False,
+        "pass": False,
+        "observation_complete": False,
+        "returncode": None,
+        "timed_out": False,
+        "elapsed_ms": 0,
+        "evidence": [],
+        "usage_normalized": {"source": "missing"},
+        "cost_normalized": {"source": "missing"},
+        "stderr": message[-1000:],
+        "error": message,
+    }
+    if metadata:
+        row.update({k: v for k, v in metadata.items() if k not in row})
+    return row
 
 
 def run_cell_query(adapter: AgentAdapter, tree_dir: Path, query: str, should_trigger: bool,
                    model: str | None, timeout: int, trace_dir: Path | None = None,
                    metadata: dict[str, Any] | None = None) -> dict[str, Any]:
     """One run of one query in one (agent, model) cell, in a fresh workspace."""
+    secrets: list[str] = []
     with tempfile.TemporaryDirectory(prefix=f"trigger-{adapter.name}-") as td:
         workspace = Path(td)
         copied = adapter.mount(tree_dir, workspace)
         names = mounted_skill_names(copied)
         result = validate_invoke_result(adapter.name, adapter.invoke(query, model, workspace, timeout))
         stdout = str(result["stdout"])
+        secrets = workspace_secret_values(workspace)
         triggered, evidence = adapter.detect(stdout, names, copied)
-    usage, cost = stream_usage_and_cost(stdout)
+    redacted_stdout = redact_sensitive_text(stdout, secrets)
+    redacted_evidence = [redact_sensitive_text(str(item), secrets) for item in evidence]
+    redacted_stderr = redact_sensitive_text(str(result["stderr"] or ""), secrets)
+    telemetry_error = None
+    try:
+        usage, cost = stream_usage_and_cost(stdout)
+    except Exception as exc:
+        telemetry_error = f"{type(exc).__name__}: {exc}"
+        usage, cost = {"source": "missing"}, {"source": "missing"}
     observation_complete = bool(result["observation_complete"])
     row = {
         "agent": adapter.name,
@@ -377,11 +487,16 @@ def run_cell_query(adapter: AgentAdapter, tree_dir: Path, query: str, should_tri
         "returncode": result["returncode"],
         "timed_out": bool(result["timed_out"]),
         "elapsed_ms": result["elapsed_ms"],
-        "evidence": evidence,
+        "evidence": redacted_evidence,
         "usage_normalized": usage,
         "cost_normalized": cost,
-        "stderr": (str(result["stderr"] or ""))[-1000:],
+        "stderr": redacted_stderr[-1000:],
     }
+    for key in INVOKE_RESULT_METADATA_KEYS:
+        if key in result:
+            row[key] = result[key]
+    if telemetry_error:
+        row["telemetry_error"] = telemetry_error
     if metadata:
         row.update({k: v for k, v in metadata.items() if k not in row})
     if trace_dir is not None:
@@ -393,26 +508,32 @@ def run_cell_query(adapter: AgentAdapter, tree_dir: Path, query: str, should_tri
             "timed_out": row["timed_out"],
             "observation_complete": observation_complete,
             "triggered": triggered,
-            "evidence": evidence,
+            "evidence": redacted_evidence,
             "usage_normalized": usage,
             "cost_normalized": cost,
             **(metadata or {}),
         }
-        write_trace_artifacts(
-            trace_dir,
-            stdout,
-            source=adapter.name,
-            metadata=trace_metadata,
-            extra_metrics={
-                "elapsed_ms": row["elapsed_ms"],
-                "returncode": row["returncode"],
-                "timed_out": row["timed_out"],
-                "skill_invoked": triggered,
-                "skill_invocation_evidence": evidence,
-            },
-            environment={"runner": adapter.name, "model": model, "trigger_eval": True},
-            write_metadata=True,
-        )
+        for key in INVOKE_RESULT_METADATA_KEYS:
+            if key in result:
+                trace_metadata[key] = result[key]
+        try:
+            write_trace_artifacts(
+                trace_dir,
+                redacted_stdout,
+                source=adapter.name,
+                metadata=trace_metadata,
+                extra_metrics={
+                    "elapsed_ms": row["elapsed_ms"],
+                    "returncode": row["returncode"],
+                    "timed_out": row["timed_out"],
+                    "skill_invoked": triggered,
+                    "skill_invocation_evidence": redacted_evidence,
+                },
+                environment={"runner": adapter.name, "model": model, "trigger_eval": True},
+                write_metadata=True,
+            )
+        except Exception as exc:
+            row["trace_error"] = f"{type(exc).__name__}: {exc}"
     return row
 
 
@@ -473,6 +594,9 @@ def run_matrix(manifest_path: Path, rows: list[dict[str, Any]], agents: list[str
                ablation: str | None = None) -> dict[str, Any]:
     manifest = load_manifest(manifest_path)
     repo_root = repo_root_for_manifest(manifest_path)
+    reject_duplicates(agents, "--agent")
+    if models is not None:
+        reject_duplicates(models, "--model")
     adapters: list[AgentAdapter] = []
     capability_rows: dict[str, Any] = {}
     for name in agents:
@@ -487,7 +611,12 @@ def run_matrix(manifest_path: Path, rows: list[dict[str, Any]], agents: list[str
         # One skill tree for the whole matrix: every cell mounts the exact same
         # bytes, and the recorded hash/provenance proves which revision was measured.
         tree_dir, tree_hash, provenance = trigger_tree_for_manifest(repo_root, manifest, Path(td), ablation)
+        trace_root = None
+        if trace_runs is not None:
+            trace_runs.mkdir(parents=True, exist_ok=True)
+            trace_root = Path(tempfile.mkdtemp(prefix="matrix-", dir=trace_runs))
         futures, results = [], []
+        future_context: dict[Any, tuple[str, str | None, str, bool, dict[str, Any]]] = {}
         with ThreadPoolExecutor(max_workers=workers) as ex:
             for adapter in adapters:
                 for model in (models if models is not None else adapter.default_models):
@@ -495,20 +624,28 @@ def run_matrix(manifest_path: Path, rows: list[dict[str, Any]], agents: list[str
                         query = str(row["query"])
                         for run_number in range(1, runs_per_query + 1):
                             trace_dir = None
-                            if trace_runs is not None:
-                                trace_dir = (trace_runs / adapter.name / str(model or "default") /
+                            if trace_root is not None:
+                                agent_segment = safe_trace_segment(adapter.name, "agent")
+                                model_segment = safe_trace_segment(str(model or "default"), "default")
+                                trace_dir = (trace_root / agent_segment / model_segment /
                                              f"query-{row_index:03d}-{safe_trace_label(query, f'query-{row_index}')}" /
                                              f"run-{run_number}")
                             metadata = {
-                                "measurement": TRIGGER_MEASUREMENT_EVIDENCE_CLASS,
+                                "measurement": EvidenceClass.RAW_MEASUREMENT.value,
                                 "ablation": ablation,
                                 "skill_tree_hash": tree_hash,
                             }
-                            futures.append(ex.submit(run_cell_query, adapter, tree_dir,
-                                                     query, bool(row["should_trigger"]),
-                                                     model, timeout, trace_dir, metadata))
+                            future = ex.submit(run_cell_query, adapter, tree_dir,
+                                               query, bool(row["should_trigger"]),
+                                               model, timeout, trace_dir, metadata)
+                            futures.append(future)
+                            future_context[future] = (adapter.name, model, query, bool(row["should_trigger"]), metadata)
             for fut in as_completed(futures):
-                results.append(fut.result())
+                try:
+                    results.append(fut.result())
+                except Exception as exc:
+                    agent, model, query, should_trigger, metadata = future_context[fut]
+                    results.append(matrix_failure_row(agent, model, query, should_trigger, exc, metadata))
     matrix = summarize_matrix(results)
     passed = sum(1 for r in results if r["pass"])
     return {

--- a/skill_benchmark.py
+++ b/skill_benchmark.py
@@ -1600,6 +1600,21 @@ def materialize_ablation(repo_root: Path, manifest: dict[str, Any], ablation: di
     return materialize(ValidatedAblation.validate(repo_root, manifest, ablation), out_root).as_legacy_dict()
 
 
+def materialize_trigger_ablation(repo_root: Path, manifest: dict[str, Any], ablation_id: str, out_root: Path) -> dict[str, Any]:
+    """Materialize a discovery/trigger-population ablation for autonomous trigger
+    runners. This is the shared gate for Pi trigger and the trigger matrix, so
+    they cannot diverge on which ablations are valid to mount."""
+    ablation = ablation_by_id(manifest, ablation_id)
+    if ablation is None:
+        raise AblationError(f"unknown ablation: {ablation_id}")
+    components = ablation_components(ablation)
+    if not components:
+        raise AblationError(f"ablation {ablation_id} is instruction-simulated; trigger ablations must declare a materialized removal")
+    if derived_population(components) != "trigger":
+        raise AblationError(f"ablation {ablation_id} is an answer-population ablation; trigger ablations must target discovery/trigger behavior")
+    return materialize_ablation(repo_root, manifest, ablation, out_root)
+
+
 def materialize(validated: ValidatedAblation, out_root: Path) -> MaterializedArm:
     """Produce out_root/<id>/ holding the altered skill tree for a VALIDATED
     ablation, and return a MaterializedArm (which itself cannot exist without an
@@ -2798,14 +2813,27 @@ def event_mentions_skill_file(event: dict[str, Any]) -> bool:
     return "SKILL.md" in hay or "/skills/" in hay or "\\skills\\" in hay
 
 
+EVENT_TEXT_KEYS = {"file_path", "path", "skill", "input", "partial_json", "command", "cmd", "args", "argv"}
+
+
+def _flatten_event_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return " ".join(_flatten_event_text(item) for item in value).strip()
+    return ""
+
+
 def event_texts_for_tool_input(obj: Any) -> list[str]:
     """Recursively collect file-path-ish strings from a runner event (tool inputs),
     used to detect whether the model actually opened a mounted skill file."""
     out: list[str] = []
     if isinstance(obj, dict):
         for key, value in obj.items():
-            if key in {"file_path", "path", "skill", "input", "partial_json"} and isinstance(value, str):
-                out.append(value)
+            if key in EVENT_TEXT_KEYS:
+                text = _flatten_event_text(value)
+                if text:
+                    out.append(text)
             out.extend(event_texts_for_tool_input(value))
     elif isinstance(obj, list):
         for item in obj:
@@ -2829,6 +2857,11 @@ def detect_trigger(stdout: str, copied_paths: list[Path]) -> tuple[bool, list[st
             if any(n and n in text for n in needles):
                 evidence.append(text[:500])
     return bool(evidence), evidence[:5]
+
+
+def safe_trace_label(text: str, fallback: str) -> str:
+    label = re.sub(r"[^a-zA-Z0-9_.-]+", "-", text)[:80].strip("-")
+    return label or fallback
 
 
 def mount_skill_tree(tree_dir: Path, skills_dir: Path) -> list[Path]:
@@ -3447,31 +3480,61 @@ def normalize_trace_records(records: list[dict[str, Any]], *, source: str = "gen
     return event_doc, metrics
 
 
+def _stream_usage_doc(record: dict[str, Any]) -> dict[str, Any] | None:
+    usage = raw_trace_value(record, "usage", "tokens")
+    return usage if isinstance(usage, dict) else None
+
+
+def _is_cumulative_usage_record(record: dict[str, Any]) -> bool:
+    top_type = str(raw_trace_value(record, "type", "event", "name", "kind") or "").casefold()
+    item_type = nested_item_type(record).casefold()
+    return top_type in {"result", "response.completed"} or item_type in {"result", "response.completed"}
+
+
+def _sum_stream_usage(records: list[dict[str, Any]]) -> dict[str, Any]:
+    totals: dict[str, int] = {}
+    for record in records:
+        usage = _stream_usage_doc(record)
+        if not usage:
+            continue
+        normalized = normalize_usage(usage, source="provider_reported")
+        for key in USAGE_ALIASES:
+            value = normalized.get(key)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                totals[key] = totals.get(key, 0) + int(value)
+    return normalize_usage(totals if totals else None, source="provider_reported")
+
+
+def _cost_value_from_record(record: dict[str, Any]) -> float | None:
+    raw = raw_trace_value(record, "cost", "cost_usd", "total_cost_usd")
+    if raw is None:
+        usage_obj = _stream_usage_doc(record)
+        if isinstance(usage_obj, dict):
+            raw = usage_obj.get("cost", usage_obj.get("cost_usd"))
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        return float(raw)
+    if isinstance(raw, dict):
+        value = normalize_cost(raw).get("total_cost")
+        return float(value) if isinstance(value, (int, float)) else None
+    return None
+
+
 def stream_usage_and_cost(raw_text: str) -> tuple[dict[str, Any], dict[str, Any]]:
     """usage_normalized/cost_normalized straight from a runner's raw JSONL
-    stream (issue #21): tokens via the trace normalizer (provider usage events
-    relayed verbatim), provider cost records summed. Missing stays marked."""
+    stream (issue #21). Prefer final cumulative result/completion usage when a
+    provider emits it; otherwise sum per-event usage deltas. Missing stays
+    marked."""
     records = [obj for obj in iter_json_objects(raw_text) if isinstance(obj, dict)]
-    _, metrics = normalize_trace_records(records, source="stream")
-    has_tokens = any(isinstance(metrics.get(k), (int, float)) and metrics.get(k) for k in ("input_tokens", "output_tokens", "total_tokens"))
-    usage = normalize_usage(metrics if has_tokens else None, source="provider_reported")
-    cost_total = 0.0
-    cost_found = False
-    for record in records:
-        raw = raw_trace_value(record, "cost", "cost_usd", "total_cost_usd")
-        if raw is None:
-            # Pi relays cost inside the usage object ({"usage": {..., "cost": x}}).
-            usage_obj = raw_trace_value(record, "usage", "tokens")
-            if isinstance(usage_obj, dict):
-                raw = usage_obj.get("cost", usage_obj.get("cost_usd"))
-        value = None
-        if isinstance(raw, (int, float)) and not isinstance(raw, bool):
-            value = float(raw)
-        elif isinstance(raw, dict):
-            value = normalize_cost(raw).get("total_cost")
-        if value is not None:
-            cost_total += value
-            cost_found = True
+    cumulative_usage = [_stream_usage_doc(record) for record in records if _is_cumulative_usage_record(record) and _stream_usage_doc(record)]
+    usage = normalize_usage(cumulative_usage[-1], source="provider_reported") if cumulative_usage else _sum_stream_usage(records)
+
+    cumulative_cost = [_cost_value_from_record(record) for record in records if _is_cumulative_usage_record(record) and _cost_value_from_record(record) is not None]
+    if cumulative_cost:
+        cost = normalize_cost(cumulative_cost[-1], source="provider_reported")
+        return usage, cost
+    cost_values = [_cost_value_from_record(record) for record in records]
+    cost_total = sum(value for value in cost_values if value is not None)
+    cost_found = any(value is not None for value in cost_values)
     cost = normalize_cost(round(cost_total, 6) if cost_found else None, source="provider_reported")
     return usage, cost
 

--- a/skill_benchmark.py
+++ b/skill_benchmark.py
@@ -22,6 +22,7 @@ import os
 import random
 import re
 import shutil
+import signal
 import statistics
 import subprocess
 import sys
@@ -2899,11 +2900,18 @@ def run_argv_with_timeout(argv: list[str], *, cwd: Path | str | None = None,
         return str(value)
 
     start = time.time()
+    proc = subprocess.Popen(argv, cwd=cwd, env=env, text=True, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, start_new_session=True)
     try:
-        proc = subprocess.run(argv, cwd=cwd, env=env, text=True, capture_output=True, timeout=timeout)
-        stdout, stderr, returncode, timed_out = _text(proc.stdout), _text(proc.stderr), proc.returncode, False
-    except subprocess.TimeoutExpired as exc:
-        stdout, stderr, returncode, timed_out = _text(exc.stdout), _text(exc.stderr), 124, True
+        out, err = proc.communicate(timeout=timeout)
+        stdout, stderr, returncode, timed_out = _text(out), _text(err), proc.returncode, False
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except Exception:
+            proc.kill()
+        out, err = proc.communicate()
+        stdout, stderr, returncode, timed_out = _text(out), _text(err), 124, True
     return {"stdout": stdout, "stderr": stderr, "returncode": returncode, "timed_out": timed_out,
             "elapsed_ms": int((time.time() - start) * 1000),
             "observation_complete": returncode == 0 and not timed_out}
@@ -2947,7 +2955,7 @@ def metric_number(metrics: dict[str, Any], *keys: str) -> float | None:
 
 
 USAGE_SOURCES = {"provider_reported", "trace_normalized", "estimated", "missing", "not_applicable"}
-COST_SOURCES = {"provider_reported", "price_table_estimated", "missing", "not_applicable"}
+COST_SOURCES = {"provider_reported", "trace_normalized", "price_table_estimated", "missing", "not_applicable"}
 # THE token-usage alias table. Every normalizer (metadata `normalize_usage`, the
 # trace-stream `usage_number`, and the Claude envelope parser) reads THIS table,
 # so the same provider payload can never be classified differently by two paths
@@ -2970,7 +2978,13 @@ COST_PART_ALIASES: dict[str, tuple[str, ...]] = {
 
 
 def _num(value: Any) -> float | None:
-    return float(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (OverflowError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
 
 
 def normalize_usage(raw: Any, *, source: str = "provider_reported") -> dict[str, Any]:
@@ -3304,9 +3318,9 @@ def usage_number(usage: dict[str, Any], *keys: str) -> float | None:
     for key in keys:
         search.extend(USAGE_ALIASES.get(key, [key]))
     for key in search:
-        value = usage.get(key)
-        if isinstance(value, (int, float)):
-            return float(value)
+        value = _num(usage.get(key))
+        if value is not None:
+            return value
     return None
 
 
@@ -3362,12 +3376,12 @@ def normalize_trace_record(record: dict[str, Any], *, source: str, index: int, l
     exit_code = raw_trace_value(record, "exit_code", "returncode")
     if isinstance(exit_code, int):
         event["exit_code"] = exit_code
-    duration = raw_trace_value(record, "duration_ms", "elapsed_ms")
-    if isinstance(duration, (int, float)):
+    duration = _num(raw_trace_value(record, "duration_ms", "elapsed_ms"))
+    if duration is not None:
         event["duration_ms"] = duration
     usage = raw_trace_value(record, "usage", "tokens")
     if isinstance(usage, dict):
-        token_doc = {k: v for k, v in usage.items() if isinstance(v, (int, float))}
+        token_doc = {k: v for k, raw in usage.items() if (v := _num(raw)) is not None}
         normalized_total = usage_number(usage, "total_tokens")
         normalized_input = usage_number(usage, "input_tokens")
         normalized_output = usage_number(usage, "output_tokens")
@@ -3411,10 +3425,10 @@ def otel_attributes_for_event(event: dict[str, Any]) -> dict[str, Any]:
             attrs["file.path"] = event["input_summary"][:500]
     tokens = event.get("tokens")
     if isinstance(tokens, dict):
-        if isinstance(tokens.get("input_tokens"), (int, float)):
-            attrs["gen_ai.usage.input_tokens"] = int(tokens["input_tokens"])
-        if isinstance(tokens.get("output_tokens"), (int, float)):
-            attrs["gen_ai.usage.output_tokens"] = int(tokens["output_tokens"])
+        if (input_tokens := _num(tokens.get("input_tokens"))) is not None:
+            attrs["gen_ai.usage.input_tokens"] = int(input_tokens)
+        if (output_tokens := _num(tokens.get("output_tokens"))) is not None:
+            attrs["gen_ai.usage.output_tokens"] = int(output_tokens)
     if isinstance(event.get("exit_code"), int):
         attrs["process.exit_code"] = event["exit_code"]
     return attrs
@@ -3436,9 +3450,9 @@ def normalize_trace_records(records: list[dict[str, Any]], *, source: str = "gen
             for key, value in [("input_tokens", input_tokens), ("output_tokens", output_tokens), ("total_tokens", total_tokens)]:
                 if isinstance(value, (int, float)):
                     token_totals[key] += value
-        duration = raw_trace_value(record, "duration_ms", "elapsed_ms")
-        if isinstance(duration, (int, float)):
-            elapsed_ms += float(duration)
+        duration = _num(raw_trace_value(record, "duration_ms", "elapsed_ms"))
+        if duration is not None:
+            elapsed_ms += duration
         tokens = event.get("tokens")
         if isinstance(tokens, dict) and not isinstance(usage, dict):
             for key in token_totals:
@@ -3497,12 +3511,12 @@ def _sum_stream_usage(records: list[dict[str, Any]]) -> dict[str, Any]:
         usage = _stream_usage_doc(record)
         if not usage:
             continue
-        normalized = normalize_usage(usage, source="provider_reported")
+        normalized = normalize_usage(usage, source="trace_normalized")
         for key in USAGE_ALIASES:
             value = normalized.get(key)
             if isinstance(value, (int, float)) and not isinstance(value, bool):
                 totals[key] = totals.get(key, 0) + int(value)
-    return normalize_usage(totals if totals else None, source="provider_reported")
+    return normalize_usage(totals if totals else None, source="trace_normalized")
 
 
 def _cost_value_from_record(record: dict[str, Any]) -> float | None:
@@ -3512,10 +3526,10 @@ def _cost_value_from_record(record: dict[str, Any]) -> float | None:
         if isinstance(usage_obj, dict):
             raw = usage_obj.get("cost", usage_obj.get("cost_usd"))
     if isinstance(raw, (int, float)) and not isinstance(raw, bool):
-        return float(raw)
+        return _num(raw)
     if isinstance(raw, dict):
         value = normalize_cost(raw).get("total_cost")
-        return float(value) if isinstance(value, (int, float)) else None
+        return _num(value)
     return None
 
 
@@ -3525,17 +3539,35 @@ def stream_usage_and_cost(raw_text: str) -> tuple[dict[str, Any], dict[str, Any]
     provider emits it; otherwise sum per-event usage deltas. Missing stays
     marked."""
     records = [obj for obj in iter_json_objects(raw_text) if isinstance(obj, dict)]
-    cumulative_usage = [_stream_usage_doc(record) for record in records if _is_cumulative_usage_record(record) and _stream_usage_doc(record)]
-    usage = normalize_usage(cumulative_usage[-1], source="provider_reported") if cumulative_usage else _sum_stream_usage(records)
+    cumulative_usage: list[dict[str, Any]] = []
+    for record in records:
+        if not _is_cumulative_usage_record(record):
+            continue
+        usage_doc = _stream_usage_doc(record)
+        if not usage_doc:
+            continue
+        normalized = normalize_usage(usage_doc, source="trace_normalized")
+        if normalized.get("source") != "missing":
+            cumulative_usage.append(normalized)
+    usage = cumulative_usage[-1] if cumulative_usage else _sum_stream_usage(records)
 
-    cumulative_cost = [_cost_value_from_record(record) for record in records if _is_cumulative_usage_record(record) and _cost_value_from_record(record) is not None]
+    cumulative_cost: list[dict[str, Any]] = []
+    for record in records:
+        if not _is_cumulative_usage_record(record):
+            continue
+        value = _cost_value_from_record(record)
+        if value is None:
+            continue
+        normalized = normalize_cost(value, source="trace_normalized")
+        if normalized.get("source") != "missing":
+            cumulative_cost.append(normalized)
     if cumulative_cost:
-        cost = normalize_cost(cumulative_cost[-1], source="provider_reported")
+        cost = cumulative_cost[-1]
         return usage, cost
     cost_values = [_cost_value_from_record(record) for record in records]
     cost_total = sum(value for value in cost_values if value is not None)
     cost_found = any(value is not None for value in cost_values)
-    cost = normalize_cost(round(cost_total, 6) if cost_found else None, source="provider_reported")
+    cost = normalize_cost(round(cost_total, 6) if cost_found else None, source="trace_normalized")
     return usage, cost
 
 
@@ -3568,14 +3600,14 @@ def write_trace_artifacts(
     # blocks — missing telemetry is marked, never silently absent or zero.
     for key in ("usage_normalized", "cost_normalized"):
         block = (metadata or {}).get(key)
-        if isinstance(block, dict) and block.get("source") in {"provider_reported", "price_table_estimated", "estimated", "not_applicable"}:
+        if isinstance(block, dict) and block.get("source") in {"provider_reported", "trace_normalized", "price_table_estimated", "estimated", "not_applicable"}:
             metrics[key] = block
     write_json(out_events or run_dir / "events.json", events)
     write_json(out_metrics or run_dir / "metrics.json", metrics)
     if environment:
         write_json(run_dir / "environment.json", environment)
     if write_metadata:
-        existing = read_metadata_base(run_dir)
+        existing: dict[str, Any] = {}
         if metadata:
             existing.update(metadata)
         existing.update({k: v for k, v in metrics.items() if k not in {"schema_version", "source"}})

--- a/tests/test_ablations.py
+++ b/tests/test_ablations.py
@@ -589,6 +589,8 @@ class AblationRunnerIntegrationTests(unittest.TestCase):
             prov = am.Provenance.from_dict(provenance)
             self.assertEqual(tree_hash, prov.identity.canonical)
             self.assertEqual(tree_hash, provenance["parent_skill_hash"])
+            self.assertNotIn("dir", provenance)
+            self.assertNotIn("skill_files", provenance)
 
     def test_pi_trigger_baseline_matches_ablation_surface(self):
         # The baseline (no-ablation) arm must use the SAME canonical tree builder as

--- a/tests/test_ablations.py
+++ b/tests/test_ablations.py
@@ -24,6 +24,7 @@ from unittest import mock
 
 import skill_benchmark as sb
 import run_pi_trigger_eval as tr
+import run_trigger_matrix as tm
 import ablation_model as am
 from helpers import (
     CODEX_CRASH_OUTPUT as CRASH,
@@ -576,6 +577,18 @@ class AblationRunnerIntegrationTests(unittest.TestCase):
                 text = Path(copied[0]).read_text(encoding="utf-8")
                 self.assertNotIn("when_to_use", text)
                 self.assertIn("name: good-pr", text)
+
+    def test_trigger_matrix_ablation_hash_comes_from_provenance(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            p = self.repo(root, [self.DISCO_ABL])
+            manifest = sb.validate_manifest(p)
+            repo_root = sb.repo_root_for_manifest(p)
+            tree_dir, tree_hash, provenance = tm.trigger_tree_for_manifest(repo_root, manifest, root / "work", "no-wtu")
+            self.assertTrue(tree_dir.is_dir())
+            prov = am.Provenance.from_dict(provenance)
+            self.assertEqual(tree_hash, prov.identity.canonical)
+            self.assertEqual(tree_hash, provenance["parent_skill_hash"])
 
     def test_pi_trigger_baseline_matches_ablation_surface(self):
         # The baseline (no-ablation) arm must use the SAME canonical tree builder as

--- a/tests/test_consolidation_guards.py
+++ b/tests/test_consolidation_guards.py
@@ -51,6 +51,17 @@ class SharedOwnerIdentityTests(unittest.TestCase):
         self.assertIs(tm.eval_rows_from_args, tr.eval_rows_from_args)
         self.assertIs(tm.pi_argv, tr.pi_argv)
 
+    def test_trigger_runners_share_trace_label_sanitizer(self):
+        self.assertIs(tr.safe_trace_label, sb.safe_trace_label)
+        self.assertIs(tm.safe_trace_label, sb.safe_trace_label)
+
+    def test_codex_default_command_has_one_code_owner(self):
+        parser = tm.build_arg_parser()
+        codex_action = next(a for a in parser._actions if "--codex-cmd" in getattr(a, "option_strings", ()))
+        self.assertEqual(codex_action.default, tm.DEFAULT_CODEX_CMD)
+        self.assertEqual(tm.CodexAdapter().codex_cmd, tm.DEFAULT_CODEX_CMD)
+        self.assertEqual((ROOT / "run_trigger_matrix.py").read_text(encoding="utf-8").count(tm.DEFAULT_CODEX_CMD), 1)
+
     def test_manifest_loading_goes_through_the_harness_source_loader(self):
         # tr.load_manifest is a thin named wrapper; what matters is that a YAML
         # manifest or dataset_files resolve for the runners exactly as for the

--- a/tests/test_consolidation_guards.py
+++ b/tests/test_consolidation_guards.py
@@ -25,6 +25,7 @@ import skill_benchmark as sb
 import run_pi_trigger_eval as tr
 import run_trigger_matrix as tm
 import ablation_model as am
+import agent_capabilities as ac
 from helpers import make_eval_repo
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -133,6 +134,10 @@ class SharedOwnerIdentityTests(unittest.TestCase):
         self.assertIn("cost_totals_block", inspect.getsource(sb.build_cost_summary))
         self.assertIn("cost_totals_block", inspect.getsource(sb.suite_cost_ledger))
         self.assertIn("discover_on_disk_run_rows", inspect.getsource(sb.suite_cost_ledger))
+
+    def test_agent_cost_capabilities_use_normalized_source_vocabulary(self):
+        for name, cap in ac.AGENT_CAPABILITIES.items():
+            self.assertIn(cap.dollar_cost, sb.COST_SOURCES, name)
 
 
 class TimeoutConventionTests(unittest.TestCase):

--- a/tests/test_cost_telemetry.py
+++ b/tests/test_cost_telemetry.py
@@ -113,6 +113,18 @@ class RunnerStampTests(unittest.TestCase):
         self.assertEqual(empty_usage, {"source": "missing"})
         self.assertEqual(empty_cost, {"source": "missing"})
 
+    def test_stream_usage_prefers_cumulative_result_usage(self):
+        stream = "\n".join([
+            json.dumps({"type": "assistant", "message": {"usage": {"input_tokens": 100, "output_tokens": 20}}}),
+            json.dumps({"type": "assistant", "message": {"usage": {"input_tokens": 200, "output_tokens": 40}}}),
+            json.dumps({"type": "result", "usage": {"input_tokens": 300, "output_tokens": 60, "total_tokens": 360}}),
+        ])
+        usage, _ = sb.stream_usage_and_cost(stream)
+        self.assertEqual(usage["input_tokens"], 300)
+        self.assertEqual(usage["output_tokens"], 60)
+        self.assertEqual(usage["total_tokens"], 360)
+        self.assertEqual(usage["source"], "provider_reported")
+
     def test_jetty_metadata_carries_blocks_both_ways(self):
         record = {"trajectory_id": "t1", "status": "completed",
                   "trajectory": {"input_tokens": 10, "output_tokens": 4, "total_tokens": 14, "cost": 0.07},

--- a/tests/test_cost_telemetry.py
+++ b/tests/test_cost_telemetry.py
@@ -35,6 +35,11 @@ class NormalizeUsageCostTests(unittest.TestCase):
         self.assertEqual(sb.normalize_usage({}), {"source": "missing"})
         self.assertEqual(sb.normalize_usage({"input_tokens": 5}, source="not_applicable"), {"source": "not_applicable"})
 
+    def test_non_finite_numbers_are_missing_not_exceptions(self):
+        self.assertEqual(sb.normalize_usage({"input_tokens": float("inf")}), {"source": "missing"})
+        self.assertEqual(sb.normalize_usage({"input_tokens": float("nan")}), {"source": "missing"})
+        self.assertEqual(sb.normalize_cost(float("inf")), {"source": "missing"})
+
     def test_invalid_source_raises(self):
         with self.assertRaises(ValueError):
             sb.normalize_usage({"input_tokens": 1}, source="vibes")
@@ -99,6 +104,33 @@ class RunnerStampTests(unittest.TestCase):
             self.assertEqual(metrics["usage_normalized"]["total_tokens"], 42)
             self.assertEqual(metrics["usage_normalized"]["source"], "trace_normalized")
 
+    def test_trace_artifacts_tolerate_non_finite_json_numbers(self):
+        with tempfile.TemporaryDirectory() as td:
+            run_dir = Path(td) / "run"
+            sb.write_trace_artifacts(
+                run_dir,
+                '{"usage":{"input_tokens":1e999},"duration_ms":1e999,"cost":NaN}',
+                source="codex",
+            )
+            metrics = json.loads((run_dir / "metrics.json").read_text(encoding="utf-8"))
+            event = json.loads((run_dir / "events.json").read_text(encoding="utf-8"))["events"][0]
+            self.assertNotIn("usage_normalized", metrics)
+            self.assertNotIn("elapsed_ms", metrics)
+            self.assertEqual(event.get("tokens"), {})
+            self.assertNotIn("duration_ms", event)
+
+    def test_write_trace_artifacts_metadata_is_current_run_only(self):
+        with tempfile.TemporaryDirectory() as td:
+            run_dir = Path(td) / "run"
+            run_dir.mkdir()
+            (run_dir / "metadata.json").write_text(json.dumps({"parse_errors": ["stale"], "old": True}), encoding="utf-8")
+            sb.write_trace_artifacts(run_dir, "", source="codex", metadata={"provider": "codex"})
+            metadata = json.loads((run_dir / "metadata.json").read_text(encoding="utf-8"))
+            self.assertNotIn("old", metadata)
+            self.assertNotIn("parse_errors", metadata)
+            self.assertNotIn("schema_version", metadata)
+            self.assertNotIn("source", metadata)
+
     def test_stream_usage_and_cost(self):
         stream = "\n".join([
             json.dumps({"type": "message_end", "usage": {"input": 200, "output": 50, "totalTokens": 250, "cost": 0.01}}),
@@ -107,11 +139,36 @@ class RunnerStampTests(unittest.TestCase):
         ])
         usage, cost = sb.stream_usage_and_cost(stream)
         self.assertEqual(usage["total_tokens"], 375)
-        self.assertEqual(usage["source"], "provider_reported")
+        self.assertEqual(usage["source"], "trace_normalized")
         self.assertEqual(cost["total_cost"], 0.015)
         empty_usage, empty_cost = sb.stream_usage_and_cost("plain text only")
         self.assertEqual(empty_usage, {"source": "missing"})
         self.assertEqual(empty_cost, {"source": "missing"})
+
+    def test_stream_usage_and_cost_tolerates_non_finite_json_numbers(self):
+        usage, cost = sb.stream_usage_and_cost('{"type":"result","usage":{"input_tokens":1e999},"total_cost_usd":NaN}')
+        self.assertEqual(usage, {"source": "missing"})
+        self.assertEqual(cost, {"source": "missing"})
+
+    def test_stream_usage_and_cost_ignores_non_finite_sibling_costs(self):
+        stream = "\n".join([
+            json.dumps({"cost": 0.25}),
+            '{"cost": 1e999}',
+        ])
+        _, cost = sb.stream_usage_and_cost(stream)
+        self.assertEqual(cost["total_cost"], 0.25)
+        self.assertEqual(cost["source"], "trace_normalized")
+
+    def test_stream_usage_and_cost_uses_last_valid_cumulative_blocks(self):
+        stream = "\n".join([
+            json.dumps({"type": "result", "usage": {"input_tokens": 7, "output_tokens": 3}, "cost": 0.25}),
+            '{"type":"result","usage":{"input_tokens":1e999},"cost":1e999}',
+        ])
+        usage, cost = sb.stream_usage_and_cost(stream)
+        self.assertEqual(usage["input_tokens"], 7)
+        self.assertEqual(usage["output_tokens"], 3)
+        self.assertEqual(usage["total_tokens"], 10)
+        self.assertEqual(cost["total_cost"], 0.25)
 
     def test_stream_usage_prefers_cumulative_result_usage(self):
         stream = "\n".join([
@@ -123,7 +180,7 @@ class RunnerStampTests(unittest.TestCase):
         self.assertEqual(usage["input_tokens"], 300)
         self.assertEqual(usage["output_tokens"], 60)
         self.assertEqual(usage["total_tokens"], 360)
-        self.assertEqual(usage["source"], "provider_reported")
+        self.assertEqual(usage["source"], "trace_normalized")
 
     def test_jetty_metadata_carries_blocks_both_ways(self):
         record = {"trajectory_id": "t1", "status": "completed",

--- a/tests/test_skill_benchmark.py
+++ b/tests/test_skill_benchmark.py
@@ -219,6 +219,13 @@ class SkillBenchmarkTests(unittest.TestCase):
         self.assertTrue(triggered)
         self.assertIn("/tmp/pi-trigger-x/skills/good-readme/SKILL.md", evidence[0])
 
+    def test_trigger_detector_reads_command_array_events(self):
+        copied = [Path("/tmp/codex-trigger-x/.codex/skills/good-readme/SKILL.md")]
+        event = json.dumps({"type": "command", "command": ["bash", "-lc", f"cat {copied[0]}"]})
+        triggered, evidence = tr.detect_trigger(event, copied)
+        self.assertTrue(triggered)
+        self.assertIn("SKILL.md", evidence[0])
+
     def test_prepare_includes_input_files(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)

--- a/tests/test_trigger_matrix.py
+++ b/tests/test_trigger_matrix.py
@@ -4,7 +4,8 @@ Offline: the stub adapter runs the whole pipeline in CI with no model — the
 demo skill's should-fire query triggers, the should-not-fire query doesn't,
 and weakening the mounted description measurably under-triggers (the tuning
 loop's core signal, reproduced deterministically). Claude-specific detection
-and the observation-window rule are covered with canned event streams.
+and the observation-window rule are covered with canned event streams; Codex is
+covered through its adapter contract and shared path-evidence detector.
 
 Live (manual): RUN_TRIGGER_SMOKE=1 runs the real Claude CLI across haiku,
 sonnet, and opus as subagents:
@@ -53,6 +54,20 @@ class StubMatrixOfflineTests(unittest.TestCase):
             self.assertEqual(s["incomplete_observations"], 0)
         self.assertEqual(report["summary"]["pass_rate"], 1.0)
 
+    def test_trace_runs_are_written_for_matrix_agents(self):
+        with tempfile.TemporaryDirectory() as td:
+            trace_root = Path(td) / "traces"
+            report = tm.run_matrix(DEMO_MANIFEST, demo_trigger_rows()[:1], agents=["stub"],
+                                   models=["offline"], runs_per_query=1,
+                                   timeout=30, workers=1, trace_runs=trace_root)
+            trace_dir = Path(report["results"][0]["trace_dir"])
+            self.assertTrue((trace_dir / "trace.jsonl").is_file())
+            self.assertTrue((trace_dir / "events.json").is_file())
+            self.assertTrue((trace_dir / "metrics.json").is_file())
+            meta = json.loads((trace_dir / "metadata.json").read_text(encoding="utf-8"))
+            self.assertEqual(meta["provider"], "stub")
+            self.assertEqual(meta["measurement"], "raw_autonomous_trigger_measurement")
+
     def test_weakened_description_under_triggers_offline(self):
         """The loop's core signal, deterministic: strip the description of the
         words users actually type and the (stub) agent stops loading the skill
@@ -84,7 +99,7 @@ class StubMatrixOfflineTests(unittest.TestCase):
 
     def test_unknown_agent_names_the_extension_seam(self):
         with self.assertRaises(SystemExit) as ctx:
-            tm.run_matrix(DEMO_MANIFEST, demo_trigger_rows(), agents=["codex"], models=None,
+            tm.run_matrix(DEMO_MANIFEST, demo_trigger_rows(), agents=["missing-agent"], models=None,
                           runs_per_query=1, timeout=30, workers=1)
         self.assertIn("AgentAdapter", str(ctx.exception))
 
@@ -129,6 +144,47 @@ class ClaudeDetectionTests(unittest.TestCase):
             skill_md.parent.mkdir()
             skill_md.write_text("---\nname: demo-reviewer\ndescription: x\n---\n", encoding="utf-8")
             self.assertEqual(tm.mounted_skill_names([skill_md]), ["demo-reviewer"])
+
+
+class CodexAdapterTests(unittest.TestCase):
+    """Codex trigger support without a live codex binary."""
+
+    def test_codex_is_registered_and_declares_matrix_capability(self):
+        self.assertIn("codex", tm.ADAPTERS)
+        cap = tm.matrix_capabilities()["codex"]
+        self.assertTrue(cap.autonomous_trigger)
+        self.assertTrue(cap.trigger_ablation)
+        parser = tm.build_arg_parser()
+        agent_action = next(a for a in parser._actions if "--agent" in getattr(a, "option_strings", ()))
+        self.assertIn("codex", agent_action.choices)
+
+    def test_codex_uses_shared_path_evidence_detector(self):
+        mounted = Path("/tmp/trigger-x/.codex/skills/demo-reviewer/SKILL.md")
+        stream = json.dumps({"type": "tool_use", "name": "Read", "input": {"file_path": str(mounted)}})
+        triggered, evidence = tm.CodexAdapter().detect(stream, ["demo-reviewer"], [mounted])
+        self.assertTrue(triggered)
+        self.assertTrue(evidence)
+        prose = json.dumps({"type": "message", "content": "I would use demo-reviewer."})
+        self.assertEqual(tm.CodexAdapter().detect(prose, ["demo-reviewer"], [mounted]), (False, []))
+
+    def test_codex_invoke_appends_raw_query_and_model(self):
+        seen = {}
+        old = tm.CodexAdapter._run_argv
+
+        def fake_run(argv, *, cwd, env, timeout):
+            seen.update({"argv": argv, "cwd": cwd, "env": env, "timeout": timeout})
+            return {"stdout": "{}\n", "stderr": "", "returncode": 0, "timed_out": False,
+                    "elapsed_ms": 1, "observation_complete": True}
+
+        try:
+            tm.CodexAdapter._run_argv = staticmethod(fake_run)
+            with tempfile.TemporaryDirectory() as td:
+                tm.CodexAdapter(codex_cmd="codex exec --json").invoke("raw trigger query", "o4-mini", Path(td), 12)
+        finally:
+            tm.CodexAdapter._run_argv = old
+        self.assertEqual(seen["argv"], ["codex", "exec", "--json", "--model", "o4-mini", "raw trigger query"])
+        self.assertTrue(str(seen["env"]["CODEX_HOME"]).endswith(".codex"))
+        self.assertEqual(seen["timeout"], 12)
 
 
 @unittest.skipUnless(os.environ.get("RUN_TRIGGER_SMOKE") == "1",

--- a/tests/test_trigger_matrix.py
+++ b/tests/test_trigger_matrix.py
@@ -10,7 +10,8 @@ covered through its adapter contract and shared path-evidence detector.
 Live (manual): RUN_AGENT_INVOKE_SMOKE=1 runs one cheap invocation for every
 supported live trigger adapter/model to verify auth/network/process plumbing.
 RUN_TRIGGER_SMOKE=1 runs the fuller Claude trigger matrix across haiku, sonnet,
-and opus:
+and opus; RUN_CODEX_TRIGGER_SMOKE=1 and RUN_PI_TRIGGER_SMOKE=1 run the same
+trigger path for those adapters:
 
     RUN_AGENT_INVOKE_SMOKE=1 python3 -m unittest tests.test_trigger_matrix.AgentInvokeSmokeTests -v
     RUN_TRIGGER_SMOKE=1 python3 -m unittest tests.test_trigger_matrix -v
@@ -26,6 +27,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from agent_capabilities import AGENT_CAPABILITIES
 import run_trigger_matrix as tm
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -69,7 +71,126 @@ class StubMatrixOfflineTests(unittest.TestCase):
             self.assertTrue((trace_dir / "metrics.json").is_file())
             meta = json.loads((trace_dir / "metadata.json").read_text(encoding="utf-8"))
             self.assertEqual(meta["provider"], "stub")
-            self.assertEqual(meta["measurement"], "raw_autonomous_trigger_measurement")
+            self.assertEqual(meta["measurement"], "raw_measurement")
+            self.assertEqual(report["results"][0]["measurement"], "raw_measurement")
+            self.assertTrue(trace_dir.is_relative_to(trace_root))
+
+    def test_trace_runs_use_unique_matrix_root_per_invocation(self):
+        with tempfile.TemporaryDirectory() as td, mock.patch.object(tm.time, "time", return_value=1234567890):
+            trace_root = Path(td) / "traces"
+            first = tm.run_matrix(DEMO_MANIFEST, demo_trigger_rows()[:1], agents=["stub"],
+                                  models=["offline"], runs_per_query=2,
+                                  timeout=30, workers=1, trace_runs=trace_root)
+            second = tm.run_matrix(DEMO_MANIFEST, demo_trigger_rows()[:1], agents=["stub"],
+                                   models=["offline"], runs_per_query=1,
+                                   timeout=30, workers=1, trace_runs=trace_root)
+        first_roots = {Path(r["trace_dir"]).relative_to(trace_root).parts[0] for r in first["results"]}
+        second_roots = {Path(r["trace_dir"]).relative_to(trace_root).parts[0] for r in second["results"]}
+        self.assertEqual(len(first_roots), 1)
+        self.assertEqual(len(second_roots), 1)
+        self.assertNotEqual(first_roots, second_roots)
+
+    def test_trace_model_segment_is_path_safe(self):
+        with tempfile.TemporaryDirectory() as td:
+            trace_root = Path(td) / "traces"
+            report = tm.run_matrix(DEMO_MANIFEST, demo_trigger_rows()[:1], agents=["stub"],
+                                   models=["../bad/model"], runs_per_query=1,
+                                   timeout=30, workers=1, trace_runs=trace_root)
+            trace_dir = Path(report["results"][0]["trace_dir"])
+        self.assertTrue(trace_dir.is_relative_to(trace_root))
+        parts = trace_dir.relative_to(trace_root).parts
+        self.assertNotIn("..", parts)
+        self.assertIn("bad-model", parts)
+
+    def test_baseline_provenance_records_skill_tree_hash(self):
+        report = tm.run_matrix(DEMO_MANIFEST, demo_trigger_rows()[:1], agents=["stub"],
+                               models=[None], runs_per_query=1, timeout=30, workers=1)
+        self.assertEqual(report["provenance"], {"mode": "baseline", "skill_tree_hash": report["skill_tree_hash"]})
+
+    def test_demo_manifest_contains_documented_discovery_ablation(self):
+        manifest = tm.load_manifest(DEMO_MANIFEST)
+        repo_root = tm.repo_root_for_manifest(DEMO_MANIFEST)
+        with tempfile.TemporaryDirectory() as td:
+            _, tree_hash, provenance = tm.trigger_tree_for_manifest(repo_root, manifest, Path(td), "weaker-description")
+        self.assertEqual(provenance["id"], "weaker-description")
+        self.assertEqual(provenance["population"], "trigger")
+        self.assertEqual(tree_hash, provenance["parent_skill_hash"])
+        self.assertNotIn("dir", provenance)
+        self.assertNotIn("skill_files", provenance)
+
+    def test_duplicate_agents_or_models_are_rejected(self):
+        with self.assertRaises(SystemExit) as agent_ctx:
+            tm.run_matrix(DEMO_MANIFEST, demo_trigger_rows()[:1], agents=["stub", "stub"],
+                          models=[None], runs_per_query=1, timeout=30, workers=1)
+        self.assertIn("duplicate --agent", str(agent_ctx.exception))
+        with self.assertRaises(SystemExit) as model_ctx:
+            tm.run_matrix(DEMO_MANIFEST, demo_trigger_rows()[:1], agents=["stub"],
+                          models=["same", "same"], runs_per_query=1, timeout=30, workers=1)
+        self.assertIn("duplicate --model", str(model_ctx.exception))
+
+    def test_trace_write_failure_does_not_discard_observation(self):
+        with tempfile.TemporaryDirectory() as td, mock.patch.object(tm, "write_trace_artifacts", side_effect=OSError("ENOSPC")):
+            report = tm.run_matrix(DEMO_MANIFEST, demo_trigger_rows()[:1], agents=["stub"],
+                                   models=[None], runs_per_query=1, timeout=30, workers=1,
+                                   trace_runs=Path(td) / "traces")
+        self.assertEqual(report["summary"]["total"], 1)
+        self.assertEqual(report["summary"]["passed"], 1)
+        self.assertIn("ENOSPC", report["results"][0]["trace_error"])
+
+    def test_worker_exception_becomes_incomplete_row(self):
+        class FailingAdapter(tm.AgentAdapter):
+            name = "stub"
+
+            def mount(self, tree_dir, workspace):
+                raise OSError("disk full")
+
+            def invoke(self, query, model, workspace, timeout):
+                raise AssertionError("unreachable")
+
+        old = tm.ADAPTERS["stub"]
+        try:
+            tm.ADAPTERS["stub"] = FailingAdapter
+            report = tm.run_matrix(DEMO_MANIFEST, demo_trigger_rows()[:1], agents=["stub"],
+                                   models=[None], runs_per_query=1, timeout=30, workers=1)
+        finally:
+            tm.ADAPTERS["stub"] = old
+        self.assertEqual(report["summary"]["total"], 1)
+        self.assertEqual(report["summary"]["passed"], 0)
+        self.assertEqual(report["matrix"][0]["summary"]["incomplete_observations"], 1)
+        self.assertIn("disk full", report["results"][0]["error"])
+
+    def test_trace_redacts_workspace_credentials(self):
+        class SecretEchoAdapter(tm.AgentAdapter):
+            name = "secret"
+
+            def mount(self, tree_dir, workspace):
+                (workspace / ".codex").mkdir(parents=True)
+                (workspace / ".codex" / "auth.json").write_text('{"token":"SECRET-TOKEN-12345"}', encoding="utf-8")
+                return self._mount_tree(tree_dir, workspace / "skills")
+
+            def invoke(self, query, model, workspace, timeout):
+                skill = next((workspace / "skills").glob("*/SKILL.md"))
+                stdout = json.dumps({
+                    "type": "command",
+                    "command": ["bash", "-lc", f"cat {skill}; echo SECRET-TOKEN-12345"],
+                }) + "\n"
+                return {"stdout": stdout, "stderr": "", "returncode": 0, "timed_out": False,
+                        "elapsed_ms": 1, "observation_complete": True}
+
+        with tempfile.TemporaryDirectory() as td:
+            tree = tm.build_canonical_skill_tree(tm.repo_root_for_manifest(DEMO_MANIFEST), tm.load_manifest(DEMO_MANIFEST), Path(td) / "tree")
+            trace_dir = Path(td) / "trace"
+            row = tm.run_cell_query(SecretEchoAdapter(), tree, "q", True, None, 12, trace_dir)
+            trace_text = (trace_dir / "trace.jsonl").read_text(encoding="utf-8")
+            metadata_text = (trace_dir / "metadata.json").read_text(encoding="utf-8")
+            metrics_text = (trace_dir / "metrics.json").read_text(encoding="utf-8")
+        self.assertTrue(row["triggered"])
+        self.assertNotIn("SECRET-TOKEN-12345", trace_text)
+        self.assertNotIn("SECRET-TOKEN-12345", json.dumps(row))
+        self.assertNotIn("SECRET-TOKEN-12345", metadata_text)
+        self.assertNotIn("SECRET-TOKEN-12345", metrics_text)
+        self.assertIn("[REDACTED]", trace_text)
+        self.assertIn("[REDACTED]", json.dumps(row))
 
     def test_weakened_description_under_triggers_offline(self):
         """The loop's core signal, deterministic: strip the description of the
@@ -164,9 +285,11 @@ class ClaudeDetectionTests(unittest.TestCase):
             source.mkdir()
             (source / ".credentials.json").write_text('{"token":"t"}', encoding="utf-8")
             with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(source)}, clear=True):
-                tm.ClaudeAdapter().invoke("q", "haiku", root / "run", 12)
+                result = tm.ClaudeAdapter().invoke("q", "haiku", root / "run", 12)
         self.assertEqual(seen["credentials"], '{"token":"t"}')
         self.assertTrue(str(seen["config_dir"]).endswith(".trigger-config"))
+        self.assertTrue(result["config_isolated"])
+        self.assertNotIn("config_isolation_warning", result)
 
     def test_claude_invoke_preserves_nonportable_oauth_config(self):
         seen = {}
@@ -182,9 +305,11 @@ class ClaudeDetectionTests(unittest.TestCase):
             source.mkdir()
             workspace = root / "run"
             with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(source)}, clear=True):
-                tm.ClaudeAdapter().invoke("q", "haiku", workspace, 12)
+                result = tm.ClaudeAdapter().invoke("q", "haiku", workspace, 12)
         self.assertEqual(seen["config_dir"], str(source))
         self.assertFalse((workspace / ".trigger-config").exists())
+        self.assertFalse(result["config_isolated"])
+        self.assertIn("personal config may influence", result["config_isolation_warning"])
 
 
 class CodexAdapterTests(unittest.TestCase):
@@ -417,6 +542,12 @@ class AgentInvokeSmokeConfigTests(unittest.TestCase):
         self.assertEqual(models["codex"], [None])
         self.assertEqual(models["pi"], [None])
 
+    def test_advertised_live_smoke_envs_are_consumed_by_tests(self):
+        test_source = Path(__file__).read_text(encoding="utf-8")
+        for agent, cap in AGENT_CAPABILITIES.items():
+            if cap.live_smoke_env:
+                self.assertIn(cap.live_smoke_env, test_source, agent)
+
 
 @unittest.skipUnless(os.environ.get("RUN_TRIGGER_SMOKE") == "1",
                      "manual smoke: set RUN_TRIGGER_SMOKE=1 (needs claude CLI + credentials, spends tokens)")
@@ -448,6 +579,22 @@ class CodexMatrixSmokeTests(unittest.TestCase):
         self.assertFalse(incomplete, f"broken runs (crash/timeout), not trigger signal: {incomplete}")
         self.assertTrue(any(r["triggered"] for r in report["results"]),
                         "no Codex run loaded the skill — detection, auth, or mounting is broken")
+
+
+@unittest.skipUnless(os.environ.get("RUN_PI_TRIGGER_SMOKE") == "1",
+                     "manual smoke: set RUN_PI_TRIGGER_SMOKE=1 (needs Pi CLI + credentials, spends tokens)")
+class PiMatrixSmokeTests(unittest.TestCase):
+    def test_pi_matrix_end_to_end(self):
+        runs = int(os.environ.get("PI_TRIGGER_SMOKE_RUNS", "1"))
+        model = os.environ.get("PI_TRIGGER_SMOKE_MODEL")
+        report = tm.run_matrix(DEMO_MANIFEST, demo_trigger_rows(), agents=["pi"],
+                               models=[model] if model else [None], runs_per_query=runs,
+                               timeout=300, workers=1)
+        tm.print_matrix(report["matrix"])
+        incomplete = [r for r in report["results"] if not r["observation_complete"]]
+        self.assertFalse(incomplete, f"broken runs (crash/timeout), not trigger signal: {incomplete}")
+        self.assertTrue(any(r["triggered"] for r in report["results"]),
+                        "no Pi run loaded the skill — detection, auth, or mounting is broken")
 
 
 if __name__ == "__main__":

--- a/tests/test_trigger_matrix.py
+++ b/tests/test_trigger_matrix.py
@@ -7,21 +7,24 @@ loop's core signal, reproduced deterministically). Claude-specific detection
 and the observation-window rule are covered with canned event streams; Codex is
 covered through its adapter contract and shared path-evidence detector.
 
-Live (manual): RUN_TRIGGER_SMOKE=1 runs the real Claude CLI across haiku,
-sonnet, and opus as subagents:
+Live (manual): RUN_AGENT_INVOKE_SMOKE=1 runs one cheap invocation for every
+supported live trigger adapter/model to verify auth/network/process plumbing.
+RUN_TRIGGER_SMOKE=1 runs the fuller Claude trigger matrix across haiku, sonnet,
+and opus:
 
+    RUN_AGENT_INVOKE_SMOKE=1 python3 -m unittest tests.test_trigger_matrix.AgentInvokeSmokeTests -v
     RUN_TRIGGER_SMOKE=1 python3 -m unittest tests.test_trigger_matrix -v
 
-It needs a `claude` binary and API credentials, spends real tokens (roughly
-a dollar at the default 1 run per query x 3 models x 2 queries), and asserts
-the pipeline — every cell observed, at least one autonomous load detected —
-not per-model trigger outcomes, which are the measurement, not the contract.
+Live smokes need the relevant CLI and API credentials, and spend real tokens.
+The cheap agent smoke asserts invocation only; the trigger-matrix smokes assert
+observed trigger-eval runs and at least one autonomous load.
 """
 import json
 import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import run_trigger_matrix as tm
 
@@ -145,6 +148,44 @@ class ClaudeDetectionTests(unittest.TestCase):
             skill_md.write_text("---\nname: demo-reviewer\ndescription: x\n---\n", encoding="utf-8")
             self.assertEqual(tm.mounted_skill_names([skill_md]), ["demo-reviewer"])
 
+    def test_claude_invoke_seeds_portable_auth_into_isolated_config(self):
+        seen = {}
+
+        def fake_run(argv, *, cwd, env, timeout):
+            config_dir = Path(env["CLAUDE_CONFIG_DIR"])
+            seen["config_dir"] = config_dir
+            seen["credentials"] = (config_dir / ".credentials.json").read_text(encoding="utf-8")
+            return {"stdout": "{}\n", "stderr": "", "returncode": 0, "timed_out": False,
+                    "elapsed_ms": 1, "observation_complete": True}
+
+        with tempfile.TemporaryDirectory() as td, mock.patch.object(tm.ClaudeAdapter, "_run_argv", staticmethod(fake_run)):
+            root = Path(td)
+            source = root / "user-claude"
+            source.mkdir()
+            (source / ".credentials.json").write_text('{"token":"t"}', encoding="utf-8")
+            with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(source)}, clear=True):
+                tm.ClaudeAdapter().invoke("q", "haiku", root / "run", 12)
+        self.assertEqual(seen["credentials"], '{"token":"t"}')
+        self.assertTrue(str(seen["config_dir"]).endswith(".trigger-config"))
+
+    def test_claude_invoke_preserves_nonportable_oauth_config(self):
+        seen = {}
+
+        def fake_run(argv, *, cwd, env, timeout):
+            seen["config_dir"] = env.get("CLAUDE_CONFIG_DIR")
+            return {"stdout": "{}\n", "stderr": "", "returncode": 0, "timed_out": False,
+                    "elapsed_ms": 1, "observation_complete": True}
+
+        with tempfile.TemporaryDirectory() as td, mock.patch.object(tm.ClaudeAdapter, "_run_argv", staticmethod(fake_run)):
+            root = Path(td)
+            source = root / "oauth-backed-claude"
+            source.mkdir()
+            workspace = root / "run"
+            with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(source)}, clear=True):
+                tm.ClaudeAdapter().invoke("q", "haiku", workspace, 12)
+        self.assertEqual(seen["config_dir"], str(source))
+        self.assertFalse((workspace / ".trigger-config").exists())
+
 
 class CodexAdapterTests(unittest.TestCase):
     """Codex trigger support without a live codex binary."""
@@ -160,7 +201,7 @@ class CodexAdapterTests(unittest.TestCase):
 
     def test_codex_uses_shared_path_evidence_detector(self):
         mounted = Path("/tmp/trigger-x/.codex/skills/demo-reviewer/SKILL.md")
-        stream = json.dumps({"type": "tool_use", "name": "Read", "input": {"file_path": str(mounted)}})
+        stream = json.dumps({"type": "command", "command": ["bash", "-lc", f"cat {mounted}"]})
         triggered, evidence = tm.CodexAdapter().detect(stream, ["demo-reviewer"], [mounted])
         self.assertTrue(triggered)
         self.assertTrue(evidence)
@@ -169,22 +210,212 @@ class CodexAdapterTests(unittest.TestCase):
 
     def test_codex_invoke_appends_raw_query_and_model(self):
         seen = {}
-        old = tm.CodexAdapter._run_argv
 
         def fake_run(argv, *, cwd, env, timeout):
             seen.update({"argv": argv, "cwd": cwd, "env": env, "timeout": timeout})
             return {"stdout": "{}\n", "stderr": "", "returncode": 0, "timed_out": False,
                     "elapsed_ms": 1, "observation_complete": True}
 
-        try:
-            tm.CodexAdapter._run_argv = staticmethod(fake_run)
-            with tempfile.TemporaryDirectory() as td:
+        with mock.patch.object(tm.CodexAdapter, "_run_argv", staticmethod(fake_run)):
+            with tempfile.TemporaryDirectory() as td, mock.patch.dict(os.environ, {"CODEX_HOME": str(Path(td) / "source-codex")}):
                 tm.CodexAdapter(codex_cmd="codex exec --json").invoke("raw trigger query", "o4-mini", Path(td), 12)
-        finally:
-            tm.CodexAdapter._run_argv = old
         self.assertEqual(seen["argv"], ["codex", "exec", "--json", "--model", "o4-mini", "raw trigger query"])
         self.assertTrue(str(seen["env"]["CODEX_HOME"]).endswith(".codex"))
         self.assertEqual(seen["timeout"], 12)
+        self.assertIs(tm.CodexAdapter()._run_argv, tm.run_argv_with_timeout)
+
+    def test_codex_invoke_seeds_auth_without_copying_user_skills(self):
+        seen = {}
+
+        def fake_run(argv, *, cwd, env, timeout):
+            codex_home = Path(env["CODEX_HOME"])
+            seen["auth"] = (codex_home / "auth.json").read_text(encoding="utf-8")
+            seen["config"] = (codex_home / "config.toml").read_text(encoding="utf-8")
+            seen["mounted_skills_survive"] = (codex_home / "skills" / "demo").is_dir()
+            seen["user_skills_not_copied"] = not (codex_home / "skills" / "personal").exists()
+            return {"stdout": "{}\n", "stderr": "", "returncode": 0, "timed_out": False,
+                    "elapsed_ms": 1, "observation_complete": True}
+
+        with tempfile.TemporaryDirectory() as td, mock.patch.object(tm.CodexAdapter, "_run_argv", staticmethod(fake_run)):
+            root = Path(td)
+            source = root / "user-codex"
+            (source / "skills" / "personal").mkdir(parents=True)
+            (source / "auth.json").write_text('{"token":"t"}', encoding="utf-8")
+            (source / "config.toml").write_text("model = 'm'\n", encoding="utf-8")
+            workspace = root / "run"
+            (workspace / ".codex" / "skills" / "demo").mkdir(parents=True)
+            with mock.patch.dict(os.environ, {"CODEX_HOME": str(source)}):
+                tm.CodexAdapter(codex_cmd="codex exec --json").invoke("q", None, workspace, 12)
+        self.assertEqual(seen["auth"], '{"token":"t"}')
+        self.assertEqual(seen["config"], "model = 'm'\n")
+        self.assertTrue(seen["mounted_skills_survive"])
+        self.assertTrue(seen["user_skills_not_copied"])
+
+    def test_run_cell_query_requires_invoke_contract(self):
+        class BrokenAdapter(tm.AgentAdapter):
+            name = "broken"
+
+            def mount(self, tree_dir, workspace):
+                return self._mount_tree(tree_dir, workspace / "skills")
+
+            def invoke(self, query, model, workspace, timeout):
+                return {"stdout": "{}\n", "stderr": "", "returncode": 0, "timed_out": False, "elapsed_ms": 1}
+
+        with tempfile.TemporaryDirectory() as td:
+            tree = Path(td) / "tree"
+            skill = tree / "demo"
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text("---\nname: demo\n---\n", encoding="utf-8")
+            with self.assertRaises(KeyError) as ctx:
+                tm.run_cell_query(BrokenAdapter(), tree, "q", True, None, 12)
+        self.assertIn("observation_complete", str(ctx.exception))
+
+    def test_missing_capability_row_fails_before_any_runs(self):
+        class UnregisteredAdapter(tm.AgentAdapter):
+            name = "my-agent"
+
+            def mount(self, tree_dir, workspace):
+                raise AssertionError("mount should not run before capability validation")
+
+            def invoke(self, query, model, workspace, timeout):
+                raise AssertionError("invoke should not run before capability validation")
+
+        old = dict(tm.ADAPTERS)
+        try:
+            tm.ADAPTERS["my-agent"] = UnregisteredAdapter
+            with self.assertRaises(SystemExit) as ctx:
+                tm.run_matrix(DEMO_MANIFEST, demo_trigger_rows()[:1], agents=["my-agent"],
+                              models=[None], runs_per_query=1, timeout=30, workers=1)
+        finally:
+            tm.ADAPTERS.clear()
+            tm.ADAPTERS.update(old)
+        self.assertIn("AGENT_CAPABILITIES", str(ctx.exception))
+
+    def test_codex_default_command_is_single_owner(self):
+        self.assertEqual(tm.CodexAdapter().codex_cmd, tm.DEFAULT_CODEX_CMD)
+        parser = tm.build_arg_parser()
+        codex_action = next(a for a in parser._actions if "--codex-cmd" in getattr(a, "option_strings", ()))
+        self.assertEqual(codex_action.default, tm.DEFAULT_CODEX_CMD)
+
+
+def _csv_env(name, default):
+    raw = os.environ.get(name)
+    if raw is None:
+        return list(default)
+    return [part.strip() or None for part in raw.split(",")]
+
+
+def _live_invoke_smoke_agents():
+    configured = [name for name in _csv_env("AGENT_INVOKE_SMOKE_AGENTS", []) if name]
+    if configured:
+        return [str(name) for name in configured if name]
+    return [
+        name for name in tm.ADAPTERS
+        if name != "stub" and tm.require_agent_capabilities(name).autonomous_trigger
+    ]
+
+
+def _live_invoke_smoke_models(agent_name, adapter):
+    upper = agent_name.upper().replace("-", "_")
+    models = _csv_env(f"{upper}_INVOKE_SMOKE_MODELS", adapter.default_models)
+    if os.environ.get(f"{upper}_INVOKE_SMOKE_MODEL") is not None:
+        models = [os.environ.get(f"{upper}_INVOKE_SMOKE_MODEL") or None]
+    return models
+
+
+@unittest.skipUnless(os.environ.get("RUN_AGENT_INVOKE_SMOKE") == "1",
+                     "cheap manual smoke: set RUN_AGENT_INVOKE_SMOKE=1 (needs live agent CLIs + credentials, spends tiny requests)")
+class AgentInvokeSmokeTests(unittest.TestCase):
+    def test_live_agents_complete_trivial_prompt_for_each_model(self):
+        query = os.environ.get("AGENT_INVOKE_SMOKE_QUERY", "Reply with exactly: OK")
+        timeout = int(os.environ.get("AGENT_INVOKE_SMOKE_TIMEOUT", "90"))
+        manifest = tm.load_manifest(DEMO_MANIFEST)
+        repo_root = tm.repo_root_for_manifest(DEMO_MANIFEST)
+        results = []
+        failures = []
+
+        for agent_name in _live_invoke_smoke_agents():
+            try:
+                adapter = tm.adapter_instance(
+                    agent_name,
+                    claude_bin=os.environ.get("CLAUDE_INVOKE_SMOKE_BIN", "claude"),
+                    codex_cmd=os.environ.get("CODEX_INVOKE_SMOKE_CMD", tm.DEFAULT_CODEX_CMD),
+                    max_turns=int(os.environ.get("CLAUDE_INVOKE_SMOKE_MAX_TURNS", "1")),
+                )
+                models = _live_invoke_smoke_models(agent_name, adapter)
+            except Exception as exc:
+                failures.append(f"{agent_name}/(setup): {exc!r}")
+                results.append({"agent": agent_name, "model": "(setup)", "ok": False, "error": repr(exc)})
+                continue
+
+            for model in models:
+                model_label = model or "(default)"
+                row = {"agent": agent_name, "model": model_label}
+                try:
+                    with tempfile.TemporaryDirectory(prefix=f"{agent_name}-invoke-smoke-") as td:
+                        workspace = Path(td)
+                        tree = tm.build_canonical_skill_tree(repo_root, manifest, workspace / "tree")
+                        copied = adapter.mount(tree, workspace)
+                        result = tm.validate_invoke_result(
+                            agent_name,
+                            adapter.invoke(query, model, workspace, timeout),
+                        )
+                    row.update({
+                        "returncode": result["returncode"],
+                        "timed_out": result["timed_out"],
+                        "observation_complete": result["observation_complete"],
+                        "elapsed_ms": result["elapsed_ms"],
+                        "stdout_bytes": len(str(result["stdout"])),
+                        "stdout_tail": str(result["stdout"])[-300:],
+                        "stderr_tail": str(result["stderr"])[-300:],
+                        "mounted_paths": len(copied),
+                    })
+                    ok = (
+                        not result["timed_out"] and
+                        result["returncode"] == 0 and
+                        result["observation_complete"] and
+                        bool(str(result["stdout"]).strip())
+                    )
+                    row["ok"] = ok
+                    if not ok:
+                        failures.append(
+                            f"{agent_name}/{model_label}: returncode={result['returncode']} "
+                            f"timed_out={result['timed_out']} observation_complete={result['observation_complete']} "
+                            f"stdout_bytes={len(str(result['stdout']))} "
+                            f"stdout_tail={str(result['stdout'])[-300:]!r} "
+                            f"stderr_tail={str(result['stderr'])[-300:]!r}"
+                        )
+                except Exception as exc:
+                    row.update({"ok": False, "error": repr(exc)})
+                    failures.append(f"{agent_name}/{model_label}: {exc!r}")
+                results.append(row)
+
+        if not results:
+            failures.append("no live agent/model smoke targets were selected")
+        print(json.dumps({"cheap_invoke_smoke": results}, indent=2, sort_keys=True))
+        self.assertFalse(failures, "\n".join(failures))
+
+
+class AgentInvokeSmokeConfigTests(unittest.TestCase):
+    def test_default_cheap_smoke_targets_every_live_supported_agent_and_model(self):
+        clean_env = {
+            "AGENT_INVOKE_SMOKE_AGENTS": "",
+            "CLAUDE_INVOKE_SMOKE_MODELS": "",
+            "CODEX_INVOKE_SMOKE_MODEL": "",
+            "PI_INVOKE_SMOKE_MODEL": "",
+        }
+        with mock.patch.dict(os.environ, clean_env, clear=False):
+            for key in clean_env:
+                os.environ.pop(key, None)
+            agents = _live_invoke_smoke_agents()
+            models = {
+                name: _live_invoke_smoke_models(name, tm.adapter_instance(name))
+                for name in agents
+            }
+        self.assertEqual(agents, ["claude", "codex", "pi"])
+        self.assertEqual(models["claude"], ["haiku", "sonnet", "opus"])
+        self.assertEqual(models["codex"], [None])
+        self.assertEqual(models["pi"], [None])
 
 
 @unittest.skipUnless(os.environ.get("RUN_TRIGGER_SMOKE") == "1",
@@ -201,6 +432,22 @@ class ClaudeMatrixSmokeTests(unittest.TestCase):
         self.assertFalse(incomplete, f"broken runs (crash/timeout), not trigger signal: {incomplete}")
         self.assertTrue(any(r["triggered"] for r in report["results"]),
                         "no model loaded the skill on any run — detection or mounting is broken")
+
+
+@unittest.skipUnless(os.environ.get("RUN_CODEX_TRIGGER_SMOKE") == "1",
+                     "manual smoke: set RUN_CODEX_TRIGGER_SMOKE=1 (needs codex CLI + credentials, spends tokens)")
+class CodexMatrixSmokeTests(unittest.TestCase):
+    def test_codex_matrix_end_to_end(self):
+        runs = int(os.environ.get("CODEX_TRIGGER_SMOKE_RUNS", "1"))
+        model = os.environ.get("CODEX_TRIGGER_SMOKE_MODEL")
+        report = tm.run_matrix(DEMO_MANIFEST, demo_trigger_rows(), agents=["codex"],
+                               models=[model] if model else [None], runs_per_query=runs,
+                               timeout=300, workers=1)
+        tm.print_matrix(report["matrix"])
+        incomplete = [r for r in report["results"] if not r["observation_complete"]]
+        self.assertFalse(incomplete, f"broken runs (crash/timeout), not trigger signal: {incomplete}")
+        self.assertTrue(any(r["triggered"] for r in report["results"]),
+                        "no Codex run loaded the skill — detection, auth, or mounting is broken")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Add an explicit agent-capability registry and make Codex a shipped autonomous-trigger adapter in `skill-trigger-matrix`.

## Why

The last consolidation pass fixed several cases where runner behavior had drifted behind similar-looking APIs. This PR closes the next obvious gap: the trigger matrix supported Claude, Pi, and the offline stub, but Codex was still only a documented extension sketch. That made agent parity implicit and easy to misstate in docs.

Codex already had answer-run support through `run-codex`; this change gives it the same activation-measurement path as the other matrix agents and gives the project one place to state which agent supports which surface.

## How

- Added `agent_capabilities.py` as the single registry for agent/runner surfaces: answer runs, autonomous trigger, trigger ablations, traces, token/cost support, judge backend, tool replay, and live-smoke env.
- Added `CodexAdapter` to `run_trigger_matrix.py` and registered it in `ADAPTERS`, so `skill-trigger-matrix --agent codex` is executable instead of a prose-only sketch.
- Mounted Codex trigger runs under the project-local `.codex/skills` tree and reused the shared mounted-path detector; the raw trigger query is appended to the `codex exec --json` command prefix.
- Extended the matrix command with shared parity surfaces: `--codex-cmd`, `--trace-runs`, and `--ablation` for materialized discovery/trigger-population ablations.
- Added per-row usage/cost normalization and report-level agent capability metadata. Codex dollar cost remains explicit `missing` unless a wrapper emits provider cost.
- Added `docs/agent-parity.md`, updated `docs/README.md`, and updated `docs/tuning-skill-activation.md` with a real Codex command.
- Packaged the new module in `pyproject.toml`.

**Alternatives considered:**

- Keeping Codex as a documented adapter sketch. Rejected because it leaves the parity claim untestable.
- Doing the full provider-neutral runner refactor in the same PR. Rejected because renaming `codex_*` generic helpers and introducing a shared `RunnerOutcome` touches the broader answer-runner path and deserves a smaller follow-up PR.
- Replacing `skill-pi-trigger-eval` with a generic trigger command immediately. Rejected to avoid breaking existing Pi scripts; the shared parity surface is added to the matrix first.

## Testing

- Added offline regression tests for Codex adapter registration, capability declaration, path-evidence detection, command construction, and model/query argument handling.
- Added a matrix trace-artifact test proving `--trace-runs` writes `trace.jsonl`, `events.json`, `metrics.json`, and `metadata.json` through the same matrix path.
- CI passed on Python 3.10, 3.11, and 3.12: package install, Python compile, unit tests, and CLI entrypoint checks.
- Local syntax checks passed in the execution container for the edited Python files before pushing.

I did not run a live Codex smoke because this environment does not have a real Codex CLI/auth setup. The test coverage is therefore contract-level for the adapter seam; a live smoke should still verify the current Codex skill-discovery path and JSONL event shape before treating Codex trigger rates as production evidence.

I did not run mutation/revert checks. The new tests are intended to fail if Codex is removed from `ADAPTERS`, if the detector starts accepting prose mentions as load evidence, if the adapter stops appending the raw query/model, or if matrix trace artifacts stop being written.

## Risk

Medium. The registry/docs changes are low risk, and the matrix additions are additive. The main risk is the live Codex contract: the adapter assumes project-local `.codex/skills` discovery and a `codex exec --json` stream where path reads are visible to the shared detector. If the current Codex CLI differs, the matrix should report incomplete or non-triggering observations rather than a false positive, but a live smoke is still required.

The `--ablation` path now applies to all matrix agents. It is restricted to materialized discovery/trigger-population ablations and still stamps results as `raw_autonomous_trigger_measurement`, so this PR does not claim provenance-confirmed causal lift. `skill-pi-trigger-eval` remains available as a compatibility wrapper for existing Pi workflows.