### PR TITLE
Rename Codex-branded helpers to provider-neutral names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable public changes are listed here. Release tags are the source of truth
 
 ## Unreleased
 
+- **Provider-neutral workspace/prompt helpers.** `codex_skill_workspace` and `codex_task_prompt` are renamed to `build_skill_workspace` and `build_task_prompt`. They were never Codex-only: `run-codex`, `run-claude`, and `run-subagent` all mount their isolated workspace and build their task prompt through the same two helpers (all three register `build_skill_workspace` as their workspace builder). The names now describe the behavior instead of one caller. Pure rename — no behavior change.
+
 - **Consolidation audit, part 2: the deferred structural refactors.**
   - *One discovery loop.* `discovered_run_units` now owns the case/model/variant/run walk for `grade`, `benchmark`, the judge collector, and the contamination report (four hand-synced copies before). The suite ledger's disk walk is the named `discover_on_disk_run_rows` beside it — the ledger deliberately bills every on-disk arm while grading is variant-scoped, and that difference is now a documented decision instead of two private implementations.
   - *One cost rollup.* Both ledgers (and the manifest audit's ablation-spend finding) build coverage/totals/spend groups from shared `spend_of`/`group_spend`/`cost_coverage_block`/`cost_totals_block`/`judge_cost_block` helpers.

--- a/skill_benchmark.py
+++ b/skill_benchmark.py
@@ -3657,7 +3657,7 @@ def safe_child_path(root: Path, relative: str) -> Path:
     return dest
 
 
-def codex_skill_workspace(pt: PreparedTask, ws: Path) -> tuple[list[str], list[str]]:
+def build_skill_workspace(pt: PreparedTask, ws: Path) -> tuple[list[str], list[str]]:
     """Build an isolated workspace holding ONLY the task's selected skill tree (per
     variant) and fixtures, so executing with cwd here cannot reach the original
     repo skill. For an ablation the PreparedTask's skill_paths are the materialized
@@ -3725,12 +3725,12 @@ def register_workspace_builder(name: str, builder: Any) -> None:
     WORKSPACE_BUILDERS[name] = builder
 
 
-register_workspace_builder("codex", codex_skill_workspace)     # run-codex
-register_workspace_builder("claude", codex_skill_workspace)    # run-claude shares the workspace builder
+register_workspace_builder("codex", build_skill_workspace)     # run-codex
+register_workspace_builder("claude", build_skill_workspace)    # run-claude shares the workspace builder
 register_workspace_builder("jetty", jetty_upload_workspace)    # export-jetty upload surface
 
 
-def codex_task_prompt(pt: PreparedTask, skill_paths: list[str] | None = None, input_files: list[str] | None = None) -> str:
+def build_task_prompt(pt: PreparedTask, skill_paths: list[str] | None = None, input_files: list[str] | None = None) -> str:
     file_note = "\n".join(f"- {p}" for p in (input_files or [])) if input_files else "- none"
     if pt.variant_truth == "without_skill":
         skill_note = "Do not use any skill. No skill files are present in this workspace."
@@ -3771,8 +3771,8 @@ def run_codex(args: argparse.Namespace) -> int:
         started = time.time()
         with tempfile.TemporaryDirectory(prefix="codex-ws-") as wd:
             ws = Path(wd)
-            skill_rel, input_rel = codex_skill_workspace(pt, ws)
-            prompt = codex_task_prompt(pt, skill_paths=skill_rel, input_files=input_rel)
+            skill_rel, input_rel = build_skill_workspace(pt, ws)
+            prompt = build_task_prompt(pt, skill_paths=skill_rel, input_files=input_rel)
             try:
                 proc = subprocess.run(cmd, shell=True, input=prompt, text=True, capture_output=True, timeout=timeout, cwd=str(ws))
                 elapsed_ms = int((time.time() - started) * 1000)
@@ -3917,8 +3917,8 @@ def run_claude(args: argparse.Namespace) -> int:
         prov_extra = {**({"ablation": pt.ablation.as_dict()} if pt.ablation else {}), **({"skill_tree_hash": pt.skill_tree_hash} if pt.skill_tree_hash else {})}
         with tempfile.TemporaryDirectory(prefix="claude-ws-") as wd:
             ws = Path(wd)
-            skill_rel, input_rel = codex_skill_workspace(pt, ws)
-            prompt = codex_task_prompt(pt, skill_paths=skill_rel, input_files=input_rel)
+            skill_rel, input_rel = build_skill_workspace(pt, ws)
+            prompt = build_task_prompt(pt, skill_paths=skill_rel, input_files=input_rel)
             result = claude_cli_invoke(prompt, model=row_model, claude_bin=claude_bin, timeout=timeout)
             metrics = claude_run_metrics(result)
             usage_block = normalize_usage(result.get("usage"), source="provider_reported")
@@ -4839,8 +4839,8 @@ def run_subagent_tasks(
         turns = [str(t) for t in task.get("turns") or [] if str(t)]
         with tempfile.TemporaryDirectory(prefix="subagent-ws-") as wd:
             ws = Path(wd)
-            skill_rel, input_rel = codex_skill_workspace(pt, ws)
-            prompt = codex_task_prompt(pt, skill_paths=skill_rel, input_files=input_rel)
+            skill_rel, input_rel = build_skill_workspace(pt, ws)
+            prompt = build_task_prompt(pt, skill_paths=skill_rel, input_files=input_rel)
             started = time.time()
             try:
                 if turns:
@@ -4945,7 +4945,7 @@ def run_subagent(args: argparse.Namespace) -> int:
                               replay_mode=getattr(args, "tool_replay", None) or tool_replay_mode())
 
 
-register_workspace_builder("subagent", codex_skill_workspace)   # run-subagent inherits CF.2
+register_workspace_builder("subagent", build_skill_workspace)   # run-subagent inherits CF.2
 
 
 JUDGE_NEGATIVE_CONTROLS = {

--- a/tests/test_ablations.py
+++ b/tests/test_ablations.py
@@ -663,9 +663,9 @@ class AblationRunnerIntegrationTests(unittest.TestCase):
             wrow = next(r for r in rows if r["variant"] == "with_skill")
             apt, wpt = sb.PreparedTask.from_row(arow), sb.PreparedTask.from_row(wrow)
             with tempfile.TemporaryDirectory() as ca, tempfile.TemporaryDirectory() as cb:
-                sa, ia = sb.codex_skill_workspace(apt, Path(ca))
-                sw, iw = sb.codex_skill_workspace(wpt, Path(cb))
-                cpa, cpw = sb.codex_task_prompt(apt, sa, ia), sb.codex_task_prompt(wpt, sw, iw)
+                sa, ia = sb.build_skill_workspace(apt, Path(ca))
+                sw, iw = sb.build_skill_workspace(wpt, Path(cb))
+                cpa, cpw = sb.build_task_prompt(apt, sa, ia), sb.build_task_prompt(wpt, sw, iw)
                 self.assertEqual(cpa, cpw)
                 self.assertEqual(sa, sw)                   # identical relative mounts
                 leaks["codex_prompt"] = cpa
@@ -1602,13 +1602,13 @@ class AblationReviewFixesTests(unittest.TestCase):
             base = {"skill_paths": [str(skill / "SKILL.md")], "input_files": [], "prompt": "x"}
             with tempfile.TemporaryDirectory() as w1:
                 ws = Path(w1)
-                sk, _ = sb.codex_skill_workspace(sb.PreparedTask.from_row({**base, "variant": "without_skill"}), ws)
+                sk, _ = sb.build_skill_workspace(sb.PreparedTask.from_row({**base, "variant": "without_skill"}), ws)
                 self.assertEqual(sk, [])                       # without_skill mounts no skill
                 self.assertFalse((ws / "skills").exists())
-                self.assertIn("Do not use any skill", sb.codex_task_prompt(sb.PreparedTask.from_row({"variant": "without_skill", "prompt": "x"}), sk, []))
+                self.assertIn("Do not use any skill", sb.build_task_prompt(sb.PreparedTask.from_row({"variant": "without_skill", "prompt": "x"}), sk, []))
             with tempfile.TemporaryDirectory() as w2:
                 ws = Path(w2)
-                sk, _ = sb.codex_skill_workspace(sb.PreparedTask.from_row({**base, "variant": "with_skill"}), ws)
+                sk, _ = sb.build_skill_workspace(sb.PreparedTask.from_row({**base, "variant": "with_skill"}), ws)
                 self.assertTrue(sk and (ws / sk[0]).exists())  # skill mounted inside the isolated workspace
                 self.assertTrue(sk[0].startswith("skills/"))   # workspace-relative, not the original repo path
 
@@ -1621,7 +1621,7 @@ class AblationReviewFixesTests(unittest.TestCase):
             "ablation": {"id": "no-rp", "mode": "instruction_simulated", "population": "answer", "removed_component": "regression-proof"},
             "instruction": "Use the good-pr skill, but simulate this ablation: remove/ignore regression-proof. Expected regression to watch for: accepts weak tests.",
         }
-        sim_prompt = sb.codex_task_prompt(sb.PreparedTask.from_row(sim), skills, [])
+        sim_prompt = sb.build_task_prompt(sb.PreparedTask.from_row(sim), skills, [])
         self.assertIn("simulate this ablation", sim_prompt)
         self.assertIn("regression-proof", sim_prompt)
         # materialized: the on-disk skill is already altered -> blind, no hypothesis text.
@@ -1632,8 +1632,8 @@ class AblationReviewFixesTests(unittest.TestCase):
                          "components": [{"class": "instructions", "mechanism": "section", "skill_root": "skills/root-0/SKILL.md", "target": {"heading": "## H"}}]},
             "instruction": "Use the skill under test (good-pr). Its files are provided in your workspace ...",
         }
-        mat_prompt = sb.codex_task_prompt(sb.PreparedTask.from_row(mat), skills, [])
-        with_prompt = sb.codex_task_prompt(sb.PreparedTask.from_row({"variant": "with_skill", "prompt": "Review.", "instruction": "x"}), skills, [])
+        mat_prompt = sb.build_task_prompt(sb.PreparedTask.from_row(mat), skills, [])
+        with_prompt = sb.build_task_prompt(sb.PreparedTask.from_row({"variant": "with_skill", "prompt": "Review.", "instruction": "x"}), skills, [])
         self.assertNotIn("simulate", mat_prompt)
         self.assertNotIn("ignore/remove", mat_prompt)
         self.assertNotIn("regression-proof", mat_prompt)
@@ -2315,9 +2315,9 @@ class ConsumersTakeAPreparedTaskTests(unittest.TestCase):
                                prompt="Review.", tags=(), ablation=sim)
 
     def test_codex_prompt_consumes_preparedtask_and_blinds_materialized(self):
-        mat = sb.codex_task_prompt(self.mat_pt(), ["skills/root-0/SKILL.md"], [])
+        mat = sb.build_task_prompt(self.mat_pt(), ["skills/root-0/SKILL.md"], [])
         self.assertNotIn("simulate", mat)                  # materialized arm is blind: no hypothesis text
-        sim = sb.codex_task_prompt(self.sim_pt(), ["skills/root-0/SKILL.md"], [])
+        sim = sb.build_task_prompt(self.sim_pt(), ["skills/root-0/SKILL.md"], [])
         self.assertIn("simulate this ablation", sim)       # instruction-simulated is told what to do
 
     def test_safe_task_json_model_visible_variant_is_owned_by_the_object(self):
@@ -2400,7 +2400,7 @@ class OldSkillParityTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td, tempfile.TemporaryDirectory() as ws:
             p = self.repo(Path(td))
             _, row = self.old_row(p)
-            skill_rel, _ = sb.codex_skill_workspace(sb.PreparedTask.from_row(row), Path(ws))
+            skill_rel, _ = sb.build_skill_workspace(sb.PreparedTask.from_row(row), Path(ws))
             mounted = (Path(ws) / skill_rel[0]).read_text(encoding="utf-8")
             self.assertIn("OLD-MARKER", mounted)
             self.assertNotIn("CURRENT-MARKER", mounted)   # the silent bug: used to mount the current skill


### PR DESCRIPTION
codex_skill_workspace and codex_task_prompt were never Codex-only: run-codex,
run-claude, and run-subagent all build their isolated workspace and task prompt
through these two helpers (each registers codex_skill_workspace as its workspace
builder). Rename them to build_skill_workspace and build_task_prompt so the names
describe the shared behavior instead of one caller. Pure rename, no behavior change.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012PZubijVq4NE5ZAtwwcvL9