### PR TITLE
Make telemetry availability explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install package and dependencies
-        run: python -m pip install -e .
+        run: python -m pip install -e ".[test]"
 
       - name: Compile Python files
         run: python -m py_compile *.py examples/adewale-workspace/*.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,14 @@ uv tool install --editable .
 skill-benchmark --help
 ```
 
-The only runtime dependency is PyYAML (declared in `pyproject.toml`, used to parse skill frontmatter); install it with `pip install -e .` before running tests. CI installs the package this way.
+The only runtime dependency is PyYAML (declared in `pyproject.toml`, used to parse skill frontmatter). Install test dependencies with `pip install -e ".[test]"` before running tests; CI uses that same extra.
 
 ## Validation
 
 Run these before opening a PR:
 
 ```sh
+pip install -e ".[test]"
 python3 -m py_compile *.py examples/adewale-workspace/*.py
 python3 -m unittest discover tests -v
 ```

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -361,3 +361,39 @@ Latest allowlisted Pi generation cost snapshot (`safe-suite-20260630-201448-pi`;
 - Run live parity checks with the smallest models first, and record quota/auth/config failures as eval-run artifacts rather than losing the row.
 
 **Follow-up from PR audit:** these failures were exactly what Correctness by Construction is meant to prevent. The fix was not another scatter of checks; it moved invariants into the adapter boundary: native subprocess calls require an explicit cwd, all native invocations share one process-group timeout/spawn-failure contract, and provider-specific schema conversion constructs a strict schema before Codex ever sees it. Tests now try to reach the invalid states directly: repo-cwd inheritance, missing executable with no artifact, and graded-dimension schemas without strict object constraints.
+
+## 2026-07-10 — Telemetry is evidence, not a nullable number
+
+**Problem:** Normalized telemetry made several materially different states look alike: absent data could be treated as zero, partial traces could support a negative process assertion, legacy numeric fields looked as trustworthy as provider evidence, and unlike currency/basis/model arms could flow into a lift-per-dollar ratio.
+
+**Lesson:** A number becomes decision evidence only with an explicit observation state, provenance, and comparison basis. “No value,” “not applicable,” “known subtotal,” “measured zero,” and “blocked comparison” must remain different states all the way to the report.
+
+**Rule:**
+- Use the schema-v3 typed telemetry envelope as the canonical interior: `available`, `unavailable`, and `not_applicable` measurements; complete/partial aggregates; and comparable/blocked pair results.
+- Never coerce missing telemetry to zero. Preserve a real zero as available evidence, expose partial aggregates only as `known_*` subtotals, and fail process/efficiency assertions closed when trace observation is incomplete.
+- Require matching case/run/model/population/billing/provenance evidence before causal deltas or lift ratios; legacy telemetry stays readable as `legacy_unverified` but cannot establish a causal comparison.
+- Treat currency as a unit, not a display label: preserve object currencies, bucket non-USD amounts, populate dollar fields only from USD evidence, and never use foreign-currency rows in a USD historical-cost denominator without an explicit FX policy.
+- Migration is a data transaction: stage replacements, track which files actually moved/installed, restore only those files on failure, and fault-inject every rename boundary in tests.
+
+## 2026-07-10 — A live smoke passes only when its artifacts pass
+
+**Problem:** The first comprehensive CLI smoke returned success because harness subprocesses exited zero, even when Vibe artifacts contained authentication failures and Pi missed the positive trigger. Its generated trigger fixture initially lacked an explicit negative expectation; persistent output paths also risked running stale tasks after a failed prepare.
+
+**Lesson:** Process exit status proves only that the harness command ran. A smoke is useful only when it validates the semantic artifact contract and its declared fixture population.
+
+**Rule:**
+- Make paid live checks explicit (`--live`) and start with the smallest models, but make failure honest: inspect `execution_valid`, observation completeness, treatment assertions, and trigger pass rows rather than trusting the wrapper's exit code.
+- Require the exact expected fixture set: one positive and one negative trigger query, each once, with no duplicate or substituted row able to satisfy the check.
+- Reject an empty agent selection. Short-circuit an agent after failed `prepare`/run/benchmark prerequisites, and place every invocation in a unique attempt directory so stale artifacts can never spend provider budget.
+- Persist `smoke.json` and all attempt artifacts. Auth/config/model failures are valuable capability findings (for example, missing `MISTRAL_API_KEY` or a small model that does not activate a skill), not results to hide or silently convert to N/A.
+
+## 2026-07-10 — Independent audit should attack the rollback paths
+
+**Problem:** A broad green suite initially missed migration data loss on a second rename failure, a false singleton pairing, cross-currency USD budget dilution, and several smoke false-success paths. These were found by independent reviewers constructing adversarial states rather than by happy-path checks.
+
+**Lesson:** Cross-cutting contracts need adversarial review after implementation, especially where an apparently harmless fallback changes the meaning of evidence.
+
+**Rule:**
+- Split audits by domain integrity, producer/CLI integration, and test/CI quality; give reviewers the PR diff and ask for executable counterexamples.
+- Turn every confirmed finding into a regression test at the boundary: failed second backup, non-finite payload, mixed currency, mismatched run key, partial timeout trace, empty smoke selection, missing polarity row, and failed prerequisite.
+- Re-run the full suite, clean-install test command, packaging build, whitespace/doc-reference guards, and a targeted re-audit after fixes. A passing unit suite alone is not release evidence for a schema, migration, or live-control-plane change.

--- a/README.md
+++ b/README.md
@@ -178,8 +178,9 @@ skill-benchmark --help
 | `docs/academic-grounding.md` | The research constructs behind the harness's terms, with citations; meshes the workflow, measurement, and theory layers. |
 | `docs/jetty-support-spec.md` | Jetty payload/import contract and live-token unknowns. |
 | `docs/trace-aware-eval-spec.md` | Trace artifact contract, shipped v0.4.1 runner support, process/efficiency assertions, and remaining trace work. |
+| `docs/telemetry-availability-and-comparability-spec.md` | Proposed system-wide contract and implementation plan for measured-zero, unavailable, partial, and blocked telemetry/comparisons. |
 | `docs/agent-backend-interface-spec.md` | Draft spec for turning Claude/Codex/Gemini/Vibe support into a shared agent backend interface: parity matrix, judge backends, trigger adapters, telemetry, and tool replay. |
-| `docs/agent-cli-control-plane.md` | The shared native-CLI control plane: process invocation, config isolation, tool policy, final-answer channels, schemas, telemetry, and where Claude/Codex/Vibe intentionally differ. |
+| `docs/agent-cli-control-plane.md` | The shared native-CLI control plane: process invocation, config isolation, tool policy, final-answer channels, schemas, telemetry, where Claude/Codex/Vibe intentionally differ, and the cheap comprehensive live-smoke command. |
 | `docs/agent-cli-tradeoffs.md` | Claude/Codex/Vibe trade-offs: which CLI surfaces are strong or weak, Vibe-only gaps, and what missing schema/telemetry/prompt controls mean for eval reports. |
 | `docs/agent-parity.md` | The per-agent support matrix: which answer/judge/trigger surfaces Claude, Codex, Vibe, Pi, Jetty, subagent, and the stub each cover, with live-smoke status per backend. |
 | `docs/skill-ablation-spec.md` | Design spec for materialized (real, altered skill file) ablations: the three-layer model, manifest schema, removal mechanisms, gates, and phased plan. |
@@ -188,6 +189,7 @@ skill-benchmark --help
 | `TODO.md` | Status tracker: the eval-framework roadmap (implemented, bar two `(TODO-native)` items), the remaining Jetty adapter work (streaming/concurrency, live API validation, judge export, per-variant overrides, the `swap:<id>` ablation follow-on), the agent-backend parity follow-ups (Gemini CLI open; Vibe done), and the migration/user-journey doc backlog. |
 | `examples/demo-skill/` | Self-contained, **offline** end-to-end example: a tiny synthetic skill, two answer-path materialized ablations, one discovery ablation for trigger examples, and a deterministic stub runner (no model/API). `prepare → run-codex → benchmark` confirms a regression per answer-path ablation; exercised by `tests/test_example_demo.py`. Also carries should-fire/should-not-fire trigger cases for `skill-trigger-matrix` (offline via `--agent stub`; live smoke via `RUN_TRIGGER_SMOKE=1`). Start here. |
 | `examples/adewale-workspace/` | Adewale-specific Pi smoke runner and cross-repo aggregate report (the trigger runners are the top-level `skill-pi-trigger-eval` and `skill-trigger-matrix`). |
+| `scripts/smoke_supported_clis.py` | Opt-in, low-cost smoke across native Claude/Codex/Vibe answer paths and Pi trigger path using a disposable demo-skill eval. |
 | `tests/test_skill_benchmark.py` | Executable examples for grading, leakage lint, script assertions, judge commands, Jetty export/import, trace artifacts, and trigger detection. |
 
 ## Manifest format
@@ -444,8 +446,9 @@ above is the five commands you need first (`validate`, `prepare`, `benchmark`,
 
 | Command | What it does |
 |---|---|
-| `skill-benchmark cost-summary` | Suite cost ledger: coverage, totals, by variant/case/runner, top spenders, cost-quality findings. |
-| `skill-benchmark token-overhead` | Static footprint vs. runtime lift-per-token and lift-per-dollar. |
+| `skill-benchmark cost-summary` | Suite cost ledger: complete/partial/unavailable totals, coverage, by variant/case/runner, top spenders, cost-quality findings. |
+| `skill-benchmark migrate-telemetry` | Dry-run or atomically upgrade saved run artifacts to the availability-aware telemetry v3 envelope. |
+| `skill-benchmark token-overhead` | Static footprint vs. runtime lift-per-token and lift-per-dollar, with blocked reasons for incompatible pairs. |
 | `skill-benchmark profile-skill` | `SKILL.md`/reference token counts, module counts, oversize warnings (static, offline). |
 
 **Scale, trend, iteration**
@@ -486,6 +489,7 @@ above is the five commands you need first (`validate`, `prepare`, `benchmark`,
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for local setup, validation commands, and eval-safety rules. The short version:
 
 ```bash
+pip install -e ".[test]"
 python3 -m py_compile *.py examples/adewale-workspace/*.py
 python3 -m unittest discover tests -v
 ```
@@ -528,6 +532,7 @@ skill-eval-harness/
 ## Development
 
 ```bash
+pip install -e ".[test]"
 python3 -m py_compile *.py examples/adewale-workspace/*.py
 python3 -m unittest discover tests -v
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -71,7 +71,7 @@ Jetty runbooks emit a standardized machine-readable `validation_report.json` per
 (`jettyio/jettyio-skills`, `skills/create-runbook/SKILL.md`). Rubric evaluation scores 3-7
 dimensions on a 1-5 scale; programmatic evaluation returns `PASS` / `PARTIAL` / `FAIL`. The
 items below map that report onto the harness judge-result row `{judge_task_id, passed, score,
-threshold, evidence}` (`load_judge_results:4890`, merged in `grade_case_variant:5980`).
+threshold, evidence}` (`load_judge_results:5029`, merged in `grade_case_variant:6127`).
 
 - [ ] Export qualitative judge tasks to Jetty workflows using `simple_judge` where useful.
       Carry `judge_task_id` (`case::variant::run-n::assertion`) into the Jetty task so the
@@ -168,10 +168,17 @@ Mistral support should mean first-class Vibe CLI support, not a raw chat-complet
       smoke-test environment documentation for Vibe.
 - [x] Add a registry/conformance guard that fails when a backend is partially registered (for
       example `run-agent` supports it but parity docs or capability rows do not).
-
 Standing invariant (not a tickable task): `--judge-cmd` stays the escape hatch for arbitrary
 providers while first-class backends move through the native registry — the code documents it
 as "the universal escape hatch" and `judge` points unknown backends at it.
+
+- [ ] Apply the explicit availability/comparability approach to every cross-lab CLI wrapper:
+      model prompt transport, final-answer channels, schema support, tool policy, config isolation,
+      skill discovery, trace completeness, failure semantics, and telemetry as typed capabilities
+      rather than loose provider dictionaries or implied parity. Keep thin native adapters—not a
+      lowest-common-denominator wrapper—and add conformance fixtures for each declared surface.
+      Design: [`docs/telemetry-availability-and-comparability-spec.md`](docs/telemetry-availability-and-comparability-spec.md)
+      § “Follow-on: cross-lab CLI wrappers” and [`docs/agent-cli-control-plane.md`](docs/agent-cli-control-plane.md).
 
 ---
 

--- a/ablation_model.py
+++ b/ablation_model.py
@@ -130,7 +130,7 @@ class RunnerOutcome:
     answer: Optional[str] = None
     returncode: Optional[int] = None
     timed_out: bool = False
-    elapsed_ms: int = 0
+    elapsed_ms: Optional[int] = None
     stderr: str = ""
     error: Optional[str] = None
     timeout_s: Optional[int] = None

--- a/agent_capabilities.py
+++ b/agent_capabilities.py
@@ -11,6 +11,27 @@ from dataclasses import asdict, dataclass
 from typing import Literal
 
 CostSupport = Literal["provider_reported", "trace_normalized", "price_table_estimated", "missing", "not_applicable"]
+Availability = Literal["available", "unavailable", "not_applicable"]
+
+
+@dataclass(frozen=True)
+class TelemetryCapability:
+    """Declared evidence contract for one runner signal.
+
+    This is intentionally not a promise that a provider has internal statistics;
+    it describes what the harness can observe on its supported CLI surface.
+    """
+
+    availability: Availability
+    provenance: str | None = None
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.availability == "available":
+            if not self.provenance or self.reason is not None:
+                raise ValueError("available telemetry needs provenance and no reason")
+        elif not self.reason or self.provenance is not None:
+            raise ValueError("unavailable/not-applicable telemetry needs reason only")
 
 
 @dataclass(frozen=True)
@@ -24,10 +45,39 @@ class AgentCapabilities:
     judge_backend: bool
     tool_replay: bool
     live_smoke_env: str | None
+    elapsed_ms: Availability = "available"
     notes: str = ""
 
+    def telemetry_contract(self) -> dict[str, TelemetryCapability]:
+        """Per-signal declaration used by artifacts, docs, and conformance tests."""
+        cost = (
+            TelemetryCapability("available", provenance=self.dollar_cost)
+            if self.dollar_cost not in {"missing", "not_applicable"}
+            else TelemetryCapability(
+                "not_applicable" if self.dollar_cost == "not_applicable" else "unavailable",
+                reason="offline_runner" if self.dollar_cost == "not_applicable" else "runner_does_not_report_cost",
+            )
+        )
+        usage = (
+            TelemetryCapability("available", provenance="provider_reported")
+            if self.token_usage else TelemetryCapability("unavailable", reason="runner_does_not_report_usage")
+        )
+        return {
+            "usage": usage,
+            "cost": cost,
+            "elapsed_ms": (
+                TelemetryCapability("available", provenance="trace_normalized")
+                if self.elapsed_ms == "available"
+                else TelemetryCapability(self.elapsed_ms, reason="offline_runner" if self.elapsed_ms == "not_applicable" else "runner_does_not_measure_elapsed")
+            ),
+            "trace": (TelemetryCapability("available", provenance="trace_normalized")
+                      if self.trace_artifacts else TelemetryCapability("unavailable", reason="runner_does_not_write_trace")),
+        }
+
     def as_dict(self) -> dict[str, object]:
-        return asdict(self)
+        data = asdict(self)
+        data["telemetry"] = {name: asdict(cap) for name, cap in self.telemetry_contract().items()}
+        return data
 
 
 AGENT_CAPABILITIES: dict[str, AgentCapabilities] = {
@@ -113,6 +163,7 @@ AGENT_CAPABILITIES: dict[str, AgentCapabilities] = {
         judge_backend=False,
         tool_replay=False,
         live_smoke_env=None,
+        elapsed_ms="not_applicable",
         notes="Offline deterministic demo/CI adapter; never spends model tokens.",
     ),
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ the [README](../README.md#commands) carries the grouped index.
 Design records for shipped or in-flight subsystems:
 [`skill-ablation-spec.md`](skill-ablation-spec.md),
 [`trace-aware-eval-spec.md`](trace-aware-eval-spec.md),
+[`telemetry-availability-and-comparability-spec.md`](telemetry-availability-and-comparability-spec.md),
 [`eval-framework-roadmap-spec.md`](eval-framework-roadmap-spec.md),
 [`jetty-support-spec.md`](jetty-support-spec.md), and
 [`agent-backend-interface-spec.md`](agent-backend-interface-spec.md).

--- a/docs/abstractions.md
+++ b/docs/abstractions.md
@@ -133,10 +133,10 @@ editor. This boundary is the main extension seam in the codebase.
 
 A runner consumes task rows and produces the contract. The repo ships seven paths plus a
 generic one: Pi smoke (`examples/adewale-workspace/run_pi_smoke.py`), Pi trigger
-(`run_pi_trigger_eval.py`), Codex (`run_codex:4256`), Claude (`run_claude:4374`, capturing real
+(`run_pi_trigger_eval.py`), Codex (`run_codex:4395`), Claude (`run_claude:4513`, capturing real
 per-run cost), Mistral Vibe (`run-agent --agent vibe`, using isolated `VIBE_HOME` outside the workdir), the in-process
-subagent runner (`run_subagent:5567`, which hosts record/replay tool I/O via `ToolReplayStore`),
-Jetty (`JettyClient:2217` and the export/run/import commands), and any runner that writes the
+subagent runner (`run_subagent:5714`, which hosts record/replay tool I/O via `ToolReplayStore`),
+Jetty (`JettyClient:2219` and the export/run/import commands), and any runner that writes the
 contract directly. Each runner registers a workspace builder so
 one cross-runner invariant proves its `without_skill` arm is skill-free (CF.2). The harness
 calls no model itself; it reads what the runner left behind.
@@ -178,7 +178,7 @@ a re-grade cheap and deterministic.
 normalized gain, and a flag when the skill hurts). `build_slice_summary` breaks results down
 by domain, difficulty, trigger type, and success goal. Case flags mark saturated, no-lift,
 flaky, and with-skill-failed cases. These flags, the leakage lint
-(`prompt_assertion_leakage_findings:363`), and the split discipline are the part of the tool
+(`prompt_assertion_leakage_findings:365`), and the split discipline are the part of the tool
 no surveyed eval framework copies.
 
 ## What changes when you extend the tool

--- a/docs/agent-cli-control-plane.md
+++ b/docs/agent-cli-control-plane.md
@@ -65,3 +65,28 @@ This is intentionally a **control-plane abstraction**, not a lowest-common-denom
 - Telemetry coverage is provider-specific and must be reported, not normalized away.
 
 The rule for future CLIs is: implement the shared contracts, but do not pretend their control surface is identical. Add a capability row, a native answer backend if possible, a trigger adapter only after autonomous skill discovery is proven, and fake/offline conformance tests for prompt transport, config isolation, final answer extraction, telemetry, and failure semantics.
+
+## Cheap comprehensive live smoke
+
+[`scripts/smoke_supported_clis.py`](../scripts/smoke_supported_clis.py) is the
+explicitly opt-in, lowest-cost integration smoke. It builds a disposable one-answer
+paired eval from the bundled demo skill, then runs the native answer path for Claude,
+Codex, and Vibe plus Pi's native trigger path (one positive and one negative trigger
+query). Each invocation creates a unique `attempt-*` child for task rows and artifacts, then
+writes the top-level `smoke.json` with that artifact path; it never deletes or reuses a
+caller-owned directory.
+
+```bash
+./.venv/bin/python scripts/smoke_supported_clis.py \
+  --live \
+  --out-dir /tmp/skill-eval-cli-smoke-$(date +%Y%m%d-%H%M%S)
+```
+
+`--live` is required because this spends provider budget. Defaults are intentionally
+small (`haiku`, `gpt-5.4-mini`, `devstral-small-latest`, and
+`mistral/ministral-3b-latest`); override any model with
+`--claude-model`, `--codex-model`, `--vibe-model`, or `--pi-model` (or the matching
+`SMOKE_*_MODEL` environment variable). Jetty is an API/import surface, not a local
+CLI; retain its separate token-backed smoke. The command exits nonzero unless every selected
+CLI completes its artifact contract and the demo fixtures pass, so incomplete or substituted
+trigger rows and failed provider runs are never reported as a smoke success.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -312,19 +312,19 @@ Probes a judge's stability before you trust its verdicts (model-touching; opt-in
 
 ## Cost telemetry (tokens and dollars)
 
-Cost is a first-class eval signal (issue #21). Every runner path — Pi smoke, Pi trigger, `run-codex`, `run-claude`, `run-subagent`, the judge wrapper, and the Jetty importer — writes two normalized blocks into run metadata beside the raw provider fields (which are preserved unchanged for audit):
+Cost is a first-class eval signal. Every runner path — Pi smoke, Pi trigger, `run-codex`, `run-claude`, `run-subagent`, the judge wrapper, and the Jetty importer — writes legacy-compatible normalized blocks beside raw provider fields **and** an availability-aware telemetry v3 envelope into both `metadata.json` and `metrics.json`.
 
 - `usage_normalized`: alias-normalized token counts (`input`/`prompt_tokens`/`totalTokens`/cache/reasoning variants) with a `source` — `provider_reported` (relayed from the provider), `trace_normalized` (summed from normalized trace events), `estimated`, `missing`, or `not_applicable`.
-- `cost_normalized`: dollar cost with `currency`, per-part costs when reported, and a `source` — `provider_reported`, `trace_normalized`, and `price_table_estimated` are never conflated, and **missing cost is marked `missing`, never written as zero**. Provider-reported blocks always beat trace-derived ones; offline/stub runs carry explicit `missing` markers.
+- `cost_normalized`: legacy-compatible dollar block with `currency`, per-part costs, and a source. Its v3 counterpart separates provenance (`provider_reported`, `trace_normalized`, `price_table_estimated`, or `legacy_unverified`) from availability (`available`, `unavailable`, or `not_applicable`). A measured `$0` is available; unknown cost is never zero.
 
 Consumers of the blocks:
 
-- `benchmark`/`aggregate` emit `cost_summary`: coverage (how many runs actually carried telemetry), operational totals (**every run counts here, including execution errors — a timed-out run still cost money — while quality rates keep excluding them**), per-variant token/cost stats (mean/median/p90), per-case spend, paired `with - without` cost deltas, ablation marginal cost and cost per confirmed regression, and judge spend as its own line (never folded into model-under-test cost).
+- `benchmark`/`aggregate` emit `cost_summary`: availability-aware coverage and operational totals (**every run counts here, including execution errors — a timed-out run still cost money — while quality rates keep excluding them**). A mixed set renders a partial known subtotal, not a false total. Per-variant stats, per-case spend, paired deltas, ablation marginal cost, and judge spend retain their basis/provenance.
 - `cost-summary` writes the standalone suite ledger (`--out cost-summary.json`, `--md cost-summary.md`): coverage, totals, by variant/case/runner, top expensive cases and ablation arms, and `cost_quality_findings` when a `--benchmark` report is joined.
 - `suite-run` projects spend **before any model call** from previous ledgers (`--cost-history <dir>`, per-run medians) or a static assumption (`--assumed-tokens-per-run`), and gates on `--max-estimated-tokens` / `--max-estimated-cost-usd` — failing closed when a dollar cap is set but no dollar estimate exists — unless `--allow-over-budget`.
 - `audit-manifest --runs` adds cost-quality findings above `--expensive-case-usd` (default $1): `expensive-saturated-case`, `expensive-no-lift-case`, `high-cost-judge-only-case`, `ablation-high-spend-no-structured-regression`, and `high-footprint-low-lift-skill`.
 
-Interpretation rule: `provider_reported` numbers are a direct provider envelope; `trace_normalized` reconstructs usage or cost from event streams; `missing` means the run truly carried no telemetry — fix the runner path rather than treating it as free. The keep/trim/cut walkthrough is [`is-my-skill-worth-its-tokens.md`](is-my-skill-worth-its-tokens.md).
+Interpretation rule: `provider_reported` numbers are a direct provider envelope; `trace_normalized` reconstructs usage or cost from event streams; `unavailable` means the run carried no usable telemetry — fix the runner path rather than treating it as free. Lift-per-dollar is emitted only for scorable, basis-compatible paired costs with a strictly positive incremental cost; otherwise JSON/Markdown report a blocked reason. The complete contract and migration policy are in [`telemetry-availability-and-comparability-spec.md`](telemetry-availability-and-comparability-spec.md).
 
 ```bash
 skill-benchmark cost-summary \
@@ -334,6 +334,15 @@ skill-benchmark cost-summary \
   --out cost-summary.json \
   --md cost-summary.md
 ```
+
+Upgrade existing run directories without guessing provenance:
+
+```bash
+skill-benchmark migrate-telemetry --runs ../repo/eval-runs/latest --check
+skill-benchmark migrate-telemetry --runs ../repo/eval-runs/latest
+```
+
+The first command is byte-preserving; the second atomically adds schema v3 envelopes and any missing sibling artifact. Legacy numeric values are labelled `legacy_unverified` and do not qualify for causal lift-per-dollar comparisons.
 
 ## Profile skill size and references
 

--- a/docs/eval-framework-roadmap-spec.md
+++ b/docs/eval-framework-roadmap-spec.md
@@ -17,7 +17,7 @@ One invariant governs every item: core grading stays local and deterministic and
 model, and the harness never picks a model for the user. Anything that needs a model lives
 behind an opt-in command or the external `--judge-cmd`. Two abstractions absorb most of the
 work, so the spec returns to them often: the assertion result shape in `assertion_result`
-(`skill_benchmark.py:4679`) and the fan-out in `prepared_task_rows` (`:738`).
+(`skill_benchmark.py:4818`) and the fan-out in `prepared_task_rows` (`:740`).
 
 ## Testing baseline
 
@@ -40,7 +40,7 @@ tests are where that claim is checked rather than trusted.
 
 The buckets below extend what the harness can measure. This floor decides whether the number it
 already prints can be believed. The harness reports one thing: lift, `with_skill` minus
-`without_skill` on the same case (`build_paired_summary` (`:6598`)). That number is believable only
+`without_skill` on the same case (`build_paired_summary` (`:6759`)). That number is believable only
 when three preconditions hold, each intended today, none enforced, and each restating a claim from
 `evals-are-not-tests.md`:
 
@@ -60,22 +60,22 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
   hiding the quantity the tool exists to measure.
 - **Abstractions used or changed:** none in the engine. Adds
   `tests/fixtures/detectors/<detector_id>/should-fire.*` and `should-pass.*` that exercise
-  `assertion_result` (`:4679`) directly. That function has no direct unit test today, and its
+  `assertion_result` (`:4818`) directly. That function has no direct unit test today, and its
   `contains_any`, `excludes_any`, and `not_regex` branches go unexercised even though their types
-  are declared in the assertion registries (`TEXT_ASSERTIONS:67`).
+  are declared in the assertion registries (`TEXT_ASSERTIONS:69`).
 - **Design:** one table-driven test loads every pair and asserts the detector fires on `should-fire`
   and stays silent on `should-pass`. A `should-pass` twin is mandatory: it enforces the
   false-positive bar `authoring-evals.md` already sets for skill authors ("check both presence and
   absence"). Each `should-pass` set includes a case where the baseline echoes the prompt, because a
   detector that passes on echoed prompt text is a false oracle; this ties the fixtures to leakage
-  lint (`prompt_assertion_leakage_findings` (`:363`)). Every detector bug then becomes a permanent
+  lint (`prompt_assertion_leakage_findings` (`:365`)). Every detector bug then becomes a permanent
   fixture pair, and `test_command_assertions_match_command_inputs_not_outputs` is the first.
 - **Why it is the keystone:** the fixture pair is also the registration contract. It is what lets a
   harvested or third-party detector be trusted on entry, so it gates the exapted detector library
   (TODO, end of 2026), and it raises the oracle-strength ladder (1.7) so that "strong" means
   fixture-verified, not only deterministic.
 - **Testing:** the fixtures are the test. A meta-test asserts every name in `OBJECTIVE_ASSERTIONS`
-  (`:95`) has a fixture pair, so a new detector cannot land unverified.
+  (`:97`) has a fixture pair, so a new detector cannot land unverified.
 
 ### CF.2 — One cross-runner baseline-isolation invariant
 - **Goal:** prove the baseline is skill-free by construction, so a measured lift is the skill's
@@ -101,7 +101,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 ### CF.4 — A guard that the core grade path calls no model and no network
 - **Goal:** make the governing invariant — "core grading stays local and deterministic and never
   calls a model" — executable rather than aspirational.
-- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:5980`).
+- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:6127`).
 - **Design:** patch `urllib` and `subprocess` to raise, then grade a fixture covering every
   objective family (text, process, efficiency) and assert it completes. The sanctioned exceptions —
   `script` oracles and `judge` plumbing — are excluded from this path by design and keep their own
@@ -111,7 +111,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 
 ### Boundary
 The set stops here deliberately. Report-level correctness — whether the saturation, no-lift, flaky,
-and negative-delta flags (`build_benchmark_report` (`:7275`)) are computed right — sits a layer
+and negative-delta flags (`build_benchmark_report` (`:7634`)) are computed right — sits a layer
 above the raw measurement, where the golden-report tests the buckets already plan (1.2, 2.6) cover
 it. CF.1–CF.4 are the floor underneath that work: once they pass, a printed lift carries a checked
 measurement, and every feature in the buckets builds on a number that has been verified rather than
@@ -125,9 +125,9 @@ assumed.
 - **Goal:** ship graders authors reach for often, so they stop hand-rolling rubrics.
 - **Abstractions used or changed:** `tool_call` and `structured_output` are deterministic, so
   they become new types in `TEXT_ASSERTIONS` / `PROCESS_ASSERTIONS` and gain a branch in
-  `assertion_result`. `tool_call` reuses `command_events` (`:2814`) and the `command_order`
+  `assertion_result`. `tool_call` reuses `command_events` (`:2828`) and the `command_order`
   logic; `structured_output` extends `json_field_equals` with JSON-Schema validation.
-  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:4944`) renders
+  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:5083`) renders
   and still runs through `--judge-cmd`.
 - **Design:** a preset expands to either a deterministic objective assertion or a `judge`
   assertion with a canned rubric and threshold. No new execution path.
@@ -146,7 +146,7 @@ assumed.
 ### 1.3 Judge config slot and the "judge is not the model under test" guard
 - **Goal:** make an existing convention enforceable.
 - **Abstractions used or changed:** read an optional `judge` block in the manifest; add a check
-  in `audit_manifest_report` (`:8918`) comparing the declared judge model against `jetty.model`
+  in `audit_manifest_report` (`:9541`) comparing the declared judge model against `jetty.model`
   or the run metadata `model`.
 - **Design:** warn by default, error under `--strict-judge`.
 - **Testing:** unit tests for matching and differing model ids.
@@ -163,7 +163,7 @@ assumed.
 - **Status:** `docs/authoring-evals.md` shipped, alongside `architecture.md` and
   `abstractions.md`.
 - **Follow-on:** surface the guide's rules where they are checkable. Extend the messaging in
-  `prompt_assertion_leakage_findings` (`:363`) and `fixture_recommendations` (`:8660`) to point
+  `prompt_assertion_leakage_findings` (`:365`) and `fixture_recommendations` (`:9283`) to point
   at the relevant section.
 - **Testing:** assert the new hint strings appear for crafted manifests.
 
@@ -172,8 +172,8 @@ assumed.
   In `adewale/pythonbyexample` and `adewale/xampler` an example *is* an eval case: an input, an
   expected output, and a check that the output still matches. The harness has no equivalent of
   "this output equals this reference."
-- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:67`), implemented in
-  `assertion_result` (`:4679`). It reads `output.md` (or a named artifact), applies an optional
+- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:69`), implemented in
+  `assertion_result` (`:4818`). It reads `output.md` (or a named artifact), applies an optional
   normalization (trim, collapse whitespace, or a named normalizer), and compares to a reference
   file under the manifest dir. Evidence is a unified diff on mismatch.
 - **Design:** normalization is the whole game, so it is explicit and per-assertion, never
@@ -188,9 +188,9 @@ assumed.
   not name it.
 - **Abstractions used or changed:** an optional `oracle` tier on an assertion
   (`strong` / `demo` / `live`), defaulting by type (deterministic text/process are `strong`,
-  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:7275`)
+  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:7634`)
   reports, per case, the share of its pass rate carried by `strong` oracles;
-  `audit_manifest_report` (`:8918`) warns when a case passes only on weak ones. This extends
+  `audit_manifest_report` (`:9541`) warns when a case passes only on weak ones. This extends
   leakage lint (`:164`) from prompts to oracles.
 - **Strongest tier — the rendered-artifact oracle:** the top of the ladder is an oracle that
   builds or renders the artifact and inspects the result, not the source text.
@@ -205,8 +205,8 @@ assumed.
   splits "good poster" into seven `script` oracles, but each is forced all-or-nothing by the
   exit-code-only contract: a poster with six of seven drama carriers fails `drama_oracle` exactly
   like one with zero. That is the binary-saturation problem inside a single oracle.
-- **Abstractions used or changed:** extend `run_script_assertion` (`:4576`) and
-  `assertion_result` (`:4679`) to optionally parse a score from the oracle's stdout — a JSON line
+- **Abstractions used or changed:** extend `run_script_assertion` (`:4715`) and
+  `assertion_result` (`:4818`) to optionally parse a score from the oracle's stdout — a JSON line
   such as `{"score": 6, "max_score": 7}` (normalized to 0-1) — beside the existing
   `pass_exit_code`. The parsed score flows into the `score`/`severity` channel from 2.2, so a
   script oracle becomes a graded dimension while staying fully deterministic and model-free.
@@ -223,9 +223,9 @@ assumed.
   past it — either way, question it. This is the inverse of the saturation flag: saturation marks
   a case as too easy *now*; staleness marks a case that has never discriminated *over time*.
 - **Abstractions used or changed:** reads the cross-run history from 2.6. A `prune` report (or a
-  flag in `build_benchmark_report` (`:7275`)) marks a case a removal candidate when, across the
+  flag in `build_benchmark_report` (`:7634`)) marks a case a removal candidate when, across the
   last N runs, it never failed and never showed lift (`with_skill` == `without_skill` every time).
-  `audit_manifest_report` (`:8918`) lists the candidates; removal stays a human decision.
+  `audit_manifest_report` (`:9541`) lists the candidates; removal stays a human decision.
 - **Design:** the harness suggests, never deletes. A case may be kept deliberately as a
   regression guard even when stale; the report says so rather than acting.
 - **Depends on:** 2.6 (needs run history to judge "never failed over time").
@@ -239,12 +239,12 @@ assumed.
 ### 2.1 Multi-model fan-out (priority)
 - **Goal:** run the same cases across several models and compare lift per model. No surveyed
   framework does this; vitest-evals, eve, and viteval all push it onto the test runner.
-- **Abstractions used or changed:** `prepared_task_rows` (`:738`) gains a `model` dimension
+- **Abstractions used or changed:** `prepared_task_rows` (`:740`) gains a `model` dimension
   beside `variant` and `run_number`. Each row carries its target `model`, and `run_dir` gains a
   model segment (`<case>/<model>/<variant>/run-<n>`), kept backward-compatible when one model
   runs. Runners pass the row `model` through; per-run `model` already lands in `metadata.json`,
-  so grading needs no change. `build_benchmark_report` (`:7275`) groups `by_variant` within
-  `by_model`, and `build_paired_summary` (`:6598`) computes lift per (case, model).
+  so grading needs no change. `build_benchmark_report` (`:7634`) groups `by_variant` within
+  `by_model`, and `build_paired_summary` (`:6759`) computes lift per (case, model).
 - **Design:** model is a third axis, not a new variant. Variants stay orthogonal, giving a
   model-by-variant grid. CLI: `--models a,b,c` on `prepare`.
 - **Testing:** a fan-out test asserting row count equals cases × variants × runs × models with
@@ -261,7 +261,7 @@ assumed.
   no-regression floor. This spec ports those shapes into the harness rather than inventing new
   ones.
 - **Abstractions used or changed:**
-  - `assertion_result` (`:4679`) gains an optional `score` (0-1 or a normalized 1-5) and
+  - `assertion_result` (`:4818`) gains an optional `score` (0-1 or a normalized 1-5) and
     `severity` (`critical` / `gate` / `soft`), read from `critical`/`gate`/`soft`/`atLeast` on the
     assertion.
   - **`critical` (absorbing-barrier) tier — valley-dodging.** From the Jetty "valley-dodging"
@@ -276,13 +276,13 @@ assumed.
   - **Anchored `graded_dimensions`** as a `judge` assertion shape:
     `{name, scale: "1-5", rubric: "5 = …observable…; 1 = …observable…"}`. Anchors name what each
     score level looks like, so a judge scores against criteria, not a vibe. `judge_prompt`
-    (`:4944`) renders the dimensions; the result carries per-dimension scores in `evidence`.
+    (`:5083`) renders the dimensions; the result carries per-dimension scores in `evidence`.
   - **`dynamic_rubric`** as a second `judge` shape: `{instruction, minimum_criteria}`. The judge
     drafts 3-5 case-specific criteria before grading and must meet at least `minimum_criteria`.
-  - `grade_case_variant` (`:5980`) splits totals into critical, gated, and soft. A `critical`
+  - `grade_case_variant` (`:6127`) splits totals into critical, gated, and soft. A `critical`
     failure vetoes the case; a `gate` failure lowers the pass rate; a `soft` failure lowers
     neither and fills a `scored` bucket. A `--strict` flag promotes soft to gate.
-  - **Statistical lift** in `build_paired_summary` (`:6598`): alongside the raw delta, compute a
+  - **Statistical lift** in `build_paired_summary` (`:6759`): alongside the raw delta, compute a
     significance test over the per-case graded scores (paired bootstrap or sign-flip
     permutation, mirroring `score_delta.py`), so lift is tested, not eyeballed.
   - **Reference-anchor floor:** an optional `reference_score` / `reference_graded_score` on a
@@ -315,7 +315,7 @@ assumed.
 - **Goal:** deterministic re-runs that pay nothing for external dependencies, by recording tool
   inputs and outputs.
 - **Abstractions used or changed:** this lives in the runner, not core grading. Recording sits
-  beside `write_trace_artifacts` (`:3601`): a `tool-replay.json` keyed per tool, with
+  beside `write_trace_artifacts` (`:3696`): a `tool-replay.json` keyed per tool, with
   `sanitize` and `version`. Modes (`auto`, `record`, `off`, `strict`) come from an environment
   variable that `run_codex` and the Pi and subagent runners read.
 - **Design:** orthogonal to the disk re-grade the harness already does. Replay makes the agent
@@ -326,8 +326,8 @@ assumed.
 
 ### 2.4 OpenTelemetry GenAI normalization target
 - **Goal:** make the trace adapter boundary a standard rather than a bespoke schema.
-- **Abstractions used or changed:** `normalize_trace_record` (`:3354`) and
-  `normalize_trace_records` (`:3464`) keep their inputs but emit OTel GenAI semantic-key
+- **Abstractions used or changed:** `normalize_trace_record` (`:3442`) and
+  `normalize_trace_records` (`:3552`) keep their inputs but emit OTel GenAI semantic-key
   attributes; the `events.json` schema version bumps. Process and efficiency assertions read the
   new keys with backward-compatible fallbacks.
 - **Design:** additive schema. An old `events.json` still grades.
@@ -337,7 +337,7 @@ assumed.
 ### 2.5 Dataset abstraction
 - **Goal:** fan one case template over many rows instead of hand-authoring each case.
 - **Abstractions used or changed:** a new optional manifest construct (`datasets`, plus a case
-  `template` referencing a dataset id). `iter_cases` (`:260`) materializes template by row into
+  `template` referencing a dataset id). `iter_cases` (`:262`) materializes template by row into
   concrete cases before fan-out; `validate_manifest` validates rows and runs leakage lint per
   materialized case.
 - **Design:** materialization happens early, so prepare, grade, and report stay unchanged.
@@ -351,7 +351,7 @@ assumed.
 - **Goal:** watch lift, saturation, and token drift over time.
 - **Abstractions used or changed:** a consumer of `build_benchmark_report`. Add an append-only
   history store and a `trend` subcommand that diffs successive `benchmark.json` files, reusing
-  the `compare_results` (`:7707`) logic.
+  the `compare_results` (`:8101`) logic.
 - **Severity-weighted ranking (from the macro-evals notebook):** when surfacing recurring
   failures across runs, rank them by `prevalence × severity`, not raw count, so a rare but severe
   failure outranks a common trivial one. This is the floor-raising principle made quantitative;
@@ -377,8 +377,8 @@ assumed.
   it dispatches a subagent with a rubric whose "criteria [are] deliberately absent from
   generation rules."
 - **Abstractions used or changed:** mostly a discipline made first-class, not new machinery.
-  `prepared_task_rows` (`:738`) already omits `review_rubric` from generation payloads unless
-  `--include-answer-key`; extend `validate_manifest` (`:517`) to require that a `holdout`/
+  `prepared_task_rows` (`:740`) already omits `review_rubric` from generation payloads unless
+  `--include-answer-key`; extend `validate_manifest` (`:519`) to require that a `holdout`/
   `holdback` case's rubric stays out of the skill and public eval text, and pair it with the
   subagent judge from 2.7 and the graded scoring from 2.2. Track which rubrics were held out so
   the report can separate held-out scores from tune-visible ones.
@@ -390,7 +390,7 @@ assumed.
 ### 2.8 Interactive served report and richer artifacts
 - **Goal:** capture feedback in the browser and render image, PDF, and xlsx artifacts, beyond the
   static `render_viewer`.
-- **Abstractions used or changed:** extend `render_viewer` (`:8305`) with a `serve` mode and
+- **Abstractions used or changed:** extend `render_viewer` (`:8808`) with a `serve` mode and
   artifact encoders. Anthropic's `eval-viewer/generate_review.py` is the blueprint, including
   `feedback.json` persistence and a `--previous-workspace` diff.
 - **Testing:** unit-test the artifact embedding and categorization and the feedback round trip;
@@ -422,7 +422,7 @@ assumed.
 - **Goal:** evaluate conversational skills across a send/respond sequence.
 - **Abstractions changed (core contract):** a case gains an optional `turns` list. The
   run-output contract grows from one `output.md` to a turn-indexed transcript, so
-  `read_output_base` (`:2720`) and `discover_run_bases` learn the turn layout; runners drive the
+  `read_output_base` (`:2734`) and `discover_run_bases` learn the turn layout; runners drive the
   sequence; `grade_case_variant` grades per turn and aggregates.
 - **Design:** single-shot stays the default, so existing manifests are untouched.
 - **Testing:** a fixture multi-turn run asserting per-turn grading and aggregate, plus a
@@ -435,7 +435,7 @@ assumed.
   the model axis, plus a viewer panel.
 - **Slice-lift concentration (from the macro-evals notebook):** compute, per slice, where lift (or
   a failure) concentrates — `slice share ÷ overall share`, the macro-eval `lift` metric one level
-  up from per-case lift. `build_slice_summary` (`:6733`) already groups by domain/difficulty/
+  up from per-case lift. `build_slice_summary` (`:6894`) already groups by domain/difficulty/
   trigger/goal, so this is a ratio over groups it already forms, not new plumbing.
 - **Testing:** a report test over a two-model by two-variant fixture grid, plus a concentration
   test asserting a failure confined to one slice scores a high ratio there.
@@ -548,7 +548,7 @@ and upgrading to the new features should be something an agent can drive.
 
 ### Abstractions used or changed
 
-- `version` on the manifest (`validate_manifest:517`) becomes meaningful: `validate` accepts both
+- `version` on the manifest (`validate_manifest:519`) becomes meaningful: `validate` accepts both
   1 and 2, and warns (not errors) on a `version: 1` manifest once 2.2 has landed, pointing at
   `migrate`.
 - No grading abstraction changes for migration itself; it is a source-rewrite plus a guide.

--- a/docs/skill-ablation-spec.md
+++ b/docs/skill-ablation-spec.md
@@ -362,7 +362,7 @@ Opt in with `"invalid_skill": true` on the ablation: the run is tagged
 
 ## Validation additions
 
-`validate_manifest` (`skill_benchmark.py:517`), per ablation:
+`validate_manifest` (`skill_benchmark.py:519`), per ablation:
 
 - `id` unique and slug-formatted; keep `removed_component`.
 - If a removal is declared: exactly one of `mechanism`+`target` or `components`;

--- a/docs/telemetry-availability-and-comparability-spec.md
+++ b/docs/telemetry-availability-and-comparability-spec.md
@@ -1,0 +1,314 @@
+# Telemetry availability and comparability
+
+> **Status:** proposed implementation plan. This supersedes the informal rule that
+> missing telemetry is “marked, never zero” with a complete measurement contract
+> for producers, artifacts, reports, comparisons, exports, and budget decisions.
+>
+> **Related:** [`architecture.md`](architecture.md),
+> [`trace-aware-eval-spec.md`](trace-aware-eval-spec.md),
+> [`agent-backend-interface-spec.md`](agent-backend-interface-spec.md), and
+> [`agent-cli-control-plane.md`](agent-cli-control-plane.md).
+
+## Why this exists
+
+The current per-run normalizers correctly distinguish a missing cost or token value
+from a measured zero. Some downstream folds do not: an empty sum, a display fallback,
+or `value or 0` can turn unknown telemetry into free spend, zero latency, or a valid
+looking efficiency result. The same risk applies beyond dollars: trace-derived counts,
+artifact evidence, durations, grades, estimates, rankings, budgets, and exported
+reports all need to distinguish **observed zero** from **not observed**.
+
+The goal is not to make every field optional. It is to make each observed quantity and
+each claim derived from one explicit about what evidence supports it.
+
+## Goals and non-goals
+
+### Goals
+
+1. Preserve a real zero exactly as an available observation.
+2. Represent unavailable, not-applicable, partial, and blocked states explicitly in
+   machine-readable artifacts and human-readable reports.
+3. Make invalid paired deltas and lift-per-unit ratios unconstructable in the typed
+   interior.
+4. Centralize parsing, provenance, aggregation, comparison, and rendering so runners
+   and reports cannot drift.
+5. Keep quality scoring, execution failure, and telemetry availability as separate
+   dimensions.
+6. Read legacy run directories without inventing provenance or comparability.
+
+### Non-goals
+
+- Infer telemetry that a provider did not expose.
+- Treat unavailable telemetry as an execution failure or a failed grade.
+- Mix answer, trigger, judge, and static populations just because their units match.
+- Add live provider calls to deterministic CI.
+- Redesign objective or qualitative scoring except where a derived comparison must
+  disclose that an arm is unscorable.
+
+## Canonical domain model
+
+`telemetry.py` will own frozen domain objects, smart constructors, the wire parser,
+legacy adaptation, aggregation, comparison, and presentation helpers. Raw JSON is
+accepted only at the boundary and is converted before the rest of the harness uses it.
+
+```text
+Measurement[T] =
+    Available(value, provenance, basis)
+  | Unavailable(reason)
+  | NotApplicable(reason)
+
+Aggregate[T] =
+    Complete(value, observed_count)
+  | Partial(known_subtotal_or_stats, observed_count, unavailable_count, reason_counts)
+  | Unavailable(unavailable_count, reason_counts)
+  | NotApplicable(reason)
+
+Comparison[T] =
+    Comparable(value, basis)
+  | Blocked(reason, left_state, right_state)
+```
+
+### Measurement rules
+
+- `Available` is the **only** state allowed to carry a value. `0` is valid there.
+- `Unavailable` means the measurement could have existed but was not observed, parsed,
+  or trusted. It has a stable reason such as `runner_does_not_report_cost`,
+  `trace_absent`, `malformed_provider_value`, or `legacy_field_absent`.
+- `NotApplicable` means the measurement does not conceptually apply, such as monetary
+  cost for an offline stub. It is not a zero-dollar run.
+- Provenance applies only to available values: `provider_reported`,
+  `trace_normalized`, `price_table_estimated`, `estimated`, or `legacy_unverified`.
+  `missing` is no longer provenance; it is an unavailable state.
+- Money is exact (`Decimal` internally and a canonical decimal string on the wire),
+  non-negative, and always carries an ISO currency. A non-USD amount must not be
+  called `cost_usd`.
+- Token/count values and milliseconds are non-negative integers. Rates are finite and
+  within `[0, 1]` when available.
+- A count or boolean derived from a trace is available only when the observation is
+  complete. A completed trace with zero tool calls is different from no trace.
+
+### Basis and population
+
+An available measurement records enough basis to determine whether arithmetic is
+meaningful: population (`answer`, `trigger`, `judge`, or `static`), case, repetition,
+variant, runner/adapter, provider, model/configuration fingerprint where available,
+skill/manifest revision, billing scope, currency, pricing model/version, trace
+aggregation mode, and artifact schema version.
+
+A comparison policy declares which dimensions may differ. A normal with/without
+experiment may intentionally differ in variant and materialized skill tree, but not in
+case, repetition, model configuration, billing scope, or population. This avoids both
+false matches and an overly rigid raw-dictionary equality check.
+
+## Scope
+
+| Surface | Required treatment |
+|---|---|
+| Token telemetry | Input/output/cache/reasoning/total usage, source, and trace aggregation mode. |
+| Cost telemetry | Parts, total, currency, billing scope, price/version, and provenance. |
+| Runtime telemetry | Duration, command/tool/file/error/retry counts, and observation completeness. |
+| Artifact evidence | Raw trace, events, metrics, parser status, and evidence availability. |
+| Run state | Completion, nonzero exit, timeout, no output, and observation completeness remain outcome facts, not zero-valued metrics. |
+| Grades and rates | Valid zero, no applicable assertions, and unscorable arms remain distinct. |
+| Static estimates | Profiled skill/reference tokens are `static` estimates; they may be shown beside runtime values but never merged with them. |
+| Derived claims | Totals, statistics, rankings, deltas, ratios, trends, audit findings, and budgets use typed aggregates/comparisons. |
+| Presentations | JSON, Markdown, JUnit, GitHub summaries, Anthropic export, and the viewer render availability instead of coercing it. |
+
+## Aggregation and comparison policy
+
+### Aggregates
+
+- A fully observed set produces `Complete(value)`; all observed zero values produce
+  `Complete(0)`, not unavailable.
+- A mixed set produces `Partial(known_subtotal, …)`. The numeric member is explicitly
+  named `known_subtotal`, never `total`.
+- An all-unavailable set produces `Unavailable`, not zero or an empty statistic that
+  callers can accidentally re-sum.
+- Aggregation groups compatible basis buckets. Different currencies, populations, or
+  billing scopes stay separate; no implicit foreign-exchange conversion occurs.
+- Unknown values are excluded from spend rankings and marked unranked, rather than
+  sorted as the cheapest spend.
+
+### Deltas and ratios
+
+Raw deltas may be available when two compatible values exist, including a negative
+cost delta (a saving). A ratio is stricter:
+
+```text
+LiftPerUnit.create(pair) succeeds only when:
+  - both arms are scorable;
+  - numerator and denominator observations are available and comparable;
+  - the denominator is strictly positive; and
+  - the declared pair policy accepts both bases.
+```
+
+Otherwise it returns `Blocked`, with reasons including `missing_left`, `missing_right`,
+`not_applicable`, `currency_mismatch`, `population_mismatch`, `pair_key_mismatch`,
+`basis_mismatch`, `provenance_mismatch`, `unscorable_arm`,
+`non_positive_denominator`, and `insufficient_sample`.
+
+`objective_lift_per_dollar` and `objective_lift_per_1k_total_tokens` are constructed
+only through this API. A cost saving or zero incremental cost can be reported as a
+delta but cannot masquerade as an efficiency ratio.
+
+## Architecture and ownership
+
+### New owner: `telemetry.py`
+
+It owns:
+
+1. domain types and validation;
+2. aliases and provider/trace precedence;
+3. parsing and serialization of the schema-versioned telemetry envelope;
+4. legacy v1/v2 adaptation;
+5. compatible aggregation and statistics;
+6. pair matching, comparison, and ratio construction; and
+7. JSON/Markdown display helpers.
+
+`skill_benchmark.py`, `run_pi_trigger_eval.py`, and `run_trigger_matrix.py` become
+consumers of this API. Direct reads of `usage_normalized`, `cost_normalized`,
+`cost_usd`, `total_tokens`, and telemetry-specific `metric_number(... ) or 0` fallbacks
+outside the boundary adapter are removed.
+
+### Registries
+
+Two registries make complete application enforceable:
+
+- **Signal registry:** unit, applicability, allowed provenance, required basis fields,
+  and display policy for every telemetry signal.
+- **Surface registry:** every CLI/backend/export is declared as a telemetry producer,
+  consumer, presentation surface, pass-through, or telemetry-free command.
+
+Tests derive expected coverage from argparse/backend registries, so adding a new CLI or
+agent without a telemetry decision fails deterministically.
+
+### Artifacts
+
+New runs write `telemetry_schema_version: 3` and one canonical telemetry envelope into
+both `metadata.json` and `metrics.json`; raw provider data remains preserved for audit.
+A writer records precedence and parser errors as data. Metadata/metrics must agree on
+the normalized envelope.
+
+## Implementation sequence
+
+### Phase 0 — decisions, inventory, and characterization
+
+- Publish this contract and decide supported currencies, FX policy, provenance
+  equivalence rules, required basis fields, and deprecation timing.
+- Inventory all raw telemetry reads, empty sums, `or 0` fallbacks, rank keys, and
+  inline delta/ratio arithmetic.
+- Capture reviewed golden fixtures for complete legacy inputs only. Do not characterize
+  existing unknown-to-zero behavior as compatibility.
+
+### Phase 1 — typed boundary and regression tests
+
+- Add `telemetry.py`, schema v3, smart constructors, legacy parser, aggregate types,
+  comparison policy, and presentation helpers.
+- Add focused failing tests for each known defect before changing behavior.
+- Retain temporary compatibility re-exports while producer and consumer paths migrate.
+
+### Phase 2 — migrate every producer
+
+Route these paths through the canonical artifact writer:
+
+- `run-agent`, `run-claude`, `run-codex`, `run-subagent`, and `run-jetty`;
+- `import-jetty-results` and `import-trace`;
+- native/shell/consensus judge paths;
+- `skill-pi-trigger-eval` and `skill-trigger-matrix`.
+
+`RunnerOutcome`, judge outcomes, and agent capabilities carry structured telemetry and
+basis rather than loose `float | None` cost fields and provider dictionaries. The
+capability registry describes support per signal, including why a signal is unavailable.
+
+### Phase 3 — migrate every consumer and derived claim
+
+Replace hand-written folds in benchmark reports, aggregate reports, suite cost ledgers,
+variant summaries, audit findings, historical estimates, trends, exports, and pairwise
+analysis. In particular migrate:
+
+- `benchmark`, `aggregate`, `cost-summary`, and `token-overhead`;
+- `audit-manifest`, `suite-run`, and `trend`;
+- `grade`, `report`, `export-anthropic`, and `render-viewer`;
+- paired quality/token/cost deltas, lift-per-unit metrics, rankings, and budget gates.
+
+Quality populations remain separate from operational spend populations, but both report
+coverage and basis. A dollar budget fails closed when compatible complete history is not
+available.
+
+### Phase 4 — compatibility, documentation, and removal of bypasses
+
+- Add `migrate-telemetry --check|--write` (or an explicit telemetry mode on `migrate`)
+  with atomic writes, dry-run output, backups, and idempotence.
+- Read old artifacts through the adapter. Legacy numeric values are
+  `legacy_unverified` and are not eligible for causal ratios unless repaired with a
+  trustworthy basis.
+- Update command help, examples, vocabulary, architecture, backend interface docs, and
+  user journeys. Document `0`, unavailable, N/A, partial, and blocked rendering.
+- Remove duplicate downstream missing/zero checks only after the boundary and its tests
+  prove the invariant.
+
+## CLI matrix
+
+| Surface | Result |
+|---|---|
+| Answer/import runners | Emit canonical availability, provenance, and basis data; no fabricated zero defaults. |
+| Trigger runners | Record whether observation is complete; absence of a trace cannot become zero tokens, zero tools, or a false negative trigger result. |
+| Judge runners | Keep judge spend/population separate and expose unavailable shell-wrapper telemetry honestly. |
+| `benchmark`, `aggregate`, `cost-summary` | Emit complete/partial/unavailable compatible buckets rather than ambiguous totals. |
+| `token-overhead` | Keep cost and token channels independent; expose pair-level blocked reasons and eligible counts. |
+| `audit-manifest`, `suite-run`, `trend` | Unknown/incompatible history cannot pass thresholds, rank cheaply, or produce a dollar estimate. |
+| Exports/viewer | Omit numeric fields where external schemas require it and add explicit availability annotations; never substitute zero. |
+| `profile-skill` | Clearly label static estimates and prevent mixing with runtime spend. |
+
+## Test strategy
+
+This work follows the techniques in
+[`adewale/testing-best-practices`](https://github.com/adewale/testing-best-practices).
+Tests favor real temporary run trees and provider-shaped fixtures over mocks of the
+telemetry helpers.
+
+| Technique | Application |
+|---|---|
+| Red-green-refactor | A regression test first for every zero-coercion or invalid-ratio path. |
+| Characterization/golden fixtures | Preserve valid legacy complete-input behavior while approving intentional partial/unavailable output changes. |
+| Correctness by construction | Smart-constructor model-gap tests reject unavailable-with-value, negative/non-finite values, incomplete basis, and invalid ratio construction. |
+| Property-based tests | Parser never crashes on arbitrary JSON; encode/decode round-trips; unavailable rows do not change a known subtotal; ratios cannot exist with invalid denominators. |
+| Exhaustive tests | Enumerate availability × provenance × compatibility × denominator sign × scorable state. |
+| Mathematical properties | Compatible exact-money aggregation is permutation-invariant, associative, and commutative; incompatible buckets cannot aggregate. |
+| Contract fixtures | Redacted Claude/Codex/Pi/Jetty/judge streams cover zero, absent, malformed, cumulative, and schema-drift cases without live CI. |
+| CLI E2E/smoke | Local fake-runner workflows exercise every producer and changed consumer against real files. |
+| Documentation-code sync | Command/backend/signal registries must agree with the canonical contract and command docs. |
+| Mutation-style gap analysis | Nightly targeted mutations remove guards, alter `> 0`, swap arms, ignore basis/currency, or coerce unavailable to zero. |
+
+The fast suite must remain deterministic: no live credentials, sleeps, wall-clock
+assertions, weak truthy-only oracles, or mock-only integration tests.
+
+## Acceptance criteria
+
+The implementation is complete only when:
+
+1. no telemetry consumer bypasses the canonical parser/typed domain;
+2. every registered producer writes a valid v3 envelope and metadata/metrics agree;
+3. every CLI/backend/export is represented in the surface registry;
+4. measured zero, unavailable, not-applicable, partial, and blocked states render
+   differently in JSON and human-facing output;
+5. no aggregate labels a partial numeric as a total;
+6. every ratio carries eligible/blocked counts and stable blocked reasons;
+7. unknown/incompatible values cannot affect rankings, audits, trends, or budget passes
+   as if they were zero;
+8. legacy artifacts remain readable without acquiring false provenance; and
+9. property, fixture-contract, CLI E2E, doc-sync, and targeted mutation gates pass.
+
+## Follow-on: cross-lab CLI wrappers
+
+The same pattern applies beyond telemetry. Native wrappers around Claude, Codex, Gemini,
+Vibe, Jetty, and future lab CLIs should use explicit availability/capability and
+comparability contracts for prompt transport, final-answer channels, schema support,
+tool policy, configuration isolation, skill discovery, trace completeness, failure
+semantics, and telemetry.
+
+The aim is not a lowest-common-denominator wrapper: thin provider adapters retain their
+native controls, while a typed shared contract makes unsupported or incomparable surfaces
+explicit. This extends the control-plane approach in
+[`agent-cli-control-plane.md`](agent-cli-control-plane.md) and is tracked in
+[`TODO.md`](../TODO.md).

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -93,7 +93,7 @@ Trigger polarity is the load-time analogue, defined under **Trigger / no-trigger
 
 **`metadata.json`** — optional per-run telemetry: elapsed time, token counts, model name, and the normalized cost blocks below.
 
-**`usage_normalized` / `cost_normalized`** — the normalized token and dollar blocks every runner writes into a run's metadata/metrics, alongside the raw provider fields. Each carries a `source` provenance: `provider_reported`, `trace_normalized`, `missing`, or `not_applicable`, plus `estimated` for usage and `price_table_estimated` for cost. Missing telemetry is marked, never written as zero — so the report can total real spend and disclose coverage separately from quality.
+**`usage_normalized` / `cost_normalized`** — legacy-compatible normalized token and dollar blocks every runner writes alongside raw provider fields. Schema-v3 `telemetry` is the canonical contract: it separates provenance (`provider_reported`, `trace_normalized`, `price_table_estimated`, `estimated`, or `legacy_unverified`) from availability (`available`, `unavailable`, or `not_applicable`). A measured zero is available; unavailable telemetry is never numeric zero. See [`telemetry-availability-and-comparability-spec.md`](telemetry-availability-and-comparability-spec.md).
 
 **Trace artifacts** — what a trace-aware runner writes so process and efficiency assertions have evidence:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ classifiers = [
   "Topic :: Software Development :: Testing",
 ]
 
+[project.optional-dependencies]
+test = ["pytest>=8", "hypothesis>=6"]
+
 [project.urls]
 Homepage = "https://github.com/adewale/skill-eval-harness"
 Repository = "https://github.com/adewale/skill-eval-harness"
@@ -36,7 +39,7 @@ skill-pi-trigger-eval = "run_pi_trigger_eval:main"
 skill-trigger-matrix = "run_trigger_matrix:main"
 
 [tool.setuptools]
-py-modules = ["skill_benchmark", "run_pi_trigger_eval", "run_trigger_matrix", "ablation_model", "agent_capabilities"]
+py-modules = ["skill_benchmark", "run_pi_trigger_eval", "run_trigger_matrix", "ablation_model", "agent_capabilities", "telemetry"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/run_pi_trigger_eval.py
+++ b/run_pi_trigger_eval.py
@@ -145,7 +145,9 @@ def run_query(manifest_path: Path, query: str, should_trigger: bool, timeout: in
             ablation_field = ablation
             skill_tree_hash = (abl_prov or {}).get("skill_tree_hash")
         result = {
+            "population": "trigger",
             "query": query,
+            "model": model,
             "should_trigger": should_trigger,
             "triggered": triggered,
             # RAW measurement, NOT a confirmed ablation effect: this is one arm's
@@ -155,6 +157,7 @@ def run_query(manifest_path: Path, query: str, should_trigger: bool, timeout: in
             "pass": returncode == 0 and triggered == should_trigger,
             "measurement": EvidenceClass.RAW_MEASUREMENT.value,
             "elapsed_ms": elapsed_ms,
+            "observation_complete": bool(run.get("observation_complete", returncode == 0 and not timed_out)),
             "returncode": returncode,
             "timed_out": timed_out,
             "evidence": evidence,

--- a/run_trigger_matrix.py
+++ b/run_trigger_matrix.py
@@ -424,7 +424,7 @@ class VibeAdapter(AgentAdapter):
                                            max_turns=self.max_turns)
             except ValueError as exc:
                 return {"stdout": "", "stderr": str(exc), "returncode": 127, "timed_out": False,
-                        "elapsed_ms": 0, "observation_complete": False,
+                        "elapsed_ms": None, "observation_complete": False,
                         "config_isolated": True,
                         "vibe_env_file_copied": env_meta.get("vibe_env_file_copied", False),
                         "vibe_home_outside_workdir": True}
@@ -468,7 +468,7 @@ class StubAdapter(AgentAdapter):
                     {"type": "tool_use", "name": "Read", "input": {"file_path": str(skill_md)}}]}}))
         lines.append(json.dumps({"type": "result", "subtype": "success"}))
         return {"stdout": "\n".join(lines) + "\n", "stderr": "", "returncode": 0, "timed_out": False,
-                "elapsed_ms": 0, "observation_complete": True}
+                "elapsed_ms": None, "observation_complete": True}
 
 
 ADAPTERS: dict[str, type[AgentAdapter]] = {"claude": ClaudeAdapter, "codex": CodexAdapter, "pi": PiAdapter, "vibe": VibeAdapter, "stub": StubAdapter}
@@ -511,6 +511,7 @@ def matrix_failure_row(agent: str, model: str | None, query: str, should_trigger
                        exc: BaseException, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
     message = f"{type(exc).__name__}: {exc}"
     row: dict[str, Any] = {
+        "population": "trigger",
         "agent": agent,
         "model": model,
         "query": query,
@@ -520,7 +521,7 @@ def matrix_failure_row(agent: str, model: str | None, query: str, should_trigger
         "observation_complete": False,
         "returncode": None,
         "timed_out": False,
-        "elapsed_ms": 0,
+        "elapsed_ms": None,
         "evidence": [],
         "usage_normalized": {"source": "missing"},
         "cost_normalized": {"source": "missing"},
@@ -556,6 +557,7 @@ def run_cell_query(adapter: AgentAdapter, tree_dir: Path, query: str, should_tri
         usage, cost = {"source": "missing"}, {"source": "missing"}
     observation_complete = bool(result["observation_complete"])
     row = {
+        "population": "trigger",
         "agent": adapter.name,
         "model": model,
         "query": query,
@@ -581,6 +583,7 @@ def run_cell_query(adapter: AgentAdapter, tree_dir: Path, query: str, should_tri
     if trace_dir is not None:
         row["trace_dir"] = str(trace_dir)
         trace_metadata = {
+            "population": "trigger",
             "provider": adapter.name,
             "model": model,
             "returncode": row["returncode"],

--- a/scripts/smoke_supported_clis.py
+++ b/scripts/smoke_supported_clis.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Run the cheapest meaningful live smoke across native AI-lab CLIs.
+
+This is intentionally an opt-in operational check, not a test-suite member. It
+creates a disposable one-answer/two-trigger case using the bundled demo skill,
+then exercises the native answer path for Claude, Codex, and Vibe plus Pi's
+native trigger path. It never reads credentials; each CLI retains its normal
+isolated-home/auth behavior through the harness.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MODELS = {
+    "claude": os.environ.get("SMOKE_CLAUDE_MODEL", "haiku"),
+    "codex": os.environ.get("SMOKE_CODEX_MODEL", "gpt-5.4-mini"),
+    "vibe": os.environ.get("SMOKE_VIBE_MODEL", "devstral-small-latest"),
+    "pi": os.environ.get("SMOKE_PI_MODEL", "mistral/ministral-3b-latest"),
+}
+ANSWER_AGENTS = ("claude", "codex", "vibe")
+SMOKE_TRIGGER_EXPECTATIONS = (
+    ("Review this code change and label the severity of each finding.", True),
+    ("What is the capital of France?", False),
+)
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def make_smoke_repo(root: Path) -> Path:
+    """Copy only the demo skill and write the minimum answer+trigger manifest."""
+    source = ROOT / "examples" / "demo-skill" / "skills" / "demo"
+    destination = root / "skills" / "demo"
+    shutil.copytree(source, destination)
+    manifest = {
+        "version": 1,
+        "skill_name": "demo-reviewer-live-smoke",
+        "skill_paths": ["skills/demo/SKILL.md"],
+        "variants": ["with_skill", "without_skill"],
+        "cases": [
+            {
+                "id": "answer",
+                "split": "tune",
+                "kind": "review",
+                "prompt": "Review this change: it adds an HTTP endpoint with no test. Give me your review.",
+                "assertions": [{"name": "severity", "type": "contains_any", "values": ["Blocking", "Minor", "Clean"]}],
+            },
+            {
+                "id": "trig-pos-review-change",
+                "split": "tune",
+                "kind": "trigger",
+                "prompt": "Review this code change and label the severity of each finding.",
+                "expected_behavior": ["The demo reviewer skill should trigger."],
+            },
+            {
+                "id": "trig-neg-unrelated-question",
+                "split": "tune",
+                "kind": "trigger",
+                "prompt": "What is the capital of France?",
+                "expected_behavior": ["The demo reviewer skill should not trigger."],
+            },
+        ],
+    }
+    path = root / "evals" / "shared-benchmark.json"
+    write_json(path, manifest)
+    return path
+
+
+def run(command: list[str], *, cwd: Path, report: dict[str, Any], label: str) -> bool:
+    started = time.monotonic()
+    entry: dict[str, Any] = {"label": label, "command": command, "cwd": str(cwd)}
+    try:
+        completed = subprocess.run(command, cwd=cwd, text=True, stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE, timeout=300, check=False)
+        entry.update({"returncode": completed.returncode, "elapsed_seconds": round(time.monotonic() - started, 3),
+                      "stdout": completed.stdout[-4000:], "stderr": completed.stderr[-4000:]})
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        entry.update({"returncode": None, "elapsed_seconds": round(time.monotonic() - started, 3),
+                      "error": f"{type(exc).__name__}: {exc}"})
+    report["commands"].append(entry)
+    return entry.get("returncode") == 0
+
+
+def assess_answer_benchmark(path: Path, agent: str, report: dict[str, Any]) -> bool:
+    """Smoke success means both arms executed and treatment satisfies the fixture."""
+    try:
+        benchmark = json.loads(path.read_text(encoding="utf-8"))
+        results = benchmark["results"]
+        executions_ok = bool(results) and all(row.get("execution_valid") and not row.get("missing_output") for row in results)
+        treatment = [row for row in results if row.get("variant") == "with_skill"]
+        treatment_ok = bool(treatment) and all(row.get("objective_pass_rate") == 1.0 for row in treatment)
+        report["checks"].append({"label": f"{agent}:artifact-contract", "passed": executions_ok,
+                                 "detail": "all paired arms execution-valid"})
+        report["checks"].append({"label": f"{agent}:treatment-fixture", "passed": treatment_ok,
+                                 "detail": "with_skill meets the deterministic demo assertion"})
+        return executions_ok and treatment_ok
+    except (OSError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        report["checks"].append({"label": f"{agent}:artifact-contract", "passed": False,
+                                 "detail": f"could not read benchmark: {type(exc).__name__}: {exc}"})
+        return False
+
+
+def assess_trigger_report(path: Path, report: dict[str, Any]) -> bool:
+    try:
+        trigger = json.loads(path.read_text(encoding="utf-8"))
+        rows = trigger["results"]
+        actual_polarities = [(row.get("query"), row.get("should_trigger")) for row in rows]
+        expected_polarities = list(SMOKE_TRIGGER_EXPECTATIONS)
+        exact_fixture = (len(rows) == len(expected_polarities)
+                         and sorted(actual_polarities) == sorted(expected_polarities))
+        observed = exact_fixture and all(row.get("observation_complete") and row.get("returncode") == 0 for row in rows)
+        expected = exact_fixture and all(row.get("pass") is True for row in rows)
+        report["checks"].append({"label": "pi:observation-contract", "passed": observed,
+                                 "detail": "exactly one complete positive and one complete negative trigger observation"})
+        report["checks"].append({"label": "pi:demo-trigger-fixture", "passed": expected,
+                                 "detail": "the demo skill triggers only on its positive query"})
+        return observed and expected
+    except (OSError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        report["checks"].append({"label": "pi:observation-contract", "passed": False,
+                                 "detail": f"could not read trigger report: {type(exc).__name__}: {exc}"})
+        return False
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out-dir", required=True, help="persistent directory for tasks, run artifacts, reports, and smoke.json; never cleaned by this command")
+    parser.add_argument("--live", action="store_true", help="required acknowledgement before any model CLI is invoked")
+    parser.add_argument("--agents", default="claude,codex,vibe,pi", help="comma-separated subset of claude,codex,vibe,pi")
+    parser.add_argument("--claude-model", default=DEFAULT_MODELS["claude"])
+    parser.add_argument("--codex-model", default=DEFAULT_MODELS["codex"])
+    parser.add_argument("--vibe-model", default=DEFAULT_MODELS["vibe"])
+    parser.add_argument("--pi-model", default=DEFAULT_MODELS["pi"])
+    parser.add_argument("--timeout", type=int, default=90, help="per harness CLI invocation timeout in seconds")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    agents = tuple(item.strip() for item in args.agents.split(",") if item.strip())
+    unknown = sorted(set(agents) - {*ANSWER_AGENTS, "pi"})
+    if unknown:
+        raise SystemExit(f"unknown smoke agent(s): {', '.join(unknown)}")
+    if not agents:
+        raise SystemExit("--agents must select at least one supported CLI")
+    if not args.live:
+        print("Refusing live model calls without --live. This smoke can spend money.", file=sys.stderr)
+        return 2
+
+    out_dir = Path(args.out_dir).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    # Never recursively clean caller-controlled paths. A unique attempt keeps
+    # each invocation inspectable and prevents stale artifacts spending money.
+    attempt_dir = Path(tempfile.mkdtemp(prefix="attempt-", dir=out_dir))
+    work = attempt_dir / "work"
+    work.mkdir()
+    manifest = make_smoke_repo(work)
+    models = {name: getattr(args, f"{name}_model") for name in (*ANSWER_AGENTS, "pi")}
+    report: dict[str, Any] = {
+        "kind": "supported-cli-live-smoke",
+        "generated_at": int(time.time()),
+        "models": {name: models[name] for name in agents},
+        "scope": {"answer_case": 1, "answer_variants": 2, "trigger_cases": 2, "trigger_runs_per_query": 1,
+                  "work_dir": str(work), "artifact_dir": str(attempt_dir)},
+        "commands": [],
+        "checks": [],
+        "notes": [
+            "Jetty is an API/import surface, not a local CLI smoke; use its token-backed smoke separately.",
+            "This verifies CLI integration and artifact contracts, not model quality. Inspect benchmark/trigger reports for quality.",
+        ],
+    }
+    python = sys.executable
+    harness = str(ROOT / "skill_benchmark.py")
+    trigger = str(ROOT / "run_trigger_matrix.py")
+    all_ok = True
+    for agent in agents:
+        executable = shutil.which(agent)
+        if executable is None:
+            report["commands"].append({"label": f"{agent}:availability", "returncode": None,
+                                       "error": f"{agent} executable not found"})
+            all_ok = False
+            continue
+        if agent == "pi":
+            trigger_report = attempt_dir / "pi-trigger.json"
+            all_ok &= run([
+                python, trigger, str(manifest), "--agent", "pi", "--model", models["pi"],
+                "--runs-per-query", "1", "--timeout", str(args.timeout), "--trace-runs", str(attempt_dir / "pi-traces"),
+                "--out", str(trigger_report),
+            ], cwd=work, report=report, label="pi:trigger")
+            all_ok &= assess_trigger_report(trigger_report, report)
+            continue
+        tasks = attempt_dir / f"{agent}.tasks.jsonl"
+        runs = attempt_dir / f"{agent}.runs"
+        benchmark = attempt_dir / f"{agent}.benchmark.json"
+        prepared = run([python, harness, "prepare", str(manifest), "--split", "tune", "--runs-per-variant", "1", "--out", str(tasks)],
+                       cwd=work, report=report, label=f"{agent}:prepare")
+        all_ok &= prepared
+        if not prepared:
+            continue
+        answered = run([python, harness, "run-agent", "--agent", agent, "--tasks", str(tasks), "--runs", str(runs),
+                        "--model", models[agent], "--timeout", str(args.timeout)],
+                       cwd=work, report=report, label=f"{agent}:answer")
+        all_ok &= answered
+        if not answered:
+            continue
+        benchmarked = run([python, harness, "benchmark", str(manifest), "--runs", str(runs), "--split", "tune", "--out", str(benchmark)],
+                          cwd=work, report=report, label=f"{agent}:benchmark")
+        all_ok &= benchmarked
+        if benchmarked:
+            all_ok &= assess_answer_benchmark(benchmark, agent, report)
+    report["status"] = "passed" if all_ok else "failed"
+    write_json(out_dir / "smoke.json", report)
+    print(f"{report['status']}: {out_dir / 'smoke.json'}")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skill_benchmark.py
+++ b/skill_benchmark.py
@@ -12,6 +12,7 @@ them. Everything from `grade`/`benchmark` onward is model-free and reproducible 
 from __future__ import annotations
 
 import argparse
+import collections
 import copy
 import difflib
 import hashlib
@@ -36,6 +37,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 import yaml
+import telemetry as telemetry_domain
 
 from ablation_model import (
     AblationRecord,
@@ -2571,6 +2573,13 @@ def import_jetty_results(args: argparse.Namespace) -> int:
             (base / "output.md").write_text(f"{JETTY_FAILURE}: trajectory failed before producing output]\n", encoding="utf-8")
         meta = artifact_metadata(artifacts)
         meta.update(normalized_jetty_metadata(record, success=success))
+        meta.update({
+            "population": "answer",
+            "case_id": harness.get("case_id"),
+            "run_number": harness.get("run_number", 1),
+            "variant": harness.get("variant"),
+            "billing_scope": "run",
+        })
         # Persist the harness-only ablation provenance into the run metadata so the
         # benchmark report can VERIFY (mode/population/skill_hash/components) that a
         # materialized ablation was actually mounted — never trusting the manifest
@@ -2675,7 +2684,12 @@ def discover_on_disk_run_rows(manifest: dict[str, Any], runs: Path) -> list[dict
             for run_number, base in discover_run_bases_under(vdir):
                 merged = read_metrics_base(base)
                 facts = run_cost_facts(merged)
-                facts["elapsed_ms"] = metric_number(merged, "elapsed_ms")
+                elapsed_measurement = telemetry_domain.measurement_from_envelope_or_nonnegative(
+                    merged, "elapsed_ms", source=str(merged.get("provider") or merged.get("trace_source") or ""))
+                facts["elapsed_ms_measurement"] = elapsed_measurement
+                facts["elapsed_ms"] = elapsed_measurement.value if elapsed_measurement.availability == telemetry_domain.AVAILABLE else None
+                facts = bind_telemetry_pair_identity(
+                    facts, case_id=case["id"], run_number=run_number, variant=variant, model=model, population="answer")
                 rows.append({
                     "case_id": case["id"],
                     "variant": variant,
@@ -3050,7 +3064,13 @@ def normalize_cost(raw: Any, *, source: str = "provider_reported", currency: str
         return {"source": "not_applicable"}
     total = _num(raw)
     parts: dict[str, float] = {}
+    resolved_currency = currency
     if isinstance(raw, dict):
+        if raw.get("currency") is not None:
+            raw_currency = raw.get("currency")
+            if not isinstance(raw_currency, str) or not re.fullmatch(r"[A-Z]{3}", raw_currency):
+                return {"source": "missing"}
+            resolved_currency = raw_currency
         for key in ("total_cost", "total_cost_usd", "cost_usd", "total", "cost", "amount"):
             total = _num(raw.get(key))
             if total is not None:
@@ -3065,7 +3085,7 @@ def normalize_cost(raw: Any, *, source: str = "provider_reported", currency: str
             total = sum(parts.values())
     if total is None:
         return {"source": "missing"}
-    out: dict[str, Any] = {"currency": currency, **{k: round(v, 6) for k, v in parts.items()}, "total_cost": round(total, 6), "source": source}
+    out: dict[str, Any] = {"currency": resolved_currency, **{k: round(v, 6) for k, v in parts.items()}, "total_cost": round(total, 6), "source": source}
     if pricing_model:
         out["pricing_model"] = pricing_model
     if pricing_table_version:
@@ -3076,35 +3096,70 @@ def normalize_cost(raw: Any, *, source: str = "provider_reported", currency: str
 
 
 def run_cost_facts(merged: dict[str, Any]) -> dict[str, Any]:
-    """ONE reader for a run's usage/cost facts. Prefers the normalized blocks;
-    pre-#21 runs fall back to the legacy flat fields, so old run dirs keep
-    reporting. Returns tokens (or None), cost_usd (or None), and each source."""
-    usage_block = merged.get("usage_normalized")
-    if isinstance(usage_block, dict) and usage_block.get("source") not in (None, "missing", "not_applicable"):
-        tokens = {key: usage_block.get(key) for key in USAGE_ALIASES if isinstance(usage_block.get(key), (int, float))}
-        usage_source = str(usage_block.get("source"))
+    """ONE reader for a run's usage/cost facts.
+
+    New v3 artifacts are parsed through :mod:`telemetry`; old normalized/flat
+    fields are adapted at this boundary and labelled ``legacy_unverified``. The
+    scalar compatibility fields are populated only for available measurements,
+    so callers cannot confuse unavailable telemetry with zero.
+    """
+    basis = telemetry_domain.basis_from_run(merged, source=str(merged.get("provider") or merged.get("runner") or ""))
+    envelope = merged.get("telemetry")
+
+    def v3_or_usage(key: str):
+        if isinstance(envelope, dict) and envelope.get("schema_version") == 3:
+            measurements = envelope.get("measurements")
+            if isinstance(measurements, dict) and isinstance(measurements.get(key), dict):
+                try:
+                    return telemetry_domain.Measurement.from_dict(measurements[key])
+                except ValueError:
+                    return telemetry_domain.Measurement.unavailable(f"invalid_v3_{key}", basis=basis)
+        return telemetry_domain.measurement_from_usage_block(
+            merged.get("usage_normalized"), key,
+            legacy_value=metric_number(merged, key), basis=basis,
+        )
+
+    input_measurement = v3_or_usage("input_tokens")
+    output_measurement = v3_or_usage("output_tokens")
+    total_measurement = v3_or_usage("total_tokens")
+    if isinstance(envelope, dict) and envelope.get("schema_version") == 3:
+        measurements = envelope.get("measurements")
+        if isinstance(measurements, dict) and isinstance(measurements.get("cost"), dict):
+            try:
+                cost_measurement = telemetry_domain.Measurement.from_dict(measurements["cost"])
+            except ValueError:
+                cost_measurement = telemetry_domain.Measurement.unavailable("invalid_v3_cost", basis=basis)
+        else:
+            cost_measurement = telemetry_domain.measurement_from_cost_block(
+                merged.get("cost_normalized"), legacy_value=metric_number(merged, "cost_usd", "cost"), basis=basis)
     else:
-        tokens = {}
-        for key in ("input_tokens", "output_tokens", "total_tokens"):
-            value = metric_number(merged, key)
-            if value is not None:
-                tokens[key] = int(value)
-        usage_source = "legacy_fields" if tokens else str((usage_block or {}).get("source", "missing"))
-    cost_block = merged.get("cost_normalized")
-    if isinstance(cost_block, dict) and isinstance(cost_block.get("total_cost"), (int, float)):
-        cost_usd = float(cost_block["total_cost"])
-        cost_source = str(cost_block.get("source"))
-    else:
-        legacy = metric_number(merged, "cost_usd", "cost")
-        cost_usd = float(legacy) if legacy is not None else None
-        cost_source = "legacy_fields" if cost_usd is not None else str((cost_block or {}).get("source", "missing"))
+        cost_measurement = telemetry_domain.measurement_from_cost_block(
+            merged.get("cost_normalized"), legacy_value=metric_number(merged, "cost_usd", "cost"), basis=basis)
+
+    def value_of(measurement):
+        return measurement.value if measurement.availability == telemetry_domain.AVAILABLE else None
+
+    def source_of(measurement) -> str:
+        if measurement.availability == telemetry_domain.AVAILABLE:
+            # Keep the historical scalar reader label stable; the typed
+            # measurement still records the stricter legacy_unverified fact.
+            return "legacy_fields" if measurement.provenance == "legacy_unverified" else str(measurement.provenance)
+        return "not_applicable" if measurement.availability == telemetry_domain.NOT_APPLICABLE else "missing"
+
+    cost = value_of(cost_measurement)
+    cost_usd = float(cost.amount) if isinstance(cost, telemetry_domain.Money) and cost.currency == "USD" else None
     return {
-        "input_tokens": tokens.get("input_tokens"),
-        "output_tokens": tokens.get("output_tokens"),
-        "total_tokens": tokens.get("total_tokens"),
+        "input_tokens": value_of(input_measurement),
+        "output_tokens": value_of(output_measurement),
+        "total_tokens": value_of(total_measurement),
         "cost_usd": cost_usd,
-        "usage_source": usage_source,
-        "cost_source": cost_source,
+        "cost_currency": cost.currency if isinstance(cost, telemetry_domain.Money) else None,
+        "usage_source": source_of(total_measurement),
+        "cost_source": source_of(cost_measurement),
+        "input_tokens_measurement": input_measurement,
+        "output_tokens_measurement": output_measurement,
+        "total_tokens_measurement": total_measurement,
+        "cost_measurement": cost_measurement,
     }
 
 
@@ -3120,6 +3175,39 @@ def process_or_efficiency_assertion_result(assertion: dict[str, Any], run_base: 
     metrics = dict(metadata or {})
     metrics.update(read_metrics_base(run_base))
     ci = bool(assertion.get("ci", True))
+    envelope = metrics.get("telemetry") if isinstance(metrics.get("telemetry"), dict) else None
+
+    def require_v3_measurement(key: str) -> tuple[bool, str | None]:
+        """Fail closed when v3 says the trace observation was incomplete.
+
+        Old artifacts have no envelope and retain the historical event/metric
+        fallback. New artifacts must not let their legacy flat zero counters
+        override an explicit unavailable measurement.
+        """
+        measurements = envelope.get("measurements") if isinstance(envelope, dict) else None
+        raw = measurements.get(key) if isinstance(measurements, dict) else None
+        if not isinstance(raw, dict):
+            return True, None
+        if raw.get("availability") == telemetry_domain.AVAILABLE:
+            return True, None
+        return False, f"missing {key} evidence ({raw.get('reason', raw.get('availability', 'unavailable'))})"
+
+    required_signal = {
+        "skill_invoked": "skill_invoked",
+        "command_ran": "commands",
+        "command_not_ran": "commands",
+        "command_order": "commands",
+        "tool_call": "tool_calls",
+        "tool_count_le": "tool_calls",
+        "no_repeated_command_loop": "repeated_command_max",
+        "total_tokens_le": "total_tokens",
+        "elapsed_seconds_le": "elapsed_ms",
+        "command_count_le": "commands",
+    }.get(atype)
+    if required_signal:
+        observed, evidence_error = require_v3_measurement(required_signal)
+        if not observed:
+            return False, str(evidence_error)
 
     if atype == "skill_invoked":
         expected = bool(assertion.get("expected", True))
@@ -3546,17 +3634,17 @@ def _sum_stream_usage(records: list[dict[str, Any]]) -> dict[str, Any]:
     return normalize_usage(totals if totals else None, source="trace_normalized")
 
 
-def _cost_value_from_record(record: dict[str, Any]) -> float | None:
+def _cost_value_from_record(record: dict[str, Any]) -> Any:
+    """Return a validated raw cost value without discarding object currency."""
     raw = raw_trace_value(record, "cost", "cost_usd", "total_cost_usd")
     if raw is None:
         usage_obj = _stream_usage_doc(record)
         if isinstance(usage_obj, dict):
             raw = usage_obj.get("cost", usage_obj.get("cost_usd"))
     if isinstance(raw, (int, float)) and not isinstance(raw, bool):
-        return _num(raw)
+        return raw if _num(raw) is not None else None
     if isinstance(raw, dict):
-        value = normalize_cost(raw).get("total_cost")
-        return _num(value)
+        return raw if normalize_cost(raw).get("source") != "missing" else None
     return None
 
 
@@ -3592,9 +3680,16 @@ def stream_usage_and_cost(raw_text: str) -> tuple[dict[str, Any], dict[str, Any]
         cost = cumulative_cost[-1]
         return usage, cost
     cost_values = [_cost_value_from_record(record) for record in records]
-    cost_total = sum(value for value in cost_values if value is not None)
-    cost_found = any(value is not None for value in cost_values)
-    cost = normalize_cost(round(cost_total, 6) if cost_found else None, source="trace_normalized")
+    cost_blocks = [normalize_cost(value, source="trace_normalized") for value in cost_values if value is not None]
+    cost_blocks = [block for block in cost_blocks if block.get("source") != "missing"]
+    currencies = {str(block.get("currency")) for block in cost_blocks}
+    if len(currencies) == 1:
+        currency = next(iter(currencies))
+        cost_total = sum(float(block["total_cost"]) for block in cost_blocks)
+        cost = normalize_cost({"amount": round(cost_total, 6), "currency": currency}, source="trace_normalized")
+    else:
+        # A trace that mixes units has no total without an explicit FX policy.
+        cost = {"source": "missing"}
     return usage, cost
 
 
@@ -3619,16 +3714,43 @@ def write_trace_artifacts(
     if parse_errors:
         metrics["parse_errors"] = parse_errors[:20]
         metrics["errors"] = int(metrics.get("errors", 0) or 0) + len(parse_errors)
+    # A trace-derived count is observed only when at least one valid event was
+    # captured and parsing completed. Runners may override this with their own
+    # process-level observation state (for example a spawn failure).
+    metrics["trace_observation_complete"] = bool(records) and not parse_errors
     if extra_metrics:
         metrics.update(extra_metrics)
-    # Telemetry precedence (issue #21): a provider-reported (or explicit
-    # not_applicable) block handed in by the runner beats the trace-derived one
-    # in BOTH artifacts; and every metadata.json leaves here with explicit
-    # blocks — missing telemetry is marked, never silently absent or zero.
+    # Telemetry precedence: an explicit provider/estimated/not-applicable block
+    # supplied by a runner wins over a trace-derived block. Both artifacts then
+    # receive the same v3 envelope, including an explicit unavailable state when
+    # no value was observed. A missing trace can never become numeric zero.
     for key in ("usage_normalized", "cost_normalized"):
         block = (metadata or {}).get(key)
         if isinstance(block, dict) and block.get("source") in {"provider_reported", "trace_normalized", "price_table_estimated", "estimated", "not_applicable"}:
             metrics[key] = block
+        metrics.setdefault(key, {"source": "missing"})
+    # Metrics contains the resolved usage/cost precedence. Metadata is useful
+    # for identity/basis but must not let an explicit `source: missing` erase a
+    # usable trace-normalized observation.
+    envelope_input = {**(metadata or {}), **metrics}
+    if isinstance(envelope_input.get("observation_complete"), bool):
+        envelope_input["trace_observation_complete"] = envelope_input["observation_complete"]
+    # A crash/timeout can leave a syntactically valid partial JSONL trace. Keep
+    # its legacy debugging fields, but v3 must not present trace-derived usage
+    # or cost as complete measurement evidence. Provider-reported blocks remain
+    # valid independent observations.
+    if envelope_input.get("trace_observation_complete") is not True:
+        for key in ("usage_normalized", "cost_normalized"):
+            block = envelope_input.get(key)
+            if isinstance(block, dict) and block.get("source") == "trace_normalized":
+                envelope_input[key] = {"source": "missing"}
+    envelope = telemetry_domain.telemetry_envelope(
+        envelope_input,
+        source=source,
+        population=str(envelope_input.get("population") or "answer"),
+    )
+    metrics["telemetry_schema_version"] = 3
+    metrics["telemetry"] = envelope
     write_json(out_events or run_dir / "events.json", events)
     write_json(out_metrics or run_dir / "metrics.json", metrics)
     if environment:
@@ -3640,6 +3762,8 @@ def write_trace_artifacts(
         existing.update({k: v for k, v in metrics.items() if k not in {"schema_version", "source"}})
         existing.setdefault("usage_normalized", {"source": "missing"})
         existing.setdefault("cost_normalized", {"source": "missing"})
+        existing["telemetry_schema_version"] = 3
+        existing["telemetry"] = envelope
         existing["trace_source"] = source
         write_json(run_dir / "metadata.json", existing)
     return events, metrics
@@ -3653,7 +3777,9 @@ def import_trace(args: argparse.Namespace) -> int:
         run_dir,
         trace_text,
         source=getattr(args, "source", "generic"),
-        write_metadata=getattr(args, "write_metadata", False),
+        # v3 requires a paired metadata/metrics envelope; importing a trace is
+        # a producer, not a metrics-only convenience path.
+        write_metadata=True,
         out_events=Path(args.out_events) if getattr(args, "out_events", None) else None,
         out_metrics=Path(args.out_metrics) if getattr(args, "out_metrics", None) else None,
         write_raw_trace=False,
@@ -3699,18 +3825,23 @@ def write_runner_outcome(run_dir: Path, outcome: RunnerOutcome) -> tuple[dict[st
     returncode = 124 if timed_out else outcome.returncode
     usage_block = normalize_usage(outcome.usage, source="provider_reported")
     cost_block = normalize_cost(outcome.cost_usd, source="provider_reported", pricing_model=outcome.model)
+    elapsed = outcome.elapsed_ms
+    if isinstance(elapsed, bool) or not isinstance(elapsed, (int, float)) or not math.isfinite(float(elapsed)) or elapsed < 0:
+        elapsed = None
     metadata = {
         **outcome.metadata_extra,
         "provider": outcome.provider,
         "model": outcome.model,
         "returncode": returncode,
         "timed_out": timed_out,
-        "elapsed_ms": int(outcome.elapsed_ms),
         "stderr": outcome.stderr,
         "usage_normalized": usage_block,
         "cost_normalized": cost_block,
+        **({"elapsed_ms": int(elapsed)} if elapsed is not None else {}),
     }
-    extra_metrics = {**outcome.metrics_extra, "elapsed_ms": int(outcome.elapsed_ms), "returncode": returncode}
+    extra_metrics = {**outcome.metrics_extra, "returncode": returncode,
+                     "observation_complete": returncode == 0 and not timed_out,
+                     **({"elapsed_ms": int(elapsed)} if elapsed is not None else {})}
     events, metrics = write_trace_artifacts(
         run_dir,
         trace_text,
@@ -4123,7 +4254,7 @@ def vibe_cli_invoke(prompt: str, *, model: str | None = None, vibe_cmd: str | No
                                        max_price=max_price, max_tokens=max_tokens)
         except ValueError as exc:
             return {"answer": "", "stdout": "", "stderr": str(exc), "returncode": 127,
-                    "timed_out": False, "elapsed_ms": 0, "usage": None, "cost_usd": None,
+                    "timed_out": False, "elapsed_ms": None, "usage": None, "cost_usd": None,
                     "model": model, "trace_text": "", "environment": env_meta}
         result = run_argv_capture(argv, input_text="", cwd=workspace, env=env, timeout=timeout)
     messages = parse_vibe_messages(result.stdout)
@@ -4168,7 +4299,7 @@ class CodexBackend(AgentBackend):
         return RunnerOutcome(
             provider="codex", answer=result.get("answer"),
             returncode=result.get("returncode"), timed_out=bool(result.get("timed_out", False)), timeout_s=request.timeout_s,
-            elapsed_ms=result.get("elapsed_ms") or 0, stderr=result.get("stderr", ""),
+            elapsed_ms=result.get("elapsed_ms") if isinstance(result.get("elapsed_ms"), (int, float)) else None, stderr=result.get("stderr", ""),
             trace_text=result.get("trace_text") or "", model=request.model,
             environment={"runner": "codex", **dict(result.get("environment") or {})})
 
@@ -4183,7 +4314,7 @@ class ClaudeBackend(AgentBackend):
         return RunnerOutcome(
             provider="claude", answer=result.get("answer") or "",
             returncode=result.get("returncode"), timed_out=bool(result.get("timed_out", False)),
-            timeout_s=request.timeout_s, elapsed_ms=result.get("elapsed_ms") or 0, stderr=result.get("stderr", ""),
+            timeout_s=request.timeout_s, elapsed_ms=result.get("elapsed_ms") if isinstance(result.get("elapsed_ms"), (int, float)) else None, stderr=result.get("stderr", ""),
             usage=result.get("usage"), cost_usd=result.get("cost_usd"), model=request.model,
             metadata_extra={"cost_usd": claude_metrics.get("cost_usd")}, metrics_extra=metrics_extra,
             environment={"runner": "claude", "command": "claude -p --output-format json --no-session-persistence", "cwd": "<isolated workspace>"})
@@ -4207,7 +4338,7 @@ class VibeBackend(AgentBackend):
         return RunnerOutcome(
             provider="vibe", answer=result.get("answer") or "",
             returncode=result.get("returncode"), timed_out=bool(result.get("timed_out", False)),
-            timeout_s=request.timeout_s, elapsed_ms=result.get("elapsed_ms") or 0, stderr=result.get("stderr", ""),
+            timeout_s=request.timeout_s, elapsed_ms=result.get("elapsed_ms") if isinstance(result.get("elapsed_ms"), (int, float)) else None, stderr=result.get("stderr", ""),
             usage=result.get("usage"), cost_usd=result.get("cost_usd"), model=request.model,
             trace_text=result.get("trace_text") or "",
             environment={"runner": "vibe", **env})
@@ -4228,7 +4359,15 @@ def run_agent_tasks(tasks: list[dict[str, Any]], runs: Path, backend: AgentBacke
         row_model = task.get("model") or model
         base = safe_child_path(runs, str(pt.run_dir or f"{pt.case_id or 'case'}/{pt.variant_truth or 'variant'}"))
         base.mkdir(parents=True, exist_ok=True)
-        prov_extra = {**({"ablation": pt.ablation.as_dict()} if pt.ablation else {}), **({"skill_tree_hash": pt.skill_tree_hash} if pt.skill_tree_hash else {})}
+        prov_extra = {
+            "population": "answer",
+            "case_id": pt.case_id,
+            "run_number": task.get("run_number", 1),
+            "variant": pt.variant_truth,
+            "billing_scope": "run",
+            **({"ablation": pt.ablation.as_dict()} if pt.ablation else {}),
+            **({"skill_tree_hash": pt.skill_tree_hash} if pt.skill_tree_hash else {}),
+        }
         with tempfile.TemporaryDirectory(prefix=f"{backend.name}-ws-") as wd:
             ws = Path(wd)
             skill_rel, input_rel = build_skill_workspace(pt, ws)
@@ -5471,7 +5610,15 @@ def run_subagent_tasks(
         row_model = task.get("model") or model
         base = safe_child_path(runs, str(pt.run_dir or f"{pt.case_id or 'case'}/{pt.variant_truth or 'variant'}"))
         base.mkdir(parents=True, exist_ok=True)
-        prov_extra = {**({"ablation": pt.ablation.as_dict()} if pt.ablation else {}), **({"skill_tree_hash": pt.skill_tree_hash} if pt.skill_tree_hash else {})}
+        prov_extra = {
+            "population": "answer",
+            "case_id": pt.case_id,
+            "run_number": task.get("run_number", 1),
+            "variant": pt.variant_truth,
+            "billing_scope": "run",
+            **({"ablation": pt.ablation.as_dict()} if pt.ablation else {}),
+            **({"skill_tree_hash": pt.skill_tree_hash} if pt.skill_tree_hash else {}),
+        }
         store = ToolReplayStore(base / "tool-replay.json", mode) if mode != "off" else None
 
         def tool_executor(tool: str, payload: Any) -> Any:
@@ -6234,15 +6381,25 @@ def grade_case_variant(
 def anthropic_grading_json(result: dict[str, Any]) -> dict[str, Any]:
     expectations = expectation_texts(result)
     meta = result.get("metadata", {}) or {}
-    elapsed = metric_number(meta, "elapsed_ms")
-    if elapsed is None:
-        elapsed = metric_number(meta, "duration_ms")
-    timing = {}
-    if elapsed is not None:
-        timing["executor_duration_seconds"] = round(elapsed / 1000, 3)
-        timing["total_duration_seconds"] = round(elapsed / 1000, 3)
-    if metric_number(meta, "total_tokens") is not None:
-        timing["total_tokens"] = int(metric_number(meta, "total_tokens") or 0)
+    elapsed = telemetry_domain.measurement_from_envelope_or_nonnegative(meta, "elapsed_ms")
+    tokens = telemetry_domain.measurement_from_envelope_or_usage(meta, "total_tokens")
+    tool_calls = telemetry_domain.measurement_from_envelope_or_nonnegative(meta, "tool_calls")
+    timing: dict[str, Any] = {}
+    telemetry_status: dict[str, Any] = {}
+    if elapsed.availability == telemetry_domain.AVAILABLE:
+        timing["executor_duration_seconds"] = round(float(elapsed.value) / 1000, 3)
+        timing["total_duration_seconds"] = round(float(elapsed.value) / 1000, 3)
+    else:
+        telemetry_status["timing"] = elapsed.to_dict()
+    if tokens.availability == telemetry_domain.AVAILABLE:
+        timing["total_tokens"] = int(tokens.value)
+    else:
+        telemetry_status["total_tokens"] = tokens.to_dict()
+    execution_metrics: dict[str, Any] = {}
+    if tool_calls.availability == telemetry_domain.AVAILABLE:
+        execution_metrics["total_tool_calls"] = int(tool_calls.value)
+    else:
+        telemetry_status["total_tool_calls"] = tool_calls.to_dict()
     total = result.get("combined_total", result.get("objective_total", 0))
     passed = result.get("combined_passed", result.get("objective_passed", 0))
     return {
@@ -6253,13 +6410,8 @@ def anthropic_grading_json(result: dict[str, Any]) -> dict[str, Any]:
             "total": total,
             "pass_rate": result.get("combined_pass_rate", result.get("objective_pass_rate")),
         },
-        "execution_metrics": {
-            "tool_calls": meta.get("tool_calls", {}),
-            "total_tool_calls": meta.get("total_tool_calls", 0),
-            "errors_encountered": meta.get("errors_encountered", 0),
-            "output_chars": meta.get("output_chars", 0),
-            "transcript_chars": meta.get("transcript_chars", 0),
-        },
+        "execution_metrics": execution_metrics,
+        "telemetry": telemetry_status,
         "timing": timing,
         "claims": [],
         "user_notes_summary": {"uncertainties": [], "needs_review": [], "workarounds": []},
@@ -6330,13 +6482,22 @@ def telemetry_for_result(result: dict[str, Any]) -> dict[str, bool]:
     metrics_exists = (base / "metrics.json").exists()
     events, _ = read_events_base(base) if events_exists else (None, None)
     has_skill_event = bool(events and any(e.get("type") == "skill_load" for e in events))
+    envelope = metrics.get("telemetry") if isinstance(metrics.get("telemetry"), dict) else {}
+    measurements = envelope.get("measurements") if isinstance(envelope, dict) else {}
+
+    def observed(key: str, fallback: bool) -> bool:
+        measurement = measurements.get(key) if isinstance(measurements, dict) else None
+        if isinstance(measurement, dict):
+            return measurement.get("availability") == telemetry_domain.AVAILABLE
+        return fallback
+
     return {
         "trace": (base / "trace.jsonl").exists(),
         "events": events_exists,
         "metrics": metrics_exists,
-        "tokens": metric_number(metrics, "total_tokens") is not None,
-        "commands": metric_number(metrics, "commands", "command_count") is not None or events_exists,
-        "skill_invocation": isinstance(metrics.get("skill_invoked"), bool) or has_skill_event,
+        "tokens": observed("total_tokens", metric_number(metrics, "total_tokens") is not None),
+        "commands": observed("commands", metric_number(metrics, "commands", "command_count") is not None or events_exists),
+        "skill_invocation": observed("skill_invoked", isinstance(metrics.get("skill_invoked"), bool) or has_skill_event),
     }
 
 
@@ -7047,6 +7208,11 @@ def p90(values: list[float]) -> float | None:
 
 
 def cost_stats(values: list[float]) -> dict[str, Any]:
+    """Statistics for already-observed values.
+
+    New report paths pair this with ``measurement_stats`` below so the scalar
+    statistics cannot hide whether other runs were unavailable.
+    """
     clean = [float(v) for v in values if v is not None]
     if not clean:
         return {"sum": None, "mean": None, "median": None, "p90": None, "n": 0}
@@ -7059,23 +7225,146 @@ def cost_stats(values: list[float]) -> dict[str, Any]:
     }
 
 
+def _row_measurement(row: dict[str, Any], key: str):
+    measurement = row.get(f"{key}_measurement")
+    if isinstance(measurement, telemetry_domain.Measurement):
+        return measurement
+    return telemetry_domain.measurement_from_nonnegative(
+        row.get(key), unavailable_reason=f"missing_{key}",
+        basis=telemetry_domain.basis_from_run(row, source=str(row.get("runner") or "")),
+    )
+
+
+def _cost_measurement(row: dict[str, Any]):
+    measurement = row.get("cost_measurement")
+    if isinstance(measurement, telemetry_domain.Measurement):
+        return measurement
+    return telemetry_domain.measurement_from_cost_block(
+        None, legacy_value=row.get("cost_usd"),
+        basis=telemetry_domain.basis_from_run(row, source=str(row.get("runner") or "")),
+    )
+
+
+def _numeric_aggregate_fields(name: str, aggregate: telemetry_domain.Aggregate[Any]) -> dict[str, Any]:
+    """Expose an additive status object plus safe compatibility scalar fields."""
+    out: dict[str, Any] = {
+        name: aggregate.scalar_if_complete(),
+        f"{name}_aggregate": aggregate.to_dict(),
+        f"{name}_availability": aggregate.availability,
+    }
+    if aggregate.availability == telemetry_domain.PARTIAL:
+        out[f"known_{name}"] = aggregate.known_subtotal
+    return out
+
+
+def _money_aggregate_fields(measurements: list[telemetry_domain.Measurement[Any]]) -> dict[str, Any]:
+    buckets = telemetry_domain.aggregate_money_by_currency(measurements)
+    usd = buckets.get("USD")
+    if usd is None:
+        unknown = buckets.get("unknown")
+        if unknown is not None:
+            usd = unknown
+        else:
+            usd = telemetry_domain.Aggregate(
+                telemetry_domain.UNAVAILABLE,
+                unavailable_count=0,
+                reason_counts={"currency_mismatch": sum(a.observed_count for a in buckets.values())},
+            )
+    fields = _numeric_aggregate_fields("total_cost_usd", usd)
+    # Decimal wire values stay exact inside the status object; compatibility
+    # scalars remain JSON numbers only when the aggregate is complete.
+    if fields["total_cost_usd"] is not None:
+        fields["total_cost_usd"] = float(fields["total_cost_usd"])
+    if "known_total_cost_usd" in fields:
+        fields["known_total_cost_usd"] = float(fields["known_total_cost_usd"])
+    fields["cost_by_currency"] = {currency: aggregate.to_dict() for currency, aggregate in buckets.items()}
+    return fields
+
+
+def measurement_stats(measurements: list[telemetry_domain.Measurement[Any]]) -> dict[str, Any]:
+    """Stats plus availability; a partial set has a known sum, never a total."""
+    aggregate = telemetry_domain.aggregate_numeric(measurements)
+    values = [float(m.value) for m in measurements if m.availability == telemetry_domain.AVAILABLE]
+    out = cost_stats(values)
+    out["availability"] = aggregate.availability
+    out["aggregate"] = aggregate.to_dict()
+    if aggregate.availability != telemetry_domain.COMPLETE:
+        for key in ("sum", "mean", "median", "p90"):
+            out[key] = None
+        if aggregate.availability == telemetry_domain.PARTIAL:
+            out["known_sum"] = float(aggregate.known_subtotal)
+    return out
+
+
+def money_measurement_stats(measurements: list[telemetry_domain.Measurement[Any]], currency: str = "USD") -> dict[str, Any]:
+    buckets = telemetry_domain.aggregate_money_by_currency(measurements)
+    aggregate = buckets.get(currency) or buckets.get("unknown")
+    if aggregate is None:
+        aggregate = telemetry_domain.Aggregate(telemetry_domain.UNAVAILABLE, reason_counts={"currency_mismatch": 1})
+    values = [float(m.value.amount) for m in measurements
+              if m.availability == telemetry_domain.AVAILABLE and isinstance(m.value, telemetry_domain.Money)
+              and m.value.currency == currency]
+    out = cost_stats(values)
+    out["availability"] = aggregate.availability
+    out["aggregate"] = aggregate.to_dict()
+    if aggregate.availability != telemetry_domain.COMPLETE:
+        for key in ("sum", "mean", "median", "p90"):
+            out[key] = None
+        if aggregate.availability == telemetry_domain.PARTIAL:
+            out["known_sum"] = float(aggregate.known_subtotal)
+    return out
+
+
 def result_cost_facts(result: dict[str, Any]) -> dict[str, Any]:
     merged = dict(result.get("metadata", {}) or {})
     merged.update(read_metrics_base(Path(result.get("run_base", ""))))
     facts = run_cost_facts(merged)
-    facts["elapsed_ms"] = metric_number(merged, "elapsed_ms")
+    elapsed_measurement = telemetry_domain.measurement_from_envelope_or_nonnegative(
+        merged, "elapsed_ms", source=str(merged.get("provider") or merged.get("runner") or ""))
+    facts["elapsed_ms_measurement"] = elapsed_measurement
+    facts["elapsed_ms"] = elapsed_measurement.value if elapsed_measurement.availability == telemetry_domain.AVAILABLE else None
     return facts
 
 
+def bind_telemetry_pair_identity(facts: dict[str, Any], *, case_id: str, run_number: int,
+                                  variant: str | None = None, model: str | None = None,
+                                  population: str = "answer") -> dict[str, Any]:
+    """Attach identity known by the report/discovery layer to immutable facts."""
+    updates = {"case_id": case_id, "run_number": run_number, "variant": variant,
+               "model": model, "population": population}
+    out = dict(facts)
+    for key in ("input_tokens_measurement", "output_tokens_measurement", "total_tokens_measurement",
+                "cost_measurement", "elapsed_ms_measurement"):
+        measurement = out.get(key)
+        if isinstance(measurement, telemetry_domain.Measurement):
+            out[key] = telemetry_domain.with_basis(measurement, **updates)
+    for key, measurement_key in (("input_tokens", "input_tokens_measurement"),
+                                 ("output_tokens", "output_tokens_measurement"),
+                                 ("total_tokens", "total_tokens_measurement"),
+                                 ("cost_usd", "cost_measurement"),
+                                 ("elapsed_ms", "elapsed_ms_measurement")):
+        measurement = out.get(measurement_key)
+        if isinstance(measurement, telemetry_domain.Measurement):
+            value = measurement.value if measurement.availability == telemetry_domain.AVAILABLE else None
+            if key == "cost_usd" and isinstance(value, telemetry_domain.Money):
+                out[key] = float(value.amount) if value.currency == "USD" else None
+            else:
+                out[key] = value
+    return out
+
+
 def spend_of(rows: list[dict[str, Any]]) -> dict[str, Any]:
-    """One spend slot — {runs, total_tokens, total_cost_usd} — over cost-fact
-    rows. Missing telemetry contributes nothing (never a fake zero row). THE
-    accumulator behind every by-case/by-variant/by-runner/ablation spend view
-    in both cost ledgers (previously five hand-rolled folds)."""
+    """Availability-aware spend for one group.
+
+    ``total_*`` is populated only when every run has a compatible observation.
+    Partial groups expose ``known_total_*`` and an aggregate status instead of
+    calling a subtotal a total or turning an empty fold into zero.
+    """
+    token_aggregate = telemetry_domain.aggregate_numeric([_row_measurement(r, "total_tokens") for r in rows])
     return {
         "runs": len(rows),
-        "total_tokens": int(sum(r["total_tokens"] for r in rows if r.get("total_tokens") is not None)),
-        "total_cost_usd": round(sum(r["cost_usd"] for r in rows if r.get("cost_usd") is not None), 6),
+        **_numeric_aggregate_fields("total_tokens", token_aggregate),
+        **_money_aggregate_fields([_cost_measurement(r) for r in rows]),
     }
 
 
@@ -7087,27 +7376,45 @@ def group_spend(rows: list[dict[str, Any]], key_fn) -> dict[str, dict[str, Any]]
 
 
 def cost_coverage_block(rows: list[dict[str, Any]]) -> dict[str, Any]:
-    """Coverage separates missing telemetry from zero spend — identical keys in
-    the benchmark cost_summary and the standalone suite ledger by construction."""
+    """Coverage separates measured zero, unavailable, and N/A telemetry."""
     runs_seen = len(rows)
-    with_usage = sum(1 for r in rows if r.get("total_tokens") is not None)
-    with_cost = sum(1 for r in rows if r.get("cost_usd") is not None)
-    return {
+    usage = [_row_measurement(r, "total_tokens") for r in rows]
+    costs = [_cost_measurement(r) for r in rows]
+    with_usage = sum(1 for m in usage if m.availability == telemetry_domain.AVAILABLE)
+    with_any_cost = sum(1 for m in costs if m.availability == telemetry_domain.AVAILABLE)
+    with_usd_cost = sum(1 for m in costs if m.availability == telemetry_domain.AVAILABLE
+                        and isinstance(m.value, telemetry_domain.Money) and m.value.currency == "USD")
+    with_non_usd_cost = with_any_cost - with_usd_cost
+    na_usage = sum(1 for m in usage if m.availability == telemetry_domain.NOT_APPLICABLE)
+    na_cost = sum(1 for m in costs if m.availability == telemetry_domain.NOT_APPLICABLE)
+    out = {
         "runs_seen": runs_seen,
         "runs_with_token_usage": with_usage,
-        "runs_with_dollar_cost": with_cost,
-        "runs_missing_usage": runs_seen - with_usage,
-        "runs_missing_cost": runs_seen - with_cost,
+        # Dollar coverage is intentionally USD-only: suite budget estimates
+        # consume this denominator alongside total_cost_usd.
+        "runs_with_dollar_cost": with_usd_cost,
+        "runs_with_non_usd_cost": with_non_usd_cost,
+        "runs_missing_usage": runs_seen - with_usage - na_usage,
+        "runs_missing_cost": runs_seen - with_any_cost - na_cost,
     }
+    if na_usage:
+        out["runs_not_applicable_usage"] = na_usage
+    if na_cost:
+        out["runs_not_applicable_cost"] = na_cost
+    return out
 
 
 def cost_totals_block(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    input_aggregate = telemetry_domain.aggregate_numeric([_row_measurement(r, "input_tokens") for r in rows])
+    output_aggregate = telemetry_domain.aggregate_numeric([_row_measurement(r, "output_tokens") for r in rows])
+    total_aggregate = telemetry_domain.aggregate_numeric([_row_measurement(r, "total_tokens") for r in rows])
+    elapsed_aggregate = telemetry_domain.aggregate_numeric([_row_measurement(r, "elapsed_ms") for r in rows])
     return {
-        "input_tokens": int(sum(r["input_tokens"] for r in rows if r.get("input_tokens") is not None)),
-        "output_tokens": int(sum(r["output_tokens"] for r in rows if r.get("output_tokens") is not None)),
-        "total_tokens": int(sum(r["total_tokens"] for r in rows if r.get("total_tokens") is not None)),
-        "total_cost_usd": round(sum(r["cost_usd"] for r in rows if r.get("cost_usd") is not None), 6),
-        "elapsed_ms_sum": int(sum(r["elapsed_ms"] for r in rows if r.get("elapsed_ms") is not None)),
+        **_numeric_aggregate_fields("input_tokens", input_aggregate),
+        **_numeric_aggregate_fields("output_tokens", output_aggregate),
+        **_numeric_aggregate_fields("total_tokens", total_aggregate),
+        **_money_aggregate_fields([_cost_measurement(r) for r in rows]),
+        **_numeric_aggregate_fields("elapsed_ms_sum", elapsed_aggregate),
     }
 
 
@@ -7116,9 +7423,15 @@ def build_cost_summary(results: list[dict[str, Any]], *, judge_results: dict[str
     design: EVERY run counts here, including execution errors — a timed-out
     run still cost money — while quality rates elsewhere keep excluding them.
     Coverage separates missing telemetry from zero spend."""
-    rows = [{**result_cost_facts(r), "case_id": r["case_id"], "variant": r["variant"],
-             "missing_output": r.get("missing_output"), "execution_valid": r.get("execution_valid", True)}
-            for r in results]
+    rows = []
+    for result in results:
+        facts = bind_telemetry_pair_identity(
+            result_cost_facts(result), case_id=result["case_id"], run_number=int(result.get("run_number", 1)),
+            variant=result["variant"], model=result.get("model"), population="answer")
+        rows.append({**facts, "case_id": result["case_id"], "variant": result["variant"],
+                     "run_number": result.get("run_number", 1), "model": result.get("model"),
+                     "missing_output": result.get("missing_output"),
+                     "execution_valid": result.get("execution_valid", True)})
     totals = {
         **cost_totals_block(rows),
         "execution_errors": sum(1 for r in rows if not r.get("missing_output") and not r.get("execution_valid", True)),
@@ -7128,32 +7441,71 @@ def build_cost_summary(results: list[dict[str, Any]], *, judge_results: dict[str
         vrows = [r for r in rows if r["variant"] == variant]
         by_variant[variant] = {
             "runs": len(vrows),
-            "tokens": cost_stats([r["total_tokens"] for r in vrows if r.get("total_tokens") is not None]),
-            "cost_usd": cost_stats([r["cost_usd"] for r in vrows if r.get("cost_usd") is not None]),
+            "tokens": measurement_stats([_row_measurement(r, "total_tokens") for r in vrows]),
+            "cost_usd": money_measurement_stats([_cost_measurement(r) for r in vrows]),
         }
     by_case = group_spend(rows, lambda r: r["case_id"])
     paired_cost_delta: dict[str, Any] = {}
-    deltas = []
+    deltas_by_currency: dict[str, list[float]] = collections.defaultdict(list)
     for case_id in by_case:
-        with_costs = [r["cost_usd"] for r in rows if r["case_id"] == case_id and r["variant"] == "with_skill" and r.get("cost_usd") is not None]
-        without_costs = [r["cost_usd"] for r in rows if r["case_id"] == case_id and r["variant"] == "without_skill" and r.get("cost_usd") is not None]
-        if with_costs and without_costs:
-            delta = statistics.mean(with_costs) - statistics.mean(without_costs)
-            paired_cost_delta[case_id] = {"with_skill": round(statistics.mean(with_costs), 6), "without_skill": round(statistics.mean(without_costs), 6), "delta": round(delta, 6)}
-            deltas.append(delta)
+        with_rows = {(r.get("model"), r.get("run_number", 1)): r for r in rows if r["case_id"] == case_id and r["variant"] == "with_skill"}
+        without_rows = {(r.get("model"), r.get("run_number", 1)): r for r in rows if r["case_id"] == case_id and r["variant"] == "without_skill"}
+        comparisons = [telemetry_domain.compare_cost_pair(
+            _cost_measurement(with_rows[key]), _cost_measurement(without_rows[key]),
+            left_scorable=scorable_run(with_rows[key]), right_scorable=scorable_run(without_rows[key]))
+                       for key in sorted(set(with_rows) & set(without_rows), key=str)]
+        comparable = [c for c in comparisons if c.availability == telemetry_domain.COMPARABLE]
+        blocked = [str(c.reason) for c in comparisons if c.availability == telemetry_domain.BLOCKED]
+        if comparable:
+            by_currency: dict[str, list[Any]] = collections.defaultdict(list)
+            for comparison in comparable:
+                by_currency[comparison.value.currency].append(comparison)
+            for currency, currency_comparisons in by_currency.items():
+                deltas_by_currency[currency].append(statistics.mean(float(c.value.amount) for c in currency_comparisons))
+            if len(by_currency) == 1:
+                currency, currency_comparisons = next(iter(by_currency.items()))
+                values = [float(c.value.amount) for c in currency_comparisons]
+                delta = statistics.mean(values)
+                paired_cost_delta[case_id] = {
+                    "availability": "comparable", "currency": currency,
+                    "delta": round(delta, 6), "eligible_pairs": len(comparable),
+                    "blocked_pairs": len(blocked), "blocked_reason_counts": dict(collections.Counter(blocked)),
+                }
+            else:
+                paired_cost_delta[case_id] = {
+                    "availability": "blocked", "delta": None, "reason": "mixed_currency_pairs",
+                    "by_currency": {currency: {"delta": round(statistics.mean(float(c.value.amount) for c in cs), 6),
+                                                "eligible_pairs": len(cs)} for currency, cs in by_currency.items()},
+                    "eligible_pairs": len(comparable), "blocked_pairs": len(blocked),
+                    "blocked_reason_counts": dict(collections.Counter(blocked)),
+                }
+        else:
+            paired_cost_delta[case_id] = {
+                "availability": "blocked",
+                "delta": None,
+                "eligible_pairs": 0,
+                "blocked_pairs": len(blocked),
+                "blocked_reason_counts": dict(collections.Counter(blocked or ["missing_pair"])),
+            }
     ablation_spend = spend_of([r for r in rows if is_ablation_variant(r.get("variant", ""))])
     ablation_cost = ablation_spend["total_cost_usd"]
     out: dict[str, Any] = {
+        "telemetry_schema_version": 3,
         "coverage": cost_coverage_block(rows),
         "totals": totals,
         "by_variant": by_variant,
         "by_case": by_case,
         "paired_cost_delta": paired_cost_delta,
-        "mean_paired_cost_delta": round(statistics.mean(deltas), 6) if deltas else None,
+        # A bare paired delta is USD-only; foreign-currency results retain their
+        # own units rather than being silently labelled dollars.
+        "mean_paired_cost_delta": round(statistics.mean(deltas_by_currency["USD"]), 6) if deltas_by_currency.get("USD") else None,
+        "mean_paired_cost_delta_basis": {"currency": "USD"} if deltas_by_currency.get("USD") else None,
+        "mean_paired_cost_delta_by_currency": {currency: round(statistics.mean(values), 6)
+                                                  for currency, values in sorted(deltas_by_currency.items())},
         "ablations": {
             **ablation_spend,
             "confirmed_regressions": confirmed_regressions,
-            "cost_per_confirmed_regression": round(ablation_cost / confirmed_regressions, 6) if confirmed_regressions and ablation_cost else None,
+            "cost_per_confirmed_regression": round(ablation_cost / confirmed_regressions, 6) if confirmed_regressions and ablation_cost is not None else None,
         },
     }
     if judge_results:
@@ -7177,11 +7529,16 @@ def judge_cost_usd(row: dict[str, Any]) -> float | None:
 
 
 def judge_cost_block(judge_results: dict[str, dict[str, Any]]) -> dict[str, Any]:
-    costs = [c for c in (judge_cost_usd(row) for row in judge_results.values()) if c is not None]
+    measurements = [
+        telemetry_domain.measurement_from_envelope_or_cost(
+            row, source=str(row.get("provider") or "judge"), population="judge")
+        for row in judge_results.values()
+    ]
+    available = sum(1 for measurement in measurements if measurement.availability == telemetry_domain.AVAILABLE)
     return {
         "verdicts": len(judge_results),
-        "verdicts_with_cost": len(costs),
-        "total_cost_usd": round(sum(costs), 6) if costs else None,
+        "verdicts_with_cost": available,
+        **_money_aggregate_fields(measurements),
     }
 
 
@@ -7232,19 +7589,18 @@ def variant_summary_block(rows: list[dict[str, Any]]) -> dict[str, Any]:
     # Timing/token/command central tendencies describe SCORABLE runs, matching
     # the pass-rate block above — a timed-out run's full duration must not drag
     # the mean (the failure count is disclosed separately as execution_errors).
-    merged_metrics = []
-    for r in scorable_rows:
-        merged = dict(r.get("metadata", {}) or {})
-        merged.update(read_metrics_base(Path(r.get("run_base", ""))))
-        merged_metrics.append(merged)
-    elapsed = [metric_number(m, "elapsed_ms") for m in merged_metrics]
-    tokens = [metric_number(m, "total_tokens") for m in merged_metrics]
-    commands = [metric_number(m, "commands", "command_count") for m in merged_metrics]
-    costs = [metric_number(m, "cost_usd") for m in merged_metrics]
-    elapsed = [x for x in elapsed if x is not None]
-    tokens = [x for x in tokens if x is not None]
-    commands = [x for x in commands if x is not None]
-    costs = [x for x in costs if x is not None]
+    facts = [result_cost_facts(r) for r in scorable_rows]
+    command_measurements = []
+    for row in scorable_rows:
+        merged = dict(row.get("metadata", {}) or {})
+        merged.update(read_metrics_base(Path(row.get("run_base", ""))))
+        command_measurements.append(telemetry_domain.measurement_from_envelope_or_nonnegative(merged, "commands"))
+    elapsed_measurements = [fact["elapsed_ms_measurement"] for fact in facts]
+    token_measurements = [fact["total_tokens_measurement"] for fact in facts]
+    cost_measurements = [fact["cost_measurement"] for fact in facts]
+    cost_total = _money_aggregate_fields(cost_measurements)
+    elapsed = [m.value for m in elapsed_measurements if m.availability == telemetry_domain.AVAILABLE]
+    tokens = [m.value for m in token_measurements if m.availability == telemetry_domain.AVAILABLE]
     return {
         "cases": len({r["case_id"] for r in rows}),
         "runs": len(rows),
@@ -7258,13 +7614,16 @@ def variant_summary_block(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "combined_pass_rate": stats(combined_rates),
         "process_pass_rate": stats(process_rates),
         "efficiency_pass_rate": stats(efficiency_rates),
-        "elapsed_ms": stats(elapsed),
-        "total_tokens": stats(tokens),
-        "command_count": stats(commands),
+        "elapsed_ms": measurement_stats(elapsed_measurements),
+        "total_tokens": measurement_stats(token_measurements),
+        "command_count": measurement_stats(command_measurements),
         # Real dollar cost, when a runner recorded it (the Claude adapter does).
-        # Sum, not mean: "what did this arm cost to run" — over scorable runs only.
-        "cost_usd_total": round(sum(costs), 6) if costs else None,
-        "cost_usd": stats(costs),
+        # A partial set has a named known subtotal, never a false total.
+        "cost_usd_total": cost_total["total_cost_usd"],
+        "cost_usd_total_aggregate": cost_total["total_cost_usd_aggregate"],
+        **({"known_cost_usd_total": cost_total["known_total_cost_usd"]}
+           if "known_total_cost_usd" in cost_total else {}),
+        "cost_usd": money_measurement_stats(cost_measurements),
         "telemetry_availability": telemetry_summary(rows),
         # Backward-compatible fields used by smoke_report.py callers.
         "median_elapsed_ms": statistics.median(elapsed) if elapsed else None,
@@ -7457,14 +7816,24 @@ def junit_xml_from_report(report: dict[str, Any]) -> str:
         ET.SubElement(props, "property", {"name": key, "value": "" if value is None else f"{value:.4f}"})
     failures = 0
     total_time = 0.0
+    missing_time = 0
     for r in results:
-        elapsed_ms = metric_number(r.get("metadata", {}) or {}, "elapsed_ms") or 0.0
-        total_time += elapsed_ms / 1000.0
-        tc = ET.SubElement(suite, "testcase", {
+        elapsed = telemetry_domain.measurement_from_envelope_or_nonnegative(
+            r.get("metadata", {}) or {}, "elapsed_ms")
+        attrs = {
             "classname": f"{skill}.{r.get('case_id')}",
             "name": f"{r.get('variant')}/run-{r.get('run_number', 1)}",
-            "time": f"{elapsed_ms / 1000.0:.3f}",
-        })
+        }
+        if elapsed.availability == telemetry_domain.AVAILABLE:
+            total_time += float(elapsed.value) / 1000.0
+            attrs["time"] = f"{float(elapsed.value) / 1000.0:.3f}"
+        else:
+            missing_time += 1
+            ET.SubElement(props, "property", {
+                "name": f"telemetry.elapsed_ms.{r.get('case_id')}.{r.get('variant')}.run-{r.get('run_number', 1)}",
+                "value": elapsed.availability if elapsed.availability != telemetry_domain.UNAVAILABLE else f"unavailable:{elapsed.reason}",
+            })
+        tc = ET.SubElement(suite, "testcase", attrs)
         lines = result_failure_lines(r)
         if lines:
             failures += 1
@@ -7473,7 +7842,10 @@ def junit_xml_from_report(report: dict[str, Any]) -> str:
     suite.set("tests", str(len(results)))
     suite.set("failures", str(failures))
     suite.set("errors", "0")
-    suite.set("time", f"{total_time:.3f}")
+    if missing_time:
+        ET.SubElement(props, "property", {"name": "telemetry.elapsed_ms.aggregate", "value": "partial"})
+    else:
+        suite.set("time", f"{total_time:.3f}")
     return '<?xml version="1.0" encoding="UTF-8"?>\n' + ET.tostring(suite, encoding="unicode")
 
 
@@ -7544,11 +7916,12 @@ def aggregate(args: argparse.Namespace) -> int:
             runs = Path(args.runs)
         reports.append(build_benchmark_report(manifest_path, runs, args.split, args.variant, getattr(args, "judge_results", None), allow_scripts=getattr(args, "allow_scripts", False)))
 
-    cross_totals: dict[str, float] = {}
-    for r in reports:
-        for key, value in (r.get("cost_summary", {}).get("totals") or {}).items():
-            if isinstance(value, (int, float)):
-                cross_totals[key] = cross_totals.get(key, 0) + value
+    # Re-aggregate run facts rather than summing report scalars: a partial
+    # per-skill known subtotal is not a complete cross-skill total.
+    cross_rows = [
+        {**result_cost_facts(row), "case_id": row.get("case_id"), "variant": row.get("variant")}
+        for report in reports for row in report.get("results", [])
+    ]
     aggregate_summary: dict[str, Any] = {
         "skills": len(reports),
         "case_variant_rows": sum(len(r["results"]) for r in reports),
@@ -7556,7 +7929,8 @@ def aggregate(args: argparse.Namespace) -> int:
         "by_skill": {r["skill_name"]: r["summary"] for r in reports},
         # Cross-skill spend ledger (issue #21): which skills dominate the bill.
         "cost_summary": {
-            "totals": {k: (round(v, 6) if isinstance(v, float) else v) for k, v in cross_totals.items()},
+            "coverage": cost_coverage_block(cross_rows),
+            "totals": cost_totals_block(cross_rows),
             "by_skill": {r["skill_name"]: (r.get("cost_summary", {}).get("totals") or {}) for r in reports},
         },
         "flags": [
@@ -7591,23 +7965,35 @@ def anthropic_benchmark_from_report(report: dict[str, Any], skill_path: str = ""
     runs = []
     for r in report["results"]:
         meta = r.get("metadata", {}) or {}
-        elapsed_ms = metric_number(meta, "elapsed_ms", "duration_ms") or 0.0
-        tokens = metric_number(meta, "total_tokens") or 0.0
+        elapsed = telemetry_domain.measurement_from_envelope_or_nonnegative(meta, "elapsed_ms")
+        tokens = telemetry_domain.measurement_from_envelope_or_usage(meta, "total_tokens")
+        tool_calls = telemetry_domain.measurement_from_envelope_or_nonnegative(meta, "tool_calls")
+        result = {
+            "pass_rate": r.get("combined_pass_rate") if r.get("combined_pass_rate") is not None else r.get("objective_pass_rate", 0.0),
+            "passed": r.get("combined_passed", r.get("objective_passed", 0)),
+            "failed": r.get("combined_total", r.get("objective_total", 0)) - r.get("combined_passed", r.get("objective_passed", 0)),
+            "total": r.get("combined_total", r.get("objective_total", 0)),
+        }
+        availability: dict[str, Any] = {}
+        if elapsed.availability == telemetry_domain.AVAILABLE:
+            result["time_seconds"] = round(float(elapsed.value) / 1000, 3)
+        else:
+            availability["time_seconds"] = elapsed.to_dict()
+        if tokens.availability == telemetry_domain.AVAILABLE:
+            result["tokens"] = int(tokens.value)
+        else:
+            availability["tokens"] = tokens.to_dict()
+        if tool_calls.availability == telemetry_domain.AVAILABLE:
+            result["tool_calls"] = int(tool_calls.value)
+        else:
+            availability["tool_calls"] = tool_calls.to_dict()
         runs.append({
             "eval_id": r["case_id"],
             "eval_name": r["case_id"],
             "configuration": r["variant"],
             "run_number": r.get("run_number", 1),
-            "result": {
-                "pass_rate": r.get("combined_pass_rate") if r.get("combined_pass_rate") is not None else r.get("objective_pass_rate", 0.0),
-                "passed": r.get("combined_passed", r.get("objective_passed", 0)),
-                "failed": r.get("combined_total", r.get("objective_total", 0)) - r.get("combined_passed", r.get("objective_passed", 0)),
-                "total": r.get("combined_total", r.get("objective_total", 0)),
-                "time_seconds": round(elapsed_ms / 1000, 3),
-                "tokens": int(tokens),
-                "tool_calls": int(meta.get("total_tool_calls", 0) or 0),
-                "errors": int(meta.get("errors_encountered", 0) or (1 if meta.get("returncode", 0) else 0)),
-            },
+            "result": result,
+            "telemetry": availability,
             "expectations": expectation_texts(r),
             "notes": [],
         })
@@ -7617,19 +8003,27 @@ def anthropic_benchmark_from_report(report: dict[str, Any], skill_path: str = ""
         pr = summary.get("combined_pass_rate") or summary.get("objective_pass_rate") or {}
         tm = summary.get("elapsed_ms") or {}
         tk = summary.get("total_tokens") or {}
+        def copied_stats(values: dict[str, Any], *, divide: float = 1.0) -> dict[str, Any]:
+            out = {key: (float(values[key]) / divide if isinstance(values.get(key), (int, float)) else None)
+                   for key in ("mean", "stddev", "min", "max")}
+            if values.get("availability") not in (None, telemetry_domain.COMPLETE):
+                out["availability"] = values.get("availability")
+            return out
+
         run_summary[variant] = {
-            "pass_rate": {"mean": pr.get("mean", 0.0) or 0.0, "stddev": pr.get("stddev", 0.0) or 0.0, "min": pr.get("min", 0.0) or 0.0, "max": pr.get("max", 0.0) or 0.0},
-            "time_seconds": {"mean": ((tm.get("mean") or 0.0) / 1000), "stddev": ((tm.get("stddev") or 0.0) / 1000), "min": ((tm.get("min") or 0.0) / 1000), "max": ((tm.get("max") or 0.0) / 1000)},
-            "tokens": {"mean": tk.get("mean", 0.0) or 0.0, "stddev": tk.get("stddev", 0.0) or 0.0, "min": tk.get("min", 0.0) or 0.0, "max": tk.get("max", 0.0) or 0.0},
+            "pass_rate": copied_stats(pr),
+            "time_seconds": copied_stats(tm, divide=1000),
+            "tokens": copied_stats(tk),
         }
     configs = [k for k in run_summary.keys() if k != "delta"]
     if len(configs) >= 2:
         a, b = configs[0], configs[1]
-        run_summary["delta"] = {
-            "pass_rate": f"{run_summary[a]['pass_rate']['mean'] - run_summary[b]['pass_rate']['mean']:+.2f}",
-            "time_seconds": f"{run_summary[a]['time_seconds']['mean'] - run_summary[b]['time_seconds']['mean']:+.1f}",
-            "tokens": f"{run_summary[a]['tokens']['mean'] - run_summary[b]['tokens']['mean']:+.0f}",
-        }
+        deltas = {}
+        for key, digits in (("pass_rate", 2), ("time_seconds", 1), ("tokens", 0)):
+            left = run_summary[a][key]["mean"]
+            right = run_summary[b][key]["mean"]
+            deltas[key] = f"{left - right:+.{digits}f}" if left is not None and right is not None else None
+        run_summary["delta"] = deltas
     return {
         "metadata": {
             "skill_name": report.get("skill_name", "<skill-name>"),
@@ -8022,6 +8416,96 @@ def migrate_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def migrate_telemetry_command(args: argparse.Namespace) -> int:
+    """Upgrade run artifacts to the additive, idempotent telemetry v3 envelope."""
+    runs = Path(args.runs)
+    if not runs.is_dir():
+        die(f"runs directory does not exist: {runs}")
+    bases = sorted({p.parent for name in ("metadata.json", "metrics.json") for p in runs.rglob(name)})
+    changed: list[str] = []
+    unchanged: list[str] = []
+    for base in bases:
+        docs: dict[str, dict[str, Any]] = {}
+        for name in ("metadata.json", "metrics.json"):
+            path = base / name
+            if not path.exists():
+                continue
+            data = read_json_dict_or_list(path)
+            if isinstance(data, dict) and not data.get("_error"):
+                docs[name] = dict(data)
+        if not docs:
+            continue
+        merged: dict[str, Any] = {}
+        for name in ("metadata.json", "metrics.json"):
+            merged.update(docs.get(name, {}))
+        source = str(merged.get("provider") or merged.get("runner") or merged.get("trace_source") or "legacy")
+        envelope = telemetry_domain.telemetry_envelope(
+            merged, source=source, population=str(merged.get("population") or "answer"),
+            legacy_unverified=not (isinstance(merged.get("telemetry"), dict)
+                                   and merged["telemetry"].get("schema_version") == 3),
+        )
+        updated: dict[str, dict[str, Any]] = {}
+        for name in ("metadata.json", "metrics.json"):
+            # A v3 run contract always has both consumers' artifacts. For an old
+            # one-file run, mirror the audit fields rather than inventing metrics.
+            next_data = dict(docs.get(name, merged))
+            next_data.setdefault("usage_normalized", {"source": "missing"})
+            next_data.setdefault("cost_normalized", {"source": "missing"})
+            next_data["telemetry_schema_version"] = 3
+            next_data["telemetry"] = envelope
+            updated[name] = next_data
+        if all((base / name).exists() and updated[name] == docs.get(name) for name in updated):
+            unchanged.append(str(base))
+            continue
+        changed.append(str(base))
+        if not getattr(args, "check", False):
+            staged: list[tuple[Path, Path]] = []
+            backups: list[tuple[Path, Path]] = []
+            installed: list[Path] = []
+            try:
+                for name, data in updated.items():
+                    path = base / name
+                    tmp = path.with_suffix(path.suffix + ".telemetry-v3.tmp")
+                    tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+                    staged.append((path, tmp))
+                # Keep recoverable siblings until every replacement succeeds;
+                # an interrupted migration cannot strand metadata ahead of metrics.
+                for path, _ in staged:
+                    if path.exists():
+                        backup = path.with_suffix(path.suffix + ".telemetry-v3.bak")
+                        os.replace(path, backup)
+                        backups.append((path, backup))
+                for path, tmp in staged:
+                    os.replace(tmp, path)
+                    installed.append(path)
+            except OSError:
+                # Only delete replacements that were actually installed. A
+                # later failed backup must leave an untouched sibling intact.
+                for path in installed:
+                    path.unlink(missing_ok=True)
+                for path, backup in reversed(backups):
+                    if backup.exists():
+                        os.replace(backup, path)
+                raise
+            else:
+                for _, backup in backups:
+                    backup.unlink(missing_ok=True)
+            finally:
+                for _, tmp in staged:
+                    tmp.unlink(missing_ok=True)
+    report = {
+        "telemetry_schema_version": 3,
+        "runs": str(runs),
+        "mode": "check" if getattr(args, "check", False) else "write",
+        "run_dirs_seen": len(bases),
+        "changed": len(changed),
+        "unchanged": len(unchanged),
+        "changed_run_dirs": changed,
+    }
+    emit_report(report, getattr(args, "out", None))
+    return 0
+
+
 def suite_cost_ledger(manifest_path: Path, runs: Path, *, benchmark_report: dict[str, Any] | None = None, judge_results: dict[str, dict[str, Any]] | None = None, top_n: int = 10) -> dict[str, Any]:
     """The standalone suite cost ledger (issue #21's cost-summary.json): walks
     the run tree per manifest case — every variant directory found on disk,
@@ -8031,9 +8515,17 @@ def suite_cost_ledger(manifest_path: Path, runs: Path, *, benchmark_report: dict
     by_variant = group_spend(rows, lambda r: r["variant"])
     by_runner = group_spend(rows, lambda r: str(r.get("runner") or "unknown"))
     by_case = group_spend(rows, lambda r: r["case_id"])
-    expensive_cases = sorted(by_case.items(), key=lambda kv: (-(kv[1]["total_cost_usd"] or 0), -kv[1]["total_tokens"], kv[0]))[:top_n]
+    # Unknown/partial spend is not cheap spend. Only complete compatible USD
+    # totals are ranked; partial rows remain visible in by_case/by_variant.
+    expensive_cases = sorted(
+        ((key, value) for key, value in by_case.items() if value.get("total_cost_usd") is not None),
+        key=lambda kv: (-float(kv[1]["total_cost_usd"]), -int(kv[1].get("total_tokens") or 0), kv[0]),
+    )[:top_n]
     ablation_spend = group_spend([r for r in rows if is_ablation_variant(r["variant"])], lambda r: r["variant"])
-    top_ablations = sorted(ablation_spend.items(), key=lambda kv: (-(kv[1]["total_cost_usd"] or 0), -kv[1]["total_tokens"], kv[0]))[:top_n]
+    top_ablations = sorted(
+        ((key, value) for key, value in ablation_spend.items() if value.get("total_cost_usd") is not None),
+        key=lambda kv: (-float(kv[1]["total_cost_usd"]), -int(kv[1].get("total_tokens") or 0), kv[0]),
+    )[:top_n]
     findings: list[dict[str, Any]] = []
     if benchmark_report:
         flagged = {flag.get("case_id"): flag.get("flags", []) for flag in benchmark_report.get("case_flags", [])}
@@ -8050,8 +8542,10 @@ def suite_cost_ledger(manifest_path: Path, runs: Path, *, benchmark_report: dict
                     "total_tokens": spend["total_tokens"],
                     "total_cost_usd": spend["total_cost_usd"],
                 })
-        findings.sort(key=lambda f: (-(f.get("total_cost_usd") or 0), str(f.get("case_id"))))
+        findings.sort(key=lambda f: (-float(f["total_cost_usd"]), str(f.get("case_id")))
+                      if f.get("total_cost_usd") is not None else (float("inf"), str(f.get("case_id"))))
     ledger: dict[str, Any] = {
+        "telemetry_schema_version": 3,
         "generated_at": int(time.time()),
         "manifest": str(manifest_path),
         "skill_name": manifest.get("skill_name"),
@@ -8071,31 +8565,40 @@ def suite_cost_ledger(manifest_path: Path, runs: Path, *, benchmark_report: dict
 
 
 def cost_ledger_markdown(ledger: dict[str, Any]) -> str:
+    """Render availability-aware ledger cells without numeric fallbacks."""
     totals = ledger.get("totals", {})
     coverage = ledger.get("coverage", {})
+
+    def show(slot: dict[str, Any], name: str, prefix: str = "") -> str:
+        aggregate = slot.get(f"{name}_aggregate")
+        if isinstance(aggregate, dict):
+            return telemetry_domain.display_aggregate(aggregate, prefix=prefix)
+        value = slot.get(name)
+        return f"{prefix}{value}" if value is not None else "— unavailable"
+
     lines = [
         f"# Cost summary — {ledger.get('skill_name')}",
         "",
         f"Runs: {coverage.get('runs_seen')} (usage on {coverage.get('runs_with_token_usage')}, dollars on {coverage.get('runs_with_dollar_cost')}; missing usage {coverage.get('runs_missing_usage')}, missing cost {coverage.get('runs_missing_cost')})",
         "",
-        f"**Totals:** {totals.get('total_tokens'):,} tokens (in {totals.get('input_tokens'):,} / out {totals.get('output_tokens'):,}), ${totals.get('total_cost_usd')} provider-reported, {totals.get('elapsed_ms_sum')} ms summed",
+        f"**Totals:** {show(totals, 'total_tokens')} tokens (in {show(totals, 'input_tokens')} / out {show(totals, 'output_tokens')}), {show(totals, 'total_cost_usd', '$')}, {show(totals, 'elapsed_ms_sum')} ms summed",
         "",
         "| Variant | Runs | Tokens | Cost USD |",
         "|---|---:|---:|---:|",
     ]
     for variant, slot in ledger.get("by_variant", {}).items():
-        lines.append(f"| {variant} | {slot['runs']} | {slot['total_tokens']:,} | {slot['total_cost_usd']} |")
+        lines.append(f"| {variant} | {slot['runs']} | {show(slot, 'total_tokens')} | {show(slot, 'total_cost_usd', '$')} |")
     if ledger.get("top_expensive_cases"):
         lines += ["", "## Top expensive cases", "", "| Case | Runs | Tokens | Cost USD |", "|---|---:|---:|---:|"]
         for row in ledger["top_expensive_cases"]:
-            lines.append(f"| {row['case_id']} | {row['runs']} | {row['total_tokens']:,} | {row['total_cost_usd']} |")
+            lines.append(f"| {row['case_id']} | {row['runs']} | {show(row, 'total_tokens')} | {show(row, 'total_cost_usd', '$')} |")
     if ledger.get("cost_quality_findings"):
         lines += ["", "## Cost-quality findings", ""]
         for f in ledger["cost_quality_findings"]:
-            lines.append(f"- `{f.get('case_id')}`: {', '.join(f.get('flags', []))} — {f.get('total_tokens'):,} tokens, ${f.get('total_cost_usd')}")
+            lines.append(f"- `{f.get('case_id')}`: {', '.join(f.get('flags', []))} — {show(f, 'total_tokens')} tokens, {show(f, 'total_cost_usd', '$')}")
     if ledger.get("judge"):
         j = ledger["judge"]
-        lines += ["", f"Judge spend (separate from model under test): {j.get('verdicts')} verdicts, ${j.get('total_cost_usd')}"]
+        lines += ["", f"Judge spend (separate from model under test): {j.get('verdicts')} verdicts, {show(j, 'total_cost_usd', '$')}"]
     return "\n".join(lines) + "\n"
 
 
@@ -8425,6 +8928,24 @@ def profile_skill_report(
     }
 
 
+def paired_run_bases(runs: Path, case_id: str, with_variant: str, without_variant: str):
+    """Yield model-aware paired runs without overwriting same-number models."""
+    for model, model_root in discover_case_model_roots(runs, case_id, [with_variant, without_variant]):
+        with_dir = model_root / with_variant
+        without_dir = model_root / without_variant
+        with_runs = discover_run_bases_under(with_dir) if with_dir.exists() else []
+        without_runs = discover_run_bases_under(without_dir) if without_dir.exists() else []
+        with_by_run = {run_number: base for run_number, base in with_runs}
+        without_by_run = {run_number: base for run_number, base in without_runs}
+        if len(with_runs) == len(without_runs) == 1 and with_runs[0][0] == without_runs[0][0]:
+            # Preserve the historical one-off pairing fallback only when the
+            # recorded repetition key agrees on both arms.
+            yield model, with_runs[0][0], with_runs[0][1], without_runs[0][1]
+            continue
+        for run_number in sorted(set(with_by_run) | set(without_by_run)):
+            yield model, run_number, with_by_run.get(run_number), without_by_run.get(run_number)
+
+
 def paired_token_overhead_report(
     manifest_path: Path,
     *,
@@ -8436,16 +8957,26 @@ def paired_token_overhead_report(
     profile = profile_skill_report(manifest_path)
     with_variant, without_variant = variants
     pairs: list[dict[str, Any]] = []
+    blocked_pairs: list[dict[str, Any]] = []
     if runs is not None:
         for case in iter_cases(manifest, split):
-            with_runs = discover_run_bases(runs, case["id"], with_variant)
-            without_runs = discover_run_bases(runs, case["id"], without_variant)
-            without_by_run = {n: base for n, base in without_runs}
-            for run_number, with_base in with_runs:
-                without_base = without_by_run.get(run_number)
-                if without_base is None and len(with_runs) == 1 and len(without_runs) == 1:
-                    without_base = without_runs[0][1]
-                if without_base is None:
+            for model_name, run_number, with_base, without_base in paired_run_bases(
+                runs, case["id"], with_variant, without_variant):
+                if with_base is None or without_base is None:
+                    missing_reason = "missing_left" if with_base is None else "missing_right"
+                    blocked_pairs.append({
+                        "case_id": case["id"], "model": model_name, "run_number": run_number,
+                        "with_run_base": str(with_base) if with_base else None,
+                        "without_run_base": str(without_base) if without_base else None,
+                        "pair_status": {"availability": "blocked", "reason": missing_reason},
+                        "cost_delta_comparison": {"availability": "blocked", "reason": missing_reason},
+                        "objective_lift_per_dollar_comparison": {"availability": "blocked", "reason": missing_reason},
+                        "objective_lift_per_1k_total_tokens_comparison": {"availability": "blocked", "reason": missing_reason},
+                        "objective_delta_comparison": {"availability": "blocked", "reason": missing_reason},
+                        "cost_delta_usd": None, "objective_lift_per_dollar": None,
+                        "total_token_delta": None, "objective_lift_per_1k_total_tokens": None,
+                        "objective_delta": None,
+                    })
                     continue
                 with_metrics = read_metrics_base(with_base)
                 without_metrics = read_metrics_base(without_base)
@@ -8458,55 +8989,125 @@ def paired_token_overhead_report(
                 # scorable predicate every report view uses (was: graded raw, so a
                 # crashed with_skill arm differenced to a false -1.0 "skill regression").
                 if not (scorable_run(with_grade) and scorable_run(without_grade)):
+                    blocked_pairs.append({
+                        "case_id": case["id"], "model": model_name, "run_number": run_number,
+                        "with_run_base": str(with_base), "without_run_base": str(without_base),
+                        "pair_status": {"availability": "blocked", "reason": "unscorable_arm"},
+                        "cost_delta_comparison": {"availability": "blocked", "reason": "unscorable_arm"},
+                        "objective_lift_per_dollar_comparison": {"availability": "blocked", "reason": "unscorable_arm"},
+                        "objective_lift_per_1k_total_tokens_comparison": {"availability": "blocked", "reason": "unscorable_arm"},
+                        "objective_delta_comparison": {"availability": "blocked", "reason": "unscorable_arm"},
+                        "cost_delta_usd": None, "objective_lift_per_dollar": None,
+                        "total_token_delta": None, "objective_lift_per_1k_total_tokens": None,
+                        "objective_delta": None,
+                    })
                     continue
-                with_facts = run_cost_facts(with_metrics)
-                without_facts = run_cost_facts(without_metrics)
-                wc = with_facts.get("cost_usd")
-                nc = without_facts.get("cost_usd")
-                wt = metric_number(with_metrics, "total_tokens")
-                nt = metric_number(without_metrics, "total_tokens")
-                wi = metric_number(with_metrics, "input_tokens")
-                ni = metric_number(without_metrics, "input_tokens")
-                wo = metric_number(with_metrics, "output_tokens")
-                no = metric_number(without_metrics, "output_tokens")
-                if wt is None and wi is None and wo is None:
-                    continue
+                with_facts = bind_telemetry_pair_identity(
+                    run_cost_facts(with_metrics), case_id=case["id"], run_number=run_number,
+                    variant=with_variant, model=with_metrics.get("model") or model_name, population="answer")
+                without_facts = bind_telemetry_pair_identity(
+                    run_cost_facts(without_metrics), case_id=case["id"], run_number=run_number,
+                    variant=without_variant, model=without_metrics.get("model") or model_name, population="answer")
+                with_total = with_facts["total_tokens_measurement"]
+                without_total = without_facts["total_tokens_measurement"]
+                with_input = with_facts["input_tokens_measurement"]
+                without_input = without_facts["input_tokens_measurement"]
+                with_output = with_facts["output_tokens_measurement"]
+                without_output = without_facts["output_tokens_measurement"]
+                token_delta = telemetry_domain.compare_numeric_pair(with_total, without_total,
+                                                                      left_scorable=scorable_run(with_grade), right_scorable=scorable_run(without_grade))
+                input_delta = telemetry_domain.compare_numeric_pair(with_input, without_input,
+                                                                      left_scorable=scorable_run(with_grade), right_scorable=scorable_run(without_grade))
+                output_delta = telemetry_domain.compare_numeric_pair(with_output, without_output,
+                                                                       left_scorable=scorable_run(with_grade), right_scorable=scorable_run(without_grade))
+                cost_delta = telemetry_domain.compare_cost_pair(
+                    with_facts["cost_measurement"], without_facts["cost_measurement"],
+                    left_scorable=scorable_run(with_grade), right_scorable=scorable_run(without_grade))
+                with_rate = with_grade.get("objective_pass_rate")
+                without_rate = without_grade.get("objective_pass_rate")
+                objective_comparison = telemetry_domain.compare_objective_rates(
+                    with_rate, without_rate,
+                    left_scorable=scorable_run(with_grade), right_scorable=scorable_run(without_grade))
+                objective_delta = objective_comparison.value if objective_comparison.availability == telemetry_domain.COMPARABLE else None
+                lift_per_token = telemetry_domain.lift_per_1k_tokens(objective_comparison, token_delta)
+                lift_per_dollar = telemetry_domain.lift_per_dollar(objective_comparison, cost_delta)
+
+                def scalar(measurement):
+                    return measurement.value if measurement.availability == telemetry_domain.AVAILABLE else None
+
+                with_cost = scalar(with_facts["cost_measurement"])
+                without_cost = scalar(without_facts["cost_measurement"])
                 pairs.append({
                     "case_id": case["id"],
+                    "model": model_name or with_metrics.get("model") or without_metrics.get("model"),
+                    "pair_status": {"availability": "comparable"},
                     "run_number": run_number,
                     "with_run_base": str(with_base),
                     "without_run_base": str(without_base),
                     "with_skill_invoked": with_metrics.get("skill_invoked"),
                     "without_skill_invoked": without_metrics.get("skill_invoked"),
-                    "with_total_tokens": wt,
-                    "without_total_tokens": nt,
-                    "total_token_delta": (wt - nt) if wt is not None and nt is not None else None,
-                    "with_input_tokens": wi,
-                    "without_input_tokens": ni,
-                    "input_token_delta": (wi - ni) if wi is not None and ni is not None else None,
-                    "with_output_tokens": wo,
-                    "without_output_tokens": no,
-                    "output_token_delta": (wo - no) if wo is not None and no is not None else None,
-                    "with_objective_pass_rate": with_grade.get("objective_pass_rate"),
-                    "without_objective_pass_rate": without_grade.get("objective_pass_rate"),
-                    "objective_delta": (with_grade.get("objective_pass_rate") - without_grade.get("objective_pass_rate")) if with_grade.get("objective_pass_rate") is not None and without_grade.get("objective_pass_rate") is not None else None,
-                    "objective_lift_per_1k_total_tokens": ((with_grade.get("objective_pass_rate") - without_grade.get("objective_pass_rate")) / ((wt - nt) / 1000)) if wt is not None and nt is not None and wt > nt and with_grade.get("objective_pass_rate") is not None and without_grade.get("objective_pass_rate") is not None else None,
-                    # Dollar channel (issue #21): what the skill costs, and what
-                    # a point of lift costs, in money rather than tokens.
-                    "with_cost_usd": wc,
-                    "without_cost_usd": nc,
-                    "cost_delta_usd": round(wc - nc, 6) if wc is not None and nc is not None else None,
-                    "objective_lift_per_dollar": (((with_grade.get("objective_pass_rate") - without_grade.get("objective_pass_rate")) / (wc - nc)) if wc is not None and nc is not None and wc > nc and with_grade.get("objective_pass_rate") is not None and without_grade.get("objective_pass_rate") is not None else None),
+                    "with_total_tokens": scalar(with_total),
+                    "without_total_tokens": scalar(without_total),
+                    "total_token_delta": token_delta.value if token_delta.availability == telemetry_domain.COMPARABLE else None,
+                    "total_token_delta_comparison": token_delta.to_dict(),
+                    "with_input_tokens": scalar(with_input),
+                    "without_input_tokens": scalar(without_input),
+                    "input_token_delta": input_delta.value if input_delta.availability == telemetry_domain.COMPARABLE else None,
+                    "input_token_delta_comparison": input_delta.to_dict(),
+                    "with_output_tokens": scalar(with_output),
+                    "without_output_tokens": scalar(without_output),
+                    "output_token_delta": output_delta.value if output_delta.availability == telemetry_domain.COMPARABLE else None,
+                    "output_token_delta_comparison": output_delta.to_dict(),
+                    "with_objective_pass_rate": with_rate,
+                    "without_objective_pass_rate": without_rate,
+                    "objective_delta": objective_delta,
+                    "objective_delta_comparison": objective_comparison.to_dict(),
+                    "objective_lift_per_1k_total_tokens": lift_per_token.value if lift_per_token.availability == telemetry_domain.COMPARABLE else None,
+                    "objective_lift_per_1k_total_tokens_comparison": lift_per_token.to_dict(),
+                    "with_cost": with_facts["cost_measurement"].to_dict(),
+                    "without_cost": without_facts["cost_measurement"].to_dict(),
+                    "with_cost_usd": float(with_cost.amount) if isinstance(with_cost, telemetry_domain.Money) and with_cost.currency == "USD" else None,
+                    "without_cost_usd": float(without_cost.amount) if isinstance(without_cost, telemetry_domain.Money) and without_cost.currency == "USD" else None,
+                    "cost_delta_usd": float(cost_delta.value.amount) if cost_delta.availability == telemetry_domain.COMPARABLE and cost_delta.value.currency == "USD" else None,
+                    "cost_delta_comparison": cost_delta.to_dict(),
+                    # This legacy scalar is USD-only. Other currencies retain
+                    # their typed basis below and must not masquerade as dollars.
+                    "objective_lift_per_dollar": lift_per_dollar.value if lift_per_dollar.availability == telemetry_domain.COMPARABLE and cost_delta.value.currency == "USD" else None,
+                    "objective_lift_per_cost_unit": lift_per_dollar.value if lift_per_dollar.availability == telemetry_domain.COMPARABLE else None,
+                    "objective_lift_per_cost_unit_comparison": lift_per_dollar.to_dict(),
+                    "objective_lift_per_dollar_comparison": (
+                        lift_per_dollar.to_dict() if lift_per_dollar.availability != telemetry_domain.COMPARABLE or cost_delta.value.currency == "USD"
+                        else telemetry_domain.Comparison.blocked("currency_not_usd", basis=lift_per_dollar.basis).to_dict()
+                    ),
                 })
+    all_pair_rows = [*pairs, *blocked_pairs]
     cost_deltas = [p["cost_delta_usd"] for p in pairs if p.get("cost_delta_usd") is not None]
     lift_per_dollar = [p["objective_lift_per_dollar"] for p in pairs if p.get("objective_lift_per_dollar") is not None]
-    # The money wasted on pairs that no longer discriminate: both arms perfect
-    # (saturated) or no lift at all.
-    waste_cost = round(sum((p.get("with_cost_usd") or 0) + (p.get("without_cost_usd") or 0)
-                           for p in pairs
-                           if p.get("objective_delta") is not None and (
-                               (p.get("objective_delta") <= 0)
-                               or (p.get("with_objective_pass_rate") == 1 and p.get("without_objective_pass_rate") == 1))), 6)
+    # The money spent on non-discriminating pairs is availability-aware too:
+    # missing arm cost is not silently counted as $0.
+    waste_measurements: list[telemetry_domain.Measurement[Any]] = []
+    non_discriminating_pairs = 0
+    for pair in pairs:
+        if pair.get("objective_delta") is None or not (
+            pair.get("objective_delta") <= 0
+            or (pair.get("with_objective_pass_rate") == 1 and pair.get("without_objective_pass_rate") == 1)
+        ):
+            continue
+        non_discriminating_pairs += 1
+        for key in ("with_cost", "without_cost"):
+            try:
+                waste_measurements.append(telemetry_domain.Measurement.from_dict(pair[key]))
+            except (KeyError, ValueError):
+                waste_measurements.append(telemetry_domain.Measurement.unavailable("invalid_pair_cost"))
+    waste_buckets = telemetry_domain.aggregate_money_by_currency(waste_measurements)
+    waste_usd = waste_buckets.get("USD") or waste_buckets.get("unknown")
+    if non_discriminating_pairs == 0:
+        # The set of qualifying pairs was observed and empty: this is a real
+        # zero, unlike a qualifying pair whose cost telemetry was absent.
+        waste_usd = telemetry_domain.Aggregate(telemetry_domain.COMPLETE, value=0, observed_count=0)
+    elif waste_usd is None:
+        waste_usd = telemetry_domain.Aggregate(telemetry_domain.UNAVAILABLE, reason_counts={"currency_mismatch": 1})
+    waste_cost = float(waste_usd.value) if waste_usd.availability == telemetry_domain.COMPLETE else None
     total_deltas = [p["total_token_delta"] for p in pairs if p.get("total_token_delta") is not None]
     input_deltas = [p["input_token_delta"] for p in pairs if p.get("input_token_delta") is not None]
     output_deltas = [p["output_token_delta"] for p in pairs if p.get("output_token_delta") is not None]
@@ -8532,12 +9133,28 @@ def paired_token_overhead_report(
             "objective_delta": stats(objective_deltas),
             "objective_lift_per_1k_total_tokens": stats(lift_per_1k),
             "cost_delta_usd": stats(cost_deltas),
+            "cost_delta_coverage": {
+                "eligible_pairs": len(cost_deltas),
+                "blocked_reason_counts": dict(collections.Counter(
+                    p.get("cost_delta_comparison", {}).get("reason") for p in all_pair_rows
+                    if p.get("cost_delta_comparison", {}).get("availability") == telemetry_domain.BLOCKED)),
+            },
             "objective_lift_per_dollar": stats(lift_per_dollar),
+            "objective_lift_per_dollar_coverage": {
+                "eligible_pairs": len(lift_per_dollar),
+                "blocked_reason_counts": dict(collections.Counter(
+                    p.get("objective_lift_per_dollar_comparison", {}).get("reason") for p in all_pair_rows
+                    if p.get("objective_lift_per_dollar_comparison", {}).get("availability") == telemetry_domain.BLOCKED)),
+            },
             "saturated_or_no_lift_cost_usd": waste_cost,
+            "saturated_or_no_lift_cost_usd_aggregate": waste_usd.to_dict(),
+            **({"known_saturated_or_no_lift_cost_usd": float(waste_usd.known_subtotal)}
+               if waste_usd.availability == telemetry_domain.PARTIAL else {}),
             "mean_total_overhead_per_static_skill_token": (statistics.mean(total_deltas) / static_skill_tokens) if total_deltas and static_skill_tokens else None,
         },
         "profile": profile,
         "pairs": pairs,
+        "blocked_pairs": blocked_pairs,
     }
 
 
@@ -8573,11 +9190,17 @@ def token_overhead(args: argparse.Namespace) -> int:
             lines.append(f"| {r['skill_name']} | {s.get('static_skill_tokens')} | {s.get('static_reference_tokens')} | {s.get('paired_runtime_rows')} | {td.get('mean')} | {td.get('median')} | {idelta.get('mean')} | {odelta.get('mean')} | {lift.get('mean')} | {cd.get('mean')} | {lpd.get('mean')} | {s.get('saturated_or_no_lift_cost_usd')} |")
         lines += ["", "## Per-case runtime pairs", ""]
         for r in reports:
-            if not r.get("pairs"):
+            if not r.get("pairs") and not r.get("blocked_pairs"):
                 continue
-            lines += [f"### {r['skill_name']}", "", "| Case | Run | Total delta | Input delta | Objective delta | Lift/1k | with total | without total |", "|---|---:|---:|---:|---:|---:|---:|---:|"]
+            lines += [f"### {r['skill_name']}", "", "| Case | Run | Total delta | Input delta | Objective delta | Lift/1k | With cost | Without cost | Cost delta | Lift/$ | Lift/$ status |", "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|"]
             for p in r["pairs"]:
-                lines.append(f"| {p['case_id']} | {p['run_number']} | {p.get('total_token_delta')} | {p.get('input_token_delta')} | {p.get('objective_delta')} | {p.get('objective_lift_per_1k_total_tokens')} | {p.get('with_total_tokens')} | {p.get('without_total_tokens')} |")
+                status = p.get("objective_lift_per_dollar_comparison", {})
+                lift_status = status.get("reason") if status.get("availability") == telemetry_domain.BLOCKED else "comparable"
+                lines.append(f"| {p['case_id']} | {p['run_number']} | {p.get('total_token_delta')} | {p.get('input_token_delta')} | {p.get('objective_delta')} | {p.get('objective_lift_per_1k_total_tokens')} | {p.get('with_cost_usd')} | {p.get('without_cost_usd')} | {p.get('cost_delta_usd')} | {p.get('objective_lift_per_dollar')} | {lift_status} |")
+            if r.get("blocked_pairs"):
+                lines += ["", "Blocked pairs (not included in runtime statistics):"]
+                for pair in r["blocked_pairs"]:
+                    lines.append(f"- `{pair.get('case_id')}` / `{pair.get('model')}` / run {pair.get('run_number')}: {pair.get('pair_status', {}).get('reason')}")
             lines.append("")
         text = "\n".join(lines) + "\n"
         if args.out:
@@ -9055,8 +9678,10 @@ def audit_manifest_report(
         cost_by_case = (bench_report.get("cost_summary", {}) or {}).get("by_case", {})
         flags_by_case = {flag.get("case_id"): flag.get("flags", []) for flag in bench_report.get("case_flags", [])}
         for case_id, spend in sorted(cost_by_case.items()):
-            cost = spend.get("total_cost_usd") or 0
-            if cost < expensive_case_usd:
+            cost = spend.get("total_cost_usd")
+            # A partial/unavailable subtotal cannot establish that the case is
+            # cheap or expensive, so it must not drive a dollar finding.
+            if cost is None or cost < expensive_case_usd:
                 continue
             case_flag_list = flags_by_case.get(case_id, [])
             if any("saturated" in f for f in case_flag_list):
@@ -9065,12 +9690,13 @@ def audit_manifest_report(
                 finding("expensive-no-lift-case", "recommended", f"Case {case_id} cost ${cost} with no objective lift — spend without signal.", spend)
         judge_only_ids = {c.get("id") for c in cases if is_judge_only_case(c)}
         for case_id in sorted(judge_only_ids):
-            cost = (cost_by_case.get(case_id) or {}).get("total_cost_usd") or 0
-            if cost >= expensive_case_usd:
+            cost = (cost_by_case.get(case_id) or {}).get("total_cost_usd")
+            if cost is not None and cost >= expensive_case_usd:
                 finding("high-cost-judge-only-case", "recommended", f"Case {case_id} cost ${cost} and is graded only by judge assertions; a deterministic/script oracle would make the spend verifiable.", cost_by_case.get(case_id))
         ablation_rows = [{**result_cost_facts(r), "variant": str(r.get("variant", ""))}
                          for r in bench_report.get("results", []) if is_ablation_variant(r.get("variant", ""))]
-        ablation_spend = {variant: slot["total_cost_usd"] for variant, slot in group_spend(ablation_rows, lambda r: r["variant"]).items()}
+        ablation_spend = {variant: slot["total_cost_usd"] for variant, slot in group_spend(ablation_rows, lambda r: r["variant"]).items()
+                          if slot.get("total_cost_usd") is not None}
         structured = {f"ablation:{a.get('id')}" for a in manifest.get("ablations", []) if any(isinstance(spec, dict) and spec.get("cases") and spec.get("assertions") for spec in a.get("expected_regressions", []))}
         for variant, spend_usd in sorted(ablation_spend.items()):
             if spend_usd >= expensive_case_usd and variant not in structured:
@@ -9559,15 +10185,22 @@ def suite_cost_estimate(scope: dict[str, Any], *, history_dir: Path | None = Non
                 doc = json.loads(f.read_text(encoding="utf-8"))
             except (OSError, json.JSONDecodeError):
                 continue
+            # Legacy ledgers do not carry enough availability/basis evidence to
+            # support a budget claim. They stay readable elsewhere but cannot
+            # silently become cost history for a fail-closed dollar gate.
+            if doc.get("telemetry_schema_version") != 3:
+                continue
             coverage = doc.get("coverage") or {}
             doc_totals = doc.get("totals") or {}
             seen = coverage.get("runs_seen") or 0
             if not seen:
                 continue
-            if isinstance(doc_totals.get("total_tokens"), (int, float)):
+            if (doc_totals.get("total_tokens_availability") == telemetry_domain.COMPLETE
+                    and isinstance(doc_totals.get("total_tokens"), (int, float))):
                 token_rates.append(doc_totals["total_tokens"] / seen)
             costed = coverage.get("runs_with_dollar_cost") or 0
-            if costed and isinstance(doc_totals.get("total_cost_usd"), (int, float)):
+            if (doc_totals.get("total_cost_usd_availability") == telemetry_domain.COMPLETE
+                    and costed and isinstance(doc_totals.get("total_cost_usd"), (int, float))):
                 cost_rates.append(doc_totals["total_cost_usd"] / costed)
         if token_rates:
             per_run_tokens = statistics.median(token_rates)
@@ -9724,7 +10357,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--run-dir", required=True, help="run directory where events.json/metrics.json should be written")
     p.add_argument("--out-events")
     p.add_argument("--out-metrics")
-    p.add_argument("--write-metadata", action="store_true", help="merge normalized metrics into metadata.json")
+    p.add_argument("--write-metadata", action="store_true", help="deprecated compatibility flag; metadata.json is always written with telemetry v3")
 
     p = sub.add_parser("run-codex")
     p.add_argument("--tasks", required=True, help="prepared task JSONL from skill-benchmark prepare")
@@ -9874,6 +10507,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("manifest")
     p.add_argument("--check", action="store_true", help="dry run: print the diff and checklist, write nothing")
     p.add_argument("--out-checklist", help="also write the judgment-call checklist as JSON")
+
+    p = sub.add_parser("migrate-telemetry", help="upgrade run metadata/metrics to availability-aware telemetry schema v3")
+    p.add_argument("--runs", required=True, help="run tree containing metadata.json and/or metrics.json artifacts")
+    p.add_argument("--check", action="store_true", help="report artifacts that would change without writing them")
+    p.add_argument("--out", help="write the migration report as JSON")
 
     p = sub.add_parser("cost-summary", help="suite cost ledger over a runs tree: coverage, totals, by variant/case/runner, top spenders, cost-quality findings (issue #21)")
     p.add_argument("--manifest", required=True)
@@ -10040,6 +10678,8 @@ def main() -> int:
         return compare_results(args)
     if args.cmd == "migrate":
         return migrate_command(args)
+    if args.cmd == "migrate-telemetry":
+        return migrate_telemetry_command(args)
     if args.cmd == "cost-summary":
         return cost_summary_command(args)
     if args.cmd == "trend":

--- a/telemetry.py
+++ b/telemetry.py
@@ -1,0 +1,711 @@
+"""Typed telemetry availability, aggregation, and comparison domain.
+
+This is a leaf module: runner adapters and reports may import it, but it imports no
+harness code.  It is deliberately strict at JSON boundaries so an unavailable
+measurement cannot leak into arithmetic as zero.
+"""
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
+import math
+import re
+from typing import Any, Generic, Iterable, Mapping, TypeVar
+
+T = TypeVar("T")
+
+AVAILABLE = "available"
+UNAVAILABLE = "unavailable"
+NOT_APPLICABLE = "not_applicable"
+COMPLETE = "complete"
+PARTIAL = "partial"
+COMPARABLE = "comparable"
+BLOCKED = "blocked"
+
+PROVENANCE = {
+    "provider_reported",
+    "trace_normalized",
+    "price_table_estimated",
+    "estimated",
+    "legacy_unverified",
+}
+CURRENCY_RE = re.compile(r"^[A-Z]{3}$")
+
+
+def _decimal(value: Any) -> Decimal:
+    """Parse a finite non-negative money scalar without accepting bool/NaN."""
+    if isinstance(value, bool) or not isinstance(value, (int, float, str, Decimal)):
+        raise ValueError(f"money must be a numeric scalar, got {type(value).__name__}")
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError("money must be finite")
+    try:
+        out = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError("money must be a decimal number") from exc
+    if not out.is_finite() or out < 0:
+        raise ValueError("money must be finite and non-negative")
+    return out
+
+
+def _valid_measurement_value(value: Any) -> bool:
+    if isinstance(value, Money):
+        return True
+    if isinstance(value, bool):
+        return True
+    if isinstance(value, int):
+        return value >= 0
+    if isinstance(value, float):
+        return math.isfinite(value) and value >= 0
+    if isinstance(value, Decimal):
+        return value.is_finite() and value >= 0
+    return False
+
+
+def _valid_comparison_value(value: Any) -> bool:
+    """A delta/ratio may be signed, but it can never be NaN or infinity."""
+    if isinstance(value, (Money, SignedMoney)):
+        return True
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return True
+    if isinstance(value, float):
+        return math.isfinite(value)
+    if isinstance(value, Decimal):
+        return value.is_finite()
+    return False
+
+
+def _wire_value(value: Any) -> Any:
+    if isinstance(value, (Money, SignedMoney)):
+        return value.to_dict()
+    if isinstance(value, Decimal):
+        return format(value, "f")
+    return value
+
+
+@dataclass(frozen=True)
+class Money:
+    """A non-negative exact amount in an ISO currency."""
+
+    amount: Decimal
+    currency: str
+
+    def __post_init__(self) -> None:
+        amount = _decimal(self.amount)
+        currency = str(self.currency)
+        if not CURRENCY_RE.fullmatch(currency):
+            raise ValueError("currency must be a three-letter uppercase ISO code")
+        object.__setattr__(self, "amount", amount)
+        object.__setattr__(self, "currency", currency)
+
+    @classmethod
+    def from_raw(cls, amount: Any, currency: Any = "USD") -> "Money":
+        return cls(_decimal(amount), str(currency))
+
+    def to_dict(self) -> dict[str, str]:
+        return {"amount": format(self.amount, "f"), "currency": self.currency}
+
+
+@dataclass(frozen=True)
+class SignedMoney:
+    """A finite monetary difference. Measurements use ``Money``; deltas may save."""
+
+    amount: Decimal
+    currency: str
+
+    def __post_init__(self) -> None:
+        if isinstance(self.amount, bool):
+            raise ValueError("money delta must be numeric")
+        try:
+            amount = Decimal(str(self.amount))
+        except (InvalidOperation, ValueError) as exc:
+            raise ValueError("money delta must be numeric") from exc
+        currency = str(self.currency)
+        if not amount.is_finite() or not CURRENCY_RE.fullmatch(currency):
+            raise ValueError("money delta must be finite and use an ISO currency")
+        object.__setattr__(self, "amount", amount)
+        object.__setattr__(self, "currency", currency)
+
+    def to_dict(self) -> dict[str, str]:
+        return {"amount": format(self.amount, "f"), "currency": self.currency}
+
+
+@dataclass(frozen=True)
+class Measurement(Generic[T]):
+    """An observed value, an explicitly unavailable value, or an N/A value."""
+
+    availability: str
+    value: T | None = None
+    provenance: str | None = None
+    basis: Mapping[str, Any] = field(default_factory=dict)
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.availability not in {AVAILABLE, UNAVAILABLE, NOT_APPLICABLE}:
+            raise ValueError(f"unknown availability {self.availability!r}")
+        if self.availability == AVAILABLE:
+            if self.value is None:
+                raise ValueError("available measurement requires a value")
+            if not _valid_measurement_value(self.value):
+                raise ValueError("available measurement requires a finite non-negative value")
+            if self.provenance not in PROVENANCE:
+                raise ValueError(f"available measurement requires known provenance, got {self.provenance!r}")
+            if self.reason is not None:
+                raise ValueError("available measurement cannot carry an unavailable reason")
+        else:
+            if self.value is not None or self.provenance is not None:
+                raise ValueError("unavailable/not-applicable measurement cannot carry value or provenance")
+            if not isinstance(self.reason, str) or not self.reason:
+                raise ValueError("unavailable/not-applicable measurement requires a reason")
+        if not isinstance(self.basis, Mapping):
+            raise ValueError("measurement basis must be a mapping")
+        object.__setattr__(self, "basis", dict(self.basis))
+
+    @classmethod
+    def available(cls, value: T, *, provenance: str, basis: Mapping[str, Any] | None = None) -> "Measurement[T]":
+        return cls(AVAILABLE, value=value, provenance=provenance, basis=basis or {})
+
+    @classmethod
+    def unavailable(cls, reason: str, *, basis: Mapping[str, Any] | None = None) -> "Measurement[T]":
+        return cls(UNAVAILABLE, basis=basis or {}, reason=reason)
+
+    @classmethod
+    def not_applicable(cls, reason: str, *, basis: Mapping[str, Any] | None = None) -> "Measurement[T]":
+        return cls(NOT_APPLICABLE, basis=basis or {}, reason=reason)
+
+    @classmethod
+    def from_dict(cls, raw: Any) -> "Measurement[Any]":
+        if not isinstance(raw, Mapping):
+            raise ValueError("measurement must be an object")
+        availability = raw.get("availability")
+        basis = raw.get("basis") if isinstance(raw.get("basis"), Mapping) else {}
+        if availability == AVAILABLE:
+            value = raw.get("value")
+            if isinstance(value, Mapping) and set(value) >= {"amount", "currency"}:
+                value = Money.from_raw(value["amount"], value["currency"])
+            return cls.available(value, provenance=str(raw.get("provenance") or ""), basis=basis)
+        if availability == UNAVAILABLE:
+            return cls.unavailable(str(raw.get("reason") or ""), basis=basis)
+        if availability == NOT_APPLICABLE:
+            return cls.not_applicable(str(raw.get("reason") or ""), basis=basis)
+        raise ValueError(f"unknown measurement availability {availability!r}")
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"availability": self.availability}
+        if self.availability == AVAILABLE:
+            out["value"] = _wire_value(self.value)
+            out["provenance"] = self.provenance
+        else:
+            out["reason"] = self.reason
+        if self.basis:
+            out["basis"] = dict(self.basis)
+        return out
+
+
+@dataclass(frozen=True)
+class Aggregate(Generic[T]):
+    """A complete, partial, unavailable, or N/A aggregate without fake zeros."""
+
+    availability: str
+    value: T | None = None
+    known_subtotal: T | None = None
+    observed_count: int = 0
+    unavailable_count: int = 0
+    not_applicable_count: int = 0
+    reason_counts: Mapping[str, int] = field(default_factory=dict)
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.availability not in {COMPLETE, PARTIAL, UNAVAILABLE, NOT_APPLICABLE}:
+            raise ValueError(f"unknown aggregate availability {self.availability!r}")
+        if min(self.observed_count, self.unavailable_count, self.not_applicable_count) < 0:
+            raise ValueError("aggregate counts cannot be negative")
+        if self.availability == COMPLETE:
+            if self.value is None or self.known_subtotal is not None:
+                raise ValueError("complete aggregate requires value only")
+            if not _valid_measurement_value(self.value):
+                raise ValueError("complete aggregate requires a finite non-negative value")
+            if self.unavailable_count or self.not_applicable_count:
+                raise ValueError("complete aggregate cannot have unobserved inputs")
+        elif self.availability == PARTIAL:
+            if self.known_subtotal is None or self.value is not None:
+                raise ValueError("partial aggregate requires known_subtotal only")
+            if not _valid_measurement_value(self.known_subtotal):
+                raise ValueError("partial aggregate requires a finite non-negative subtotal")
+            if not (self.unavailable_count or self.not_applicable_count):
+                raise ValueError("partial aggregate requires unavailable or N/A inputs")
+        elif self.availability == UNAVAILABLE:
+            if self.value is not None or self.known_subtotal is not None or self.observed_count:
+                raise ValueError("unavailable aggregate cannot carry observed numeric data")
+        else:
+            if self.value is not None or self.known_subtotal is not None:
+                raise ValueError("N/A aggregate cannot carry numeric data")
+            if not self.reason:
+                raise ValueError("N/A aggregate requires a reason")
+        object.__setattr__(self, "reason_counts", dict(self.reason_counts))
+
+    def scalar_if_complete(self) -> T | None:
+        return self.value if self.availability == COMPLETE else None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "availability": self.availability,
+            "observed_count": self.observed_count,
+            "unavailable_count": self.unavailable_count,
+            "not_applicable_count": self.not_applicable_count,
+            "reason_counts": dict(self.reason_counts),
+        }
+        if self.availability == COMPLETE:
+            out["value"] = _wire_value(self.value)
+        elif self.availability == PARTIAL:
+            out["known_subtotal"] = _wire_value(self.known_subtotal)
+        elif self.availability == NOT_APPLICABLE:
+            out["reason"] = self.reason
+        return out
+
+
+@dataclass(frozen=True)
+class Comparison(Generic[T]):
+    """A pairwise value that either has a valid basis or a blocking reason."""
+
+    availability: str
+    value: T | None = None
+    basis: Mapping[str, Any] = field(default_factory=dict)
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.availability not in {COMPARABLE, BLOCKED}:
+            raise ValueError(f"unknown comparison availability {self.availability!r}")
+        if self.availability == COMPARABLE:
+            if self.value is None or self.reason is not None:
+                raise ValueError("comparable result requires value and no reason")
+            if not _valid_comparison_value(self.value):
+                raise ValueError("comparable result requires a finite numeric or money value")
+        elif self.value is not None or not self.reason:
+            raise ValueError("blocked result requires reason and no value")
+        object.__setattr__(self, "basis", dict(self.basis))
+
+    @classmethod
+    def comparable(cls, value: T, *, basis: Mapping[str, Any] | None = None) -> "Comparison[T]":
+        return cls(COMPARABLE, value=value, basis=basis or {})
+
+    @classmethod
+    def blocked(cls, reason: str, *, basis: Mapping[str, Any] | None = None) -> "Comparison[T]":
+        return cls(BLOCKED, basis=basis or {}, reason=reason)
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"availability": self.availability}
+        if self.availability == COMPARABLE:
+            out["value"] = _wire_value(self.value)
+        else:
+            out["reason"] = self.reason
+        if self.basis:
+            out["basis"] = dict(self.basis)
+        return out
+
+
+def aggregate_numeric(measurements: Iterable[Measurement[Any]], *,
+                      required_basis: tuple[str, ...] = ("population", "billing_scope", "provenance")) -> Aggregate[Any]:
+    """Aggregate compatible numeric observations without treating absent as zero.
+
+    Callers may intentionally vary case/repetition/model within a suite, but
+    population, billing scope, and provenance form a minimum compatibility
+    bucket. Mixed values produce an unavailable aggregate rather than a false
+    complete total; report callers can expose their separate buckets.
+    """
+    materialized = list(measurements)
+    signatures = {
+        tuple(m.provenance if field_name == "provenance" else m.basis.get(field_name)
+              for field_name in required_basis)
+        for m in materialized if m.availability == AVAILABLE
+    }
+    if len(signatures) > 1:
+        return Aggregate(UNAVAILABLE, reason_counts={"basis_mismatch": len(signatures)})
+    observed: list[Any] = []
+    measurements = materialized
+    unavailable = 0
+    not_applicable = 0
+    reasons: Counter[str] = Counter()
+    for measurement in measurements:
+        if measurement.availability == AVAILABLE:
+            if isinstance(measurement.value, (Money, bool)) or not _valid_measurement_value(measurement.value):
+                raise ValueError("aggregate_numeric accepts only numeric measurements")
+            observed.append(measurement.value)
+        elif measurement.availability == UNAVAILABLE:
+            unavailable += 1
+            reasons[str(measurement.reason)] += 1
+        else:
+            not_applicable += 1
+            reasons[f"not_applicable:{measurement.reason}"] += 1
+    if observed:
+        total = sum(observed)
+        if unavailable or not_applicable:
+            return Aggregate(PARTIAL, known_subtotal=total, observed_count=len(observed),
+                             unavailable_count=unavailable, not_applicable_count=not_applicable,
+                             reason_counts=reasons)
+        return Aggregate(COMPLETE, value=total, observed_count=len(observed), reason_counts=reasons)
+    if not_applicable and not unavailable:
+        reason = next(iter(reasons), "not_applicable")
+        return Aggregate(NOT_APPLICABLE, unavailable_count=0, not_applicable_count=not_applicable,
+                         reason_counts=reasons, reason=reason)
+    return Aggregate(UNAVAILABLE, unavailable_count=unavailable, not_applicable_count=not_applicable,
+                     reason_counts=reasons)
+
+
+def aggregate_money_by_currency(measurements: Iterable[Measurement[Money]], *,
+                                required_basis: tuple[str, ...] = ("population", "billing_scope", "provenance")) -> dict[str, Aggregate[Decimal]]:
+    """Return one availability-aware exact aggregate per observed currency."""
+    materialized = list(measurements)
+    currencies = sorted({m.value.currency for m in materialized if m.availability == AVAILABLE and isinstance(m.value, Money)})
+    if not currencies:
+        base = aggregate_numeric([])
+        unavailable = sum(1 for m in materialized if m.availability == UNAVAILABLE)
+        na = sum(1 for m in materialized if m.availability == NOT_APPLICABLE)
+        reasons = Counter(
+            str(m.reason) if m.availability == UNAVAILABLE else f"not_applicable:{m.reason}"
+            for m in materialized if m.availability != AVAILABLE
+        )
+        if na and not unavailable:
+            base = Aggregate(NOT_APPLICABLE, unavailable_count=0, not_applicable_count=na,
+                             reason_counts=reasons, reason=next(iter(reasons), "not_applicable"))
+        else:
+            base = Aggregate(UNAVAILABLE, unavailable_count=unavailable, not_applicable_count=na,
+                             reason_counts=reasons)
+        return {"unknown": base}
+    out: dict[str, Aggregate[Decimal]] = {}
+    for currency in currencies:
+        rows: list[Measurement[Any]] = []
+        for measurement in materialized:
+            if measurement.availability == AVAILABLE:
+                assert isinstance(measurement.value, Money)
+                if measurement.value.currency == currency:
+                    rows.append(Measurement.available(measurement.value.amount, provenance=measurement.provenance or "", basis=measurement.basis))
+                # A different observed currency belongs to its own complete
+                # bucket; it is not missing USD/EUR telemetry.
+                continue
+            elif measurement.availability == UNAVAILABLE:
+                rows.append(Measurement.unavailable(str(measurement.reason), basis=measurement.basis))
+            else:
+                rows.append(Measurement.not_applicable(str(measurement.reason), basis=measurement.basis))
+        out[currency] = aggregate_numeric(rows, required_basis=required_basis)
+    return out
+
+
+def measurement_from_cost_block(block: Any, *, legacy_value: Any = None,
+                                 basis: Mapping[str, Any] | None = None) -> Measurement[Money]:
+    """Read normalized v2 cost or a legacy scalar into the strict domain model."""
+    basis = basis or {}
+    if isinstance(block, Mapping):
+        source = block.get("source")
+        if source == "missing":
+            return Measurement.unavailable("missing", basis=basis)
+        if source == "not_applicable":
+            return Measurement.not_applicable("not_applicable", basis=basis)
+        if source is not None:
+            raw = block.get("total_cost")
+            if raw is None:
+                return Measurement.unavailable("invalid_cost_block", basis=basis)
+            try:
+                money = Money.from_raw(raw, block.get("currency", "USD"))
+            except ValueError:
+                return Measurement.unavailable("invalid_cost_block", basis=basis)
+            provenance = str(source)
+            if provenance not in PROVENANCE:
+                return Measurement.unavailable("unknown_cost_provenance", basis=basis)
+            return Measurement.available(money, provenance=provenance, basis=basis)
+    if legacy_value is not None:
+        try:
+            return Measurement.available(Money.from_raw(legacy_value, "USD"), provenance="legacy_unverified", basis=basis)
+        except ValueError:
+            return Measurement.unavailable("invalid_legacy_cost", basis=basis)
+    return Measurement.unavailable("missing", basis=basis)
+
+
+def measurement_from_usage_block(block: Any, key: str, *, legacy_value: Any = None,
+                                  basis: Mapping[str, Any] | None = None) -> Measurement[int]:
+    """Read one normalized usage key or legacy scalar into a strict measurement."""
+    basis = basis or {}
+    if isinstance(block, Mapping):
+        source = block.get("source")
+        if source == "missing":
+            return Measurement.unavailable("missing", basis=basis)
+        if source == "not_applicable":
+            return Measurement.not_applicable("not_applicable", basis=basis)
+        if source is not None:
+            raw = block.get(key)
+            if (isinstance(raw, bool) or not isinstance(raw, (int, float)) or not math.isfinite(float(raw))
+                    or raw < 0 or (isinstance(raw, float) and not raw.is_integer())):
+                return Measurement.unavailable(f"missing_{key}", basis=basis)
+            provenance = str(source)
+            if provenance not in PROVENANCE:
+                return Measurement.unavailable("unknown_usage_provenance", basis=basis)
+            return Measurement.available(int(raw), provenance=provenance, basis=basis)
+    if legacy_value is not None:
+        if (isinstance(legacy_value, bool) or not isinstance(legacy_value, (int, float))
+                or not math.isfinite(float(legacy_value)) or legacy_value < 0
+                or (isinstance(legacy_value, float) and not legacy_value.is_integer())):
+            return Measurement.unavailable(f"invalid_legacy_{key}", basis=basis)
+        return Measurement.available(int(legacy_value), provenance="legacy_unverified", basis=basis)
+    return Measurement.unavailable("missing", basis=basis)
+
+
+def measurement_from_nonnegative(value: Any, *, provenance: str = "runner_measured",
+                                  unavailable_reason: str = "missing", basis: Mapping[str, Any] | None = None) -> Measurement[int]:
+    """Build a local counter/duration measurement with no truthiness fallback."""
+    # Harness-measured values have their own explicit provenance on the v3 wire;
+    # map them to trace_normalized internally until all callers expose a richer enum.
+    normalized_provenance = "trace_normalized" if provenance == "runner_measured" else provenance
+    if (isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(float(value))
+            or value < 0 or (isinstance(value, float) and not value.is_integer())):
+        return Measurement.unavailable(unavailable_reason, basis=basis)
+    return Measurement.available(int(value), provenance=normalized_provenance, basis=basis)
+
+
+def basis_from_run(raw: Mapping[str, Any] | None, *, source: str | None = None,
+                   population: str = "answer") -> dict[str, Any]:
+    raw = raw or {}
+    return {
+        "population": raw.get("population", population),
+        "provider": raw.get("provider") or raw.get("runner") or source,
+        "runner": raw.get("runner") or source,
+        "model": raw.get("model"),
+        "billing_scope": raw.get("billing_scope", "run"),
+        "pricing_model": raw.get("pricing_model"),
+        "pricing_table_version": raw.get("pricing_table_version"),
+        "case_id": raw.get("case_id"),
+        "run_number": raw.get("run_number"),
+        "manifest_revision": raw.get("manifest_revision"),
+        "skill_tree_hash": raw.get("skill_tree_hash"),
+    }
+
+
+def telemetry_envelope(raw: Mapping[str, Any] | None, *, source: str | None = None,
+                       population: str = "answer", legacy_unverified: bool = False) -> dict[str, Any]:
+    """Build the additive v3 envelope while preserving legacy blocks beside it."""
+    raw = raw or {}
+    existing = raw.get("telemetry")
+    if isinstance(existing, Mapping) and existing.get("schema_version") == 3:
+        return dict(existing)
+    basis = basis_from_run(raw, source=source, population=population)
+    usage = raw.get("usage_normalized")
+    cost = raw.get("cost_normalized")
+    measurements: dict[str, Any] = {
+        "input_tokens": measurement_from_usage_block(usage, "input_tokens", legacy_value=raw.get("input_tokens"), basis=basis).to_dict(),
+        "output_tokens": measurement_from_usage_block(usage, "output_tokens", legacy_value=raw.get("output_tokens"), basis=basis).to_dict(),
+        "total_tokens": measurement_from_usage_block(usage, "total_tokens", legacy_value=raw.get("total_tokens"), basis=basis).to_dict(),
+        "cost": measurement_from_cost_block(cost, legacy_value=raw.get("cost_usd", raw.get("cost")), basis=basis).to_dict(),
+        "elapsed_ms": measurement_from_nonnegative(raw.get("elapsed_ms", raw.get("duration_ms")),
+                                                     unavailable_reason="missing_elapsed_ms", basis=basis).to_dict(),
+    }
+    # Trace-derived counts/bools are trustworthy only when a complete trace was
+    # observed. Their old flat fields remain for assertion compatibility, while
+    # v3 prevents an empty/malformed trace from looking like zero activity.
+    trace_complete = raw.get("observation_complete", raw.get("trace_observation_complete"))
+    for key in ("tool_calls", "commands", "file_reads", "file_writes", "errors", "retries", "repeated_command_max"):
+        if trace_complete is True:
+            measurements[key] = measurement_from_nonnegative(raw.get(key), unavailable_reason=f"missing_{key}", basis=basis).to_dict()
+        else:
+            measurements[key] = Measurement.unavailable("trace_observation_incomplete", basis=basis).to_dict()
+    if trace_complete is True and isinstance(raw.get("skill_invoked"), bool):
+        measurements["skill_invoked"] = Measurement.available(raw["skill_invoked"], provenance="trace_normalized", basis=basis).to_dict()
+    else:
+        measurements["skill_invoked"] = Measurement.unavailable("trace_observation_incomplete", basis=basis).to_dict()
+    if legacy_unverified:
+        # Normalized v1/v2 fields can be useful historical observations but do
+        # not establish the provider/billing basis needed for causal ratios.
+        for key, wire in list(measurements.items()):
+            try:
+                measurement = Measurement.from_dict(wire)
+            except ValueError:
+                continue
+            if measurement.availability == AVAILABLE:
+                measurements[key] = Measurement.available(
+                    measurement.value, provenance="legacy_unverified", basis=measurement.basis).to_dict()
+    return {
+        "schema_version": 3,
+        "population": basis["population"],
+        "basis": {key: value for key, value in basis.items() if value is not None},
+        "measurements": measurements,
+    }
+
+
+def measurement_from_envelope_or_cost(raw: Mapping[str, Any] | None, *, source: str | None = None,
+                                      population: str = "answer") -> Measurement[Money]:
+    raw = raw or {}
+    envelope = raw.get("telemetry")
+    if isinstance(envelope, Mapping) and envelope.get("schema_version") == 3:
+        measurements = envelope.get("measurements")
+        if isinstance(measurements, Mapping) and isinstance(measurements.get("cost"), Mapping):
+            try:
+                return Measurement.from_dict(measurements["cost"])
+            except ValueError:
+                return Measurement.unavailable("invalid_v3_cost")
+    basis = basis_from_run(raw, source=source, population=population)
+    return measurement_from_cost_block(raw.get("cost_normalized"), legacy_value=raw.get("cost_usd", raw.get("cost")), basis=basis)
+
+
+def measurement_from_envelope_or_nonnegative(raw: Mapping[str, Any], key: str, *, source: str | None = None,
+                                             population: str = "answer") -> Measurement[int]:
+    """Read a v3 local metric (duration/count) or adapt a legacy scalar."""
+    envelope = raw.get("telemetry")
+    if isinstance(envelope, Mapping) and envelope.get("schema_version") == 3:
+        measurements = envelope.get("measurements")
+        if isinstance(measurements, Mapping) and isinstance(measurements.get(key), Mapping):
+            try:
+                return Measurement.from_dict(measurements[key])
+            except ValueError:
+                return Measurement.unavailable(f"invalid_v3_{key}")
+    legacy_value = raw.get(key)
+    if legacy_value is None and key == "elapsed_ms":
+        legacy_value = raw.get("duration_ms")
+    return measurement_from_nonnegative(legacy_value, unavailable_reason=f"missing_{key}",
+                                        basis=basis_from_run(raw, source=source, population=population))
+
+
+def measurement_from_envelope_or_usage(raw: Mapping[str, Any], key: str, *, source: str | None = None,
+                                       population: str = "answer") -> Measurement[int]:
+    envelope = raw.get("telemetry")
+    if isinstance(envelope, Mapping) and envelope.get("schema_version") == 3:
+        measurements = envelope.get("measurements")
+        if isinstance(measurements, Mapping) and isinstance(measurements.get(key), Mapping):
+            try:
+                return Measurement.from_dict(measurements[key])
+            except ValueError:
+                return Measurement.unavailable(f"invalid_v3_{key}")
+    basis = basis_from_run(raw, source=source, population=population)
+    return measurement_from_usage_block(raw.get("usage_normalized"), key, legacy_value=raw.get(key), basis=basis)
+
+
+def with_basis(measurement: Measurement[T], **updates: Any) -> Measurement[T]:
+    """Attach run/pair identity at the harness boundary without loosening state."""
+    basis = {**measurement.basis, **{key: value for key, value in updates.items() if value is not None}}
+    if measurement.availability == AVAILABLE:
+        return Measurement.available(measurement.value, provenance=str(measurement.provenance), basis=basis)
+    if measurement.availability == UNAVAILABLE:
+        return Measurement.unavailable(str(measurement.reason), basis=basis)
+    return Measurement.not_applicable(str(measurement.reason), basis=basis)
+
+
+def _blocked_for_measurement(measurement: Measurement[Any], side: str) -> Comparison[Any] | None:
+    if measurement.availability == UNAVAILABLE:
+        return Comparison.blocked(f"missing_{side}")
+    if measurement.availability == NOT_APPLICABLE:
+        return Comparison.blocked("not_applicable")
+    return None
+
+
+def _basis_compatibility(left: Measurement[Any], right: Measurement[Any]) -> str | None:
+    if left.provenance == "legacy_unverified" or right.provenance == "legacy_unverified":
+        return "legacy_unverified"
+    if left.provenance != right.provenance:
+        return "provenance_mismatch"
+    required = ["population", "provider", "model", "billing_scope", "case_id", "run_number"]
+    if left.provenance == "price_table_estimated":
+        required.extend(["pricing_model", "pricing_table_version"])
+    for field_name in required:
+        left_value = left.basis.get(field_name)
+        right_value = right.basis.get(field_name)
+        if left_value is None or right_value is None:
+            return "basis_missing"
+        if left_value != right_value:
+            return "population_mismatch" if field_name == "population" else "pair_key_mismatch" if field_name in {"case_id", "run_number"} else "basis_mismatch"
+    # Revision identifiers are optional during migration, but if either arm
+    # supplies one it must agree; a stale tree/report cannot claim paired lift.
+    for field_name in ("manifest_revision", "skill_tree_hash"):
+        left_value = left.basis.get(field_name)
+        right_value = right.basis.get(field_name)
+        if left_value is not None or right_value is not None:
+            if left_value is None or right_value is None:
+                return "basis_missing"
+            if left_value != right_value:
+                return "basis_mismatch"
+    return None
+
+
+def compare_cost_pair(left: Measurement[Money], right: Measurement[Money], *,
+                      left_scorable: bool = True, right_scorable: bool = True) -> Comparison[SignedMoney]:
+    """Compute with-minus-without only when both cost observations are comparable."""
+    if not left_scorable or not right_scorable:
+        return Comparison.blocked("unscorable_arm")
+    if blocked := _blocked_for_measurement(left, "left"):
+        return blocked
+    if blocked := _blocked_for_measurement(right, "right"):
+        return blocked
+    assert isinstance(left.value, Money) and isinstance(right.value, Money)
+    if left.value.currency != right.value.currency:
+        return Comparison.blocked("currency_mismatch")
+    if reason := _basis_compatibility(left, right):
+        return Comparison.blocked(reason)
+    return Comparison.comparable(
+        SignedMoney(left.value.amount - right.value.amount, left.value.currency),
+        basis={"currency": left.value.currency, "population": left.basis.get("population"),
+               "provider": left.basis.get("provider"), "model": left.basis.get("model"),
+               "billing_scope": left.basis.get("billing_scope")},
+    )
+
+
+def compare_numeric_pair(left: Measurement[int], right: Measurement[int], *,
+                         left_scorable: bool = True, right_scorable: bool = True) -> Comparison[int]:
+    if not left_scorable or not right_scorable:
+        return Comparison.blocked("unscorable_arm")
+    if blocked := _blocked_for_measurement(left, "left"):
+        return blocked
+    if blocked := _blocked_for_measurement(right, "right"):
+        return blocked
+    if reason := _basis_compatibility(left, right):
+        return Comparison.blocked(reason)
+    assert isinstance(left.value, int) and isinstance(right.value, int)
+    return Comparison.comparable(left.value - right.value, basis=dict(left.basis))
+
+
+def compare_objective_rates(with_rate: Any, without_rate: Any, *,
+                            left_scorable: bool, right_scorable: bool) -> Comparison[float]:
+    """The typed numerator for efficiency claims; unscorable arms cannot leak in."""
+    if not left_scorable or not right_scorable:
+        return Comparison.blocked("unscorable_arm")
+    for value in (with_rate, without_rate):
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(float(value)) or not 0 <= float(value) <= 1:
+            return Comparison.blocked("missing_objective_lift")
+    return Comparison.comparable(float(with_rate) - float(without_rate))
+
+
+def lift_per_dollar(objective_delta: Comparison[float], cost_delta: Comparison[SignedMoney]) -> Comparison[float]:
+    """Construct the efficiency ratio only from typed comparable evidence."""
+    if objective_delta.availability == BLOCKED:
+        return Comparison.blocked(str(objective_delta.reason))
+    if cost_delta.availability == BLOCKED:
+        return Comparison.blocked(str(cost_delta.reason))
+    assert isinstance(objective_delta.value, float)
+    assert isinstance(cost_delta.value, SignedMoney)
+    if cost_delta.value.amount <= 0:
+        return Comparison.blocked("non_positive_denominator", basis=cost_delta.basis)
+    return Comparison.comparable(float(Decimal(str(objective_delta.value)) / cost_delta.value.amount), basis=cost_delta.basis)
+
+
+def lift_per_1k_tokens(objective_delta: Comparison[float], token_delta: Comparison[int]) -> Comparison[float]:
+    if objective_delta.availability == BLOCKED:
+        return Comparison.blocked(str(objective_delta.reason))
+    if token_delta.availability == BLOCKED:
+        return Comparison.blocked(str(token_delta.reason))
+    assert isinstance(objective_delta.value, float)
+    assert isinstance(token_delta.value, int)
+    if token_delta.value <= 0:
+        return Comparison.blocked("non_positive_denominator", basis=token_delta.basis)
+    return Comparison.comparable(objective_delta.value / (token_delta.value / 1000), basis=token_delta.basis)
+
+
+def display_aggregate(aggregate: Mapping[str, Any] | Aggregate[Any], *, prefix: str = "") -> str:
+    """One human renderer for complete, partial, unavailable, and N/A quantities."""
+    data = aggregate.to_dict() if isinstance(aggregate, Aggregate) else dict(aggregate)
+    availability = data.get("availability")
+    if availability == COMPLETE:
+        return f"{prefix}{data.get('value')}"
+    if availability == PARTIAL:
+        return f"partial: {prefix}{data.get('known_subtotal')} known subtotal ({data.get('unavailable_count', 0)} unavailable)"
+    if availability == NOT_APPLICABLE:
+        return "N/A"
+    reasons = data.get("reason_counts") or {}
+    reason = next(iter(reasons), "unavailable")
+    return f"— unavailable ({reason})"

--- a/tests/test_consolidation_guards.py
+++ b/tests/test_consolidation_guards.py
@@ -140,6 +140,22 @@ class SharedOwnerIdentityTests(unittest.TestCase):
         for name, cap in ac.AGENT_CAPABILITIES.items():
             self.assertIn(cap.dollar_cost, sb.COST_SOURCES, name)
 
+    def test_agent_capability_registry_declares_every_telemetry_signal(self):
+        for name, cap in ac.AGENT_CAPABILITIES.items():
+            signals = cap.telemetry_contract()
+            self.assertEqual(set(signals), {"usage", "cost", "elapsed_ms", "trace"}, name)
+            for signal in signals.values():
+                self.assertIn(signal.availability, {"available", "unavailable", "not_applicable"})
+                if signal.availability == "available":
+                    self.assertIsNotNone(signal.provenance)
+                else:
+                    self.assertIsNotNone(signal.reason)
+
+    def test_offline_stub_contract_does_not_promise_elapsed_measurement(self):
+        elapsed = ac.AGENT_CAPABILITIES["stub"].telemetry_contract()["elapsed_ms"]
+        self.assertEqual(elapsed.availability, "not_applicable")
+        self.assertEqual(elapsed.reason, "offline_runner")
+
     def test_invocation_request_is_answer_runner_only(self):
         fields = set(sb.InvocationRequest.__dataclass_fields__)
         self.assertEqual(fields, {"prompt", "workspace", "model", "timeout_s"})

--- a/tests/test_cost_telemetry.py
+++ b/tests/test_cost_telemetry.py
@@ -9,6 +9,7 @@ suite-run preflight budget gate. House rules hold: no live model, no network.
 import json
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -56,6 +57,10 @@ class NormalizeUsageCostTests(unittest.TestCase):
         self.assertEqual(parts["source"], "price_table_estimated")
         self.assertEqual(parts["pricing_table_version"], "2026-06")
         self.assertEqual(sb.normalize_cost(None), {"source": "missing"})
+        eur = sb.normalize_cost({"amount": 1, "currency": "EUR"})
+        self.assertEqual(eur["currency"], "EUR")
+        self.assertEqual(eur["total_cost"], 1.0)
+        self.assertEqual(sb.normalize_cost({"amount": 1, "currency": "eur"}), {"source": "missing"})
 
     def test_run_cost_facts_prefers_normalized_and_falls_back_to_legacy(self):
         normalized = sb.run_cost_facts({
@@ -88,6 +93,9 @@ class RunnerStampTests(unittest.TestCase):
             self.assertEqual(metadata["usage_normalized"]["total_tokens"], 150)   # provider beat the trace
             self.assertEqual(metrics["usage_normalized"]["total_tokens"], 150)
             self.assertEqual(metadata["cost_normalized"]["total_cost"], 0.25)
+            self.assertEqual(metadata["telemetry_schema_version"], 3)
+            self.assertEqual(metadata["telemetry"], metrics["telemetry"])
+            self.assertEqual(metadata["telemetry"]["measurements"]["cost"]["availability"], "available")
 
             bare_dir = Path(td) / "bare"
             sb.write_trace_artifacts(bare_dir, "", source="codex", metadata={"provider": "codex"})
@@ -104,6 +112,19 @@ class RunnerStampTests(unittest.TestCase):
             self.assertEqual(metrics["usage_normalized"]["total_tokens"], 42)
             self.assertEqual(metrics["usage_normalized"]["source"], "trace_normalized")
 
+    def test_missing_provider_block_cannot_erase_trace_telemetry_from_v3(self):
+        with tempfile.TemporaryDirectory() as td:
+            run_dir = Path(td) / "run"
+            trace = json.dumps({"type": "usage", "usage": {"input_tokens": 3, "output_tokens": 2}})
+            sb.write_trace_artifacts(run_dir, trace, source="codex",
+                                     metadata={"usage_normalized": {"source": "missing"},
+                                               "cost_normalized": {"source": "missing"}})
+            metrics = json.loads((run_dir / "metrics.json").read_text(encoding="utf-8"))
+            self.assertEqual(metrics["usage_normalized"]["total_tokens"], 5)
+            measured = metrics["telemetry"]["measurements"]["total_tokens"]
+            self.assertEqual(measured["availability"], "available")
+            self.assertEqual(measured["value"], 5)
+
     def test_trace_artifacts_tolerate_non_finite_json_numbers(self):
         with tempfile.TemporaryDirectory() as td:
             run_dir = Path(td) / "run"
@@ -114,10 +135,37 @@ class RunnerStampTests(unittest.TestCase):
             )
             metrics = json.loads((run_dir / "metrics.json").read_text(encoding="utf-8"))
             event = json.loads((run_dir / "events.json").read_text(encoding="utf-8"))["events"][0]
-            self.assertNotIn("usage_normalized", metrics)
+            self.assertEqual(metrics["usage_normalized"], {"source": "missing"})
             self.assertNotIn("elapsed_ms", metrics)
+            self.assertEqual(metrics["telemetry"]["measurements"]["total_tokens"]["availability"], "unavailable")
+            self.assertEqual(metrics["telemetry"]["measurements"]["elapsed_ms"]["availability"], "unavailable")
             self.assertEqual(event.get("tokens"), {})
             self.assertNotIn("duration_ms", event)
+
+    def test_incomplete_trace_cannot_pass_zero_activity_process_assertion(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td) / "run"
+            sb.write_trace_artifacts(base, "", source="codex")
+            passed, evidence = sb.process_or_efficiency_assertion_result(
+                {"type": "command_not_ran", "pattern": "rm -rf"}, base, {})
+        self.assertFalse(passed)
+        self.assertIn("trace_observation_incomplete", evidence)
+
+    def test_timed_out_runner_trace_is_incomplete_even_when_it_has_events(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td) / "run"
+            outcome = sb.RunnerOutcome(provider="codex", answer="partial", returncode=124, timed_out=True,
+                                       trace_text="\n".join([json.dumps({"type": "command", "command": "echo partial"}),
+                                                             json.dumps({"type": "usage", "usage": {"input_tokens": 2, "output_tokens": 1}})]))
+            sb.write_runner_outcome(base, outcome)
+            metrics = json.loads((base / "metrics.json").read_text(encoding="utf-8"))
+            self.assertFalse(metrics["observation_complete"])
+            self.assertEqual(metrics["telemetry"]["measurements"]["commands"]["availability"], "unavailable")
+            self.assertEqual(metrics["telemetry"]["measurements"]["total_tokens"]["availability"], "unavailable")
+            passed, evidence = sb.process_or_efficiency_assertion_result(
+                {"type": "command_not_ran", "pattern": "rm -rf"}, base, {})
+        self.assertFalse(passed)
+        self.assertIn("trace_observation_incomplete", evidence)
 
     def test_write_trace_artifacts_metadata_is_current_run_only(self):
         with tempfile.TemporaryDirectory() as td:
@@ -141,6 +189,10 @@ class RunnerStampTests(unittest.TestCase):
         self.assertEqual(usage["total_tokens"], 375)
         self.assertEqual(usage["source"], "trace_normalized")
         self.assertEqual(cost["total_cost"], 0.015)
+        _, eur_cost = sb.stream_usage_and_cost('{"cost":{"amount":1,"currency":"EUR"}}')
+        self.assertEqual(eur_cost, {"currency": "EUR", "total_cost": 1.0, "source": "trace_normalized"})
+        _, mixed_cost = sb.stream_usage_and_cost('\n'.join(['{"cost":{"amount":1,"currency":"EUR"}}', '{"cost":1}']))
+        self.assertEqual(mixed_cost, {"source": "missing"})
         empty_usage, empty_cost = sb.stream_usage_and_cost("plain text only")
         self.assertEqual(empty_usage, {"source": "missing"})
         self.assertEqual(empty_cost, {"source": "missing"})
@@ -231,14 +283,14 @@ class RunnerStampTests(unittest.TestCase):
         self.assertEqual(row["cost_normalized"], {"source": "missing"})
 
 
-def result_row(case_id: str, variant: str, *, cost: float | None, tokens: int | None, exec_valid: bool = True, missing: bool = False, rate: float | None = 1.0) -> dict:
-    metadata = {}
+def result_row(case_id: str, variant: str, *, cost: float | None, tokens: int | None, currency: str = "USD", exec_valid: bool = True, missing: bool = False, rate: float | None = 1.0) -> dict:
+    metadata = {"provider": "test-provider", "model": "test-model", "billing_scope": "run"}
     if tokens is not None:
         metadata["usage_normalized"] = {"input_tokens": tokens - 10, "output_tokens": 10, "total_tokens": tokens, "source": "provider_reported"}
     else:
         metadata["usage_normalized"] = {"source": "missing"}
     if cost is not None:
-        metadata["cost_normalized"] = {"currency": "USD", "total_cost": cost, "source": "provider_reported"}
+        metadata["cost_normalized"] = {"currency": currency, "total_cost": cost, "source": "provider_reported"}
     else:
         metadata["cost_normalized"] = {"source": "missing"}
     metadata["elapsed_ms"] = 1000
@@ -257,13 +309,40 @@ class CostSummaryTests(unittest.TestCase):
         ]
         summary = sb.build_cost_summary(results, confirmed_regressions=1)
         self.assertEqual(summary["coverage"], {"runs_seen": 4, "runs_with_token_usage": 3, "runs_with_dollar_cost": 3,
-                                               "runs_missing_usage": 1, "runs_missing_cost": 1})
-        self.assertEqual(summary["totals"]["total_tokens"], 900)
-        self.assertEqual(summary["totals"]["total_cost_usd"], 0.9)      # execution error included: it was paid for
+                                               "runs_with_non_usd_cost": 0, "runs_missing_usage": 1, "runs_missing_cost": 1})
+        self.assertIsNone(summary["totals"]["total_tokens"])
+        self.assertEqual(summary["totals"]["known_total_tokens"], 900)
+        self.assertEqual(summary["totals"]["total_tokens_availability"], "partial")
+        self.assertIsNone(summary["totals"]["total_cost_usd"])
+        self.assertEqual(summary["totals"]["known_total_cost_usd"], 0.9)  # paid error is retained; unknown run prevents a total
         self.assertEqual(summary["totals"]["execution_errors"], 1)
         self.assertEqual(summary["paired_cost_delta"]["c1"]["delta"], 0.2)
         self.assertEqual(summary["ablations"]["total_cost_usd"], 0.5)
         self.assertEqual(summary["ablations"]["cost_per_confirmed_regression"], 0.5)
+
+    def test_mixed_currency_pair_deltas_never_claim_one_dollar_mean(self):
+        summary = sb.build_cost_summary([
+            result_row("c1", "with_skill", cost=2.0, tokens=10, currency="USD"),
+            result_row("c1", "without_skill", cost=1.0, tokens=10, currency="USD"),
+            result_row("c2", "with_skill", cost=2.0, tokens=10, currency="EUR"),
+            result_row("c2", "without_skill", cost=1.0, tokens=10, currency="EUR"),
+        ])
+        self.assertEqual(summary["mean_paired_cost_delta"], 1.0)
+        self.assertEqual(summary["mean_paired_cost_delta_basis"], {"currency": "USD"})
+        self.assertEqual(summary["mean_paired_cost_delta_by_currency"], {"EUR": 1.0, "USD": 1.0})
+        self.assertEqual(summary["paired_cost_delta"]["c2"]["currency"], "EUR")
+
+    def test_all_missing_and_measured_zero_are_not_conflated(self):
+        unavailable = sb.build_cost_summary([
+            result_row("c1", "with_skill", cost=None, tokens=None),
+        ])
+        zero = sb.build_cost_summary([
+            result_row("c1", "with_skill", cost=0.0, tokens=0),
+        ])
+        self.assertIsNone(unavailable["totals"]["total_cost_usd"])
+        self.assertEqual(unavailable["totals"]["total_cost_usd_availability"], "unavailable")
+        self.assertEqual(zero["totals"]["total_cost_usd"], 0.0)
+        self.assertEqual(zero["totals"]["total_cost_usd_availability"], "complete")
 
     def test_judge_spend_is_a_separate_line(self):
         judge_results = {
@@ -271,7 +350,10 @@ class CostSummaryTests(unittest.TestCase):
             "b": {"cost_normalized": {"source": "missing"}},
         }
         summary = sb.build_cost_summary([result_row("c1", "with_skill", cost=1.0, tokens=100)], judge_results=judge_results)
-        self.assertEqual(summary["judge"], {"verdicts": 2, "verdicts_with_cost": 1, "total_cost_usd": 0.02})
+        self.assertEqual(summary["judge"]["verdicts"], 2)
+        self.assertEqual(summary["judge"]["verdicts_with_cost"], 1)
+        self.assertIsNone(summary["judge"]["total_cost_usd"])
+        self.assertEqual(summary["judge"]["known_total_cost_usd"], 0.02)
         self.assertEqual(summary["totals"]["total_cost_usd"], 1.0)   # not folded into model-under-test spend
 
     def test_benchmark_report_carries_cost_summary(self):
@@ -294,6 +376,7 @@ class CostSummaryTests(unittest.TestCase):
                 base.mkdir(parents=True)
                 (base / "output.md").write_text(text, encoding="utf-8")
                 (base / "metadata.json").write_text(json.dumps({
+                    "provider": "test-provider", "model": "test-model", "billing_scope": "run",
                     "usage_normalized": {"total_tokens": 100, "source": "provider_reported"},
                     "cost_normalized": {"currency": "USD", "total_cost": cost, "source": "provider_reported"},
                 }), encoding="utf-8")
@@ -367,8 +450,66 @@ class SuiteLedgerTests(unittest.TestCase):
             self.assertIn("Cost summary", md.read_text(encoding="utf-8"))
 
 
+class TelemetryMigrationTests(unittest.TestCase):
+    def test_migration_is_dry_run_safe_creates_both_artifacts_and_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as td:
+            runs = Path(td) / "runs"
+            base = runs / "c1" / "with_skill"
+            base.mkdir(parents=True)
+            metadata = {"provider": "test-provider", "model": "test-model", "total_tokens": 0,
+                        "cost_usd": 0.0, "elapsed_ms": 0}
+            (base / "metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+            report_path = Path(td) / "migration.json"
+            check = SimpleNamespace(runs=str(runs), check=True, out=str(report_path))
+            self.assertEqual(sb.migrate_telemetry_command(check), 0)
+            self.assertEqual(json.loads(report_path.read_text(encoding="utf-8"))["changed"], 1)
+            self.assertEqual(json.loads((base / "metadata.json").read_text(encoding="utf-8")), metadata)
+
+            write = SimpleNamespace(runs=str(runs), check=False, out=str(report_path))
+            self.assertEqual(sb.migrate_telemetry_command(write), 0)
+            migrated_meta = json.loads((base / "metadata.json").read_text(encoding="utf-8"))
+            migrated_metrics = json.loads((base / "metrics.json").read_text(encoding="utf-8"))
+            self.assertEqual(migrated_meta["telemetry_schema_version"], 3)
+            self.assertEqual(migrated_meta["telemetry"], migrated_metrics["telemetry"])
+            self.assertEqual(migrated_meta["telemetry"]["measurements"]["total_tokens"]["availability"], "available")
+            self.assertEqual(migrated_meta["telemetry"]["measurements"]["total_tokens"]["value"], 0)
+            self.assertEqual(migrated_meta["telemetry"]["measurements"]["cost"]["provenance"], "legacy_unverified")
+            self.assertEqual(sb.migrate_telemetry_command(write), 0)
+
+            v2 = runs / "c2" / "with_skill"
+            v2.mkdir(parents=True)
+            (v2 / "metrics.json").write_text(json.dumps({
+                "provider": "test-provider", "model": "test-model",
+                "cost_normalized": {"currency": "USD", "total_cost": 0.25, "source": "provider_reported"},
+            }), encoding="utf-8")
+            self.assertEqual(sb.migrate_telemetry_command(write), 0)
+            v2_metrics = json.loads((v2 / "metrics.json").read_text(encoding="utf-8"))
+            self.assertEqual(v2_metrics["telemetry"]["measurements"]["cost"]["provenance"], "legacy_unverified")
+
+    def test_migration_restores_first_artifact_when_second_backup_fails(self):
+        with tempfile.TemporaryDirectory() as td:
+            runs = Path(td) / "runs"
+            base = runs / "c1" / "with_skill"
+            base.mkdir(parents=True)
+            original = {"total_tokens": 10}
+            for name in ("metadata.json", "metrics.json"):
+                (base / name).write_text(json.dumps(original), encoding="utf-8")
+            real_replace = sb.os.replace
+
+            def fail_second_backup(src, dst):
+                if Path(src).name == "metrics.json" and Path(dst).name.endswith(".telemetry-v3.bak"):
+                    raise OSError("simulated second backup failure")
+                return real_replace(src, dst)
+
+            with mock.patch.object(sb.os, "replace", side_effect=fail_second_backup):
+                with self.assertRaises(OSError):
+                    sb.migrate_telemetry_command(SimpleNamespace(runs=str(runs), check=False, out=str(Path(td) / "report.json")))
+            for name in ("metadata.json", "metrics.json"):
+                self.assertEqual(json.loads((base / name).read_text(encoding="utf-8")), original)
+
+
 class TokenOverheadDollarTests(unittest.TestCase):
-    def test_pairs_carry_dollar_deltas_and_lift_per_dollar(self):
+    def test_non_usd_pairs_never_populate_dollar_fields(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
             repo = root / "repo"
@@ -388,14 +529,18 @@ class TokenOverheadDollarTests(unittest.TestCase):
                 base.mkdir(parents=True)
                 (base / "output.md").write_text(text, encoding="utf-8")
                 (base / "metadata.json").write_text(json.dumps({
-                    "total_tokens": tokens, "input_tokens": tokens - 10, "output_tokens": 10,
-                    "cost_normalized": {"currency": "USD", "total_cost": cost, "source": "provider_reported"},
+                    "provider": "test-provider", "model": "test-model", "billing_scope": "run",
+                    "usage_normalized": {"total_tokens": tokens, "input_tokens": tokens - 10, "output_tokens": 10, "source": "provider_reported"},
+                    "cost_normalized": {"currency": "EUR", "total_cost": cost, "source": "provider_reported"},
                 }), encoding="utf-8")
             report = sb.paired_token_overhead_report(path, runs=runs)
         pair = report["pairs"][0]
-        self.assertEqual(pair["cost_delta_usd"], 0.2)
-        self.assertEqual(pair["objective_lift_per_dollar"], 5.0)   # lift 1.0 / $0.20
-        self.assertEqual(report["summary"]["cost_delta_usd"]["mean"], 0.2)
+        self.assertIsNone(pair["cost_delta_usd"])
+        self.assertIsNone(pair["objective_lift_per_dollar"])
+        self.assertEqual(pair["objective_lift_per_dollar_comparison"]["reason"], "currency_not_usd")
+        self.assertEqual(pair["objective_lift_per_cost_unit"], 5.0)  # lift 1.0 / €0.20
+        self.assertEqual(pair["objective_lift_per_cost_unit_comparison"]["basis"]["currency"], "EUR")
+        self.assertIsNone(report["summary"]["cost_delta_usd"]["mean"])
         self.assertEqual(report["summary"]["saturated_or_no_lift_cost_usd"], 0)
 
     def test_saturated_pair_cost_is_reported_as_waste(self):
@@ -418,7 +563,8 @@ class TokenOverheadDollarTests(unittest.TestCase):
                 base.mkdir(parents=True)
                 (base / "output.md").write_text("alpha", encoding="utf-8")   # both pass: saturated
                 (base / "metadata.json").write_text(json.dumps({
-                    "total_tokens": 100,
+                    "provider": "test-provider", "model": "test-model", "billing_scope": "run",
+                    "usage_normalized": {"total_tokens": 100, "source": "provider_reported"},
                     "cost_normalized": {"currency": "USD", "total_cost": 0.25, "source": "provider_reported"},
                 }), encoding="utf-8")
             report = sb.paired_token_overhead_report(path, runs=runs)
@@ -479,8 +625,10 @@ class SuiteBudgetGateTests(unittest.TestCase):
             history.mkdir()
             for i, (tokens, cost, runs_n) in enumerate([(1_000_000, 10.0, 100), (3_000_000, 30.0, 100)], 1):
                 (history / f"ledger-{i}.json").write_text(json.dumps({
+                    "telemetry_schema_version": 3,
                     "coverage": {"runs_seen": runs_n, "runs_with_dollar_cost": runs_n},
-                    "totals": {"total_tokens": tokens, "total_cost_usd": cost},
+                    "totals": {"total_tokens": tokens, "total_tokens_availability": "complete",
+                               "total_cost_usd": cost, "total_cost_usd_availability": "complete"},
                 }), encoding="utf-8")
             scope = {"totals": {"selected_tier_rows": 10}, "include_ablations": False}
             estimate = sb.suite_cost_estimate(scope, history_dir=history)
@@ -488,6 +636,25 @@ class SuiteBudgetGateTests(unittest.TestCase):
         self.assertEqual(estimate["per_run_tokens"], 20000.0)       # median of 10k and 30k
         self.assertEqual(estimate["estimated_tokens"], 200000)
         self.assertEqual(estimate["estimated_cost_usd"], 2.0)       # median $0.20/run x 10 rows
+
+    def test_foreign_currency_observations_do_not_dilute_usd_budget_history(self):
+        summary = sb.build_cost_summary([
+            result_row("usd", "with_skill", cost=10.0, tokens=10, currency="USD"),
+            result_row("eur", "with_skill", cost=20.0, tokens=10, currency="EUR"),
+        ])
+        self.assertEqual(summary["coverage"]["runs_with_dollar_cost"], 1)
+        self.assertEqual(summary["coverage"]["runs_with_non_usd_cost"], 1)
+        self.assertEqual(summary["coverage"]["runs_missing_cost"], 0)
+        with tempfile.TemporaryDirectory() as td:
+            history = Path(td) / "history"
+            history.mkdir()
+            (history / "ledger.json").write_text(json.dumps({
+                "telemetry_schema_version": 3, "coverage": summary["coverage"],
+                "totals": {"total_tokens": 20, "total_tokens_availability": "complete",
+                           "total_cost_usd": 10.0, "total_cost_usd_availability": "complete"},
+            }), encoding="utf-8")
+            estimate = sb.suite_cost_estimate({"totals": {"selected_tier_rows": 2}, "include_ablations": False}, history_dir=history)
+        self.assertEqual(estimate["estimated_cost_usd"], 20.0)
 
     def test_estimate_static_fallback_has_no_dollar_guess(self):
         estimate = sb.suite_cost_estimate({"totals": {"selected_tier_rows": 4}, "include_ablations": False})

--- a/tests/test_skill_benchmark.py
+++ b/tests/test_skill_benchmark.py
@@ -554,7 +554,8 @@ class SkillBenchmarkTests(unittest.TestCase):
                 {"type": "usage", "usage": {"input_tokens": 80, "output_tokens": 20, "total_tokens": 100}},
             ]
             trace.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
-            sb.import_trace(SimpleNamespace(source="codex", trace=str(trace), run_dir=str(run_dir), out_events=None, out_metrics=None, write_metadata=True))
+            sb.import_trace(SimpleNamespace(source="codex", trace=str(trace), run_dir=str(run_dir), out_events=None, out_metrics=None, write_metadata=False))
+            self.assertTrue((run_dir / "metadata.json").is_file())
             events = json.loads((run_dir / "events.json").read_text(encoding="utf-8"))
             metrics = json.loads((run_dir / "metrics.json").read_text(encoding="utf-8"))
             self.assertEqual([e["type"] for e in events["events"]][:3], ["skill_load", "command", "command"])
@@ -583,7 +584,8 @@ class SkillBenchmarkTests(unittest.TestCase):
                 base = runs / "case-1" / variant
                 base.mkdir(parents=True)
                 (base / "output.md").write_text("alpha beta", encoding="utf-8")
-                sb.write_trace_artifacts(base, "", source="test", extra_metrics={"skill_invoked": invoked, "skill_invocation_evidence": [variant] if invoked else []}, write_metadata=True)
+                sb.write_trace_artifacts(base, json.dumps({"type": "message", "role": "assistant", "content": "done"}),
+                                         source="test", extra_metrics={"skill_invoked": invoked, "skill_invocation_evidence": [variant] if invoked else []}, write_metadata=True)
             report = sb.build_benchmark_report(manifest, runs)
             by_variant = {r["variant"]: r for r in report["results"]}
             self.assertEqual(by_variant["with_skill"]["objective_total"], 1)
@@ -673,9 +675,15 @@ class SkillBenchmarkTests(unittest.TestCase):
                 base.mkdir(parents=True)
                 (base / "output.md").write_text("alpha beta", encoding="utf-8")
                 (base / "metrics.json").write_text(json.dumps({
-                    "total_tokens": total,
-                    "input_tokens": input_tokens,
-                    "output_tokens": output_tokens,
+                    "provider": "test-provider",
+                    "model": "test-model",
+                    "billing_scope": "run",
+                    "usage_normalized": {
+                        "total_tokens": total,
+                        "input_tokens": input_tokens,
+                        "output_tokens": output_tokens,
+                        "source": "provider_reported",
+                    },
                     "skill_invoked": variant == "with_skill",
                 }), encoding="utf-8")
             report = sb.paired_token_overhead_report(manifest, runs=runs)
@@ -685,6 +693,66 @@ class SkillBenchmarkTests(unittest.TestCase):
             self.assertEqual(report["pairs"][0]["objective_delta"], 0.0)
             self.assertEqual(report["pairs"][0]["objective_lift_per_1k_total_tokens"], 0.0)
             self.assertGreater(report["summary"]["static_skill_tokens"], 0)
+
+    def test_token_overhead_pairs_each_model_root_without_overwriting_same_run_number(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            manifest = self.make_manifest(root)
+            runs = root / "repo" / "eval-runs" / "latest"
+            for model, with_tokens, without_tokens in [("model-a", 150, 50), ("model-b", 220, 100)]:
+                for variant, tokens in [("with_skill", with_tokens), ("without_skill", without_tokens)]:
+                    base = runs / "case-1" / model / variant
+                    base.mkdir(parents=True)
+                    (base / "output.md").write_text("alpha beta", encoding="utf-8")
+                    (base / "metrics.json").write_text(json.dumps({
+                        "provider": "test-provider", "model": model, "billing_scope": "run",
+                        "usage_normalized": {"total_tokens": tokens, "source": "provider_reported"},
+                    }), encoding="utf-8")
+            report = sb.paired_token_overhead_report(manifest, runs=runs)
+        self.assertEqual(report["summary"]["paired_runtime_rows"], 2)
+        self.assertEqual({pair["model"] for pair in report["pairs"]}, {"model-a", "model-b"})
+        self.assertEqual({pair["total_token_delta"] for pair in report["pairs"]}, {100, 120})
+
+    def test_pairing_refuses_singleton_arms_with_different_run_numbers(self):
+        with tempfile.TemporaryDirectory() as td:
+            runs = Path(td)
+            with_dir = runs / "case" / "with_skill" / "run-2"
+            without_dir = runs / "case" / "without_skill" / "run-1"
+            with_dir.mkdir(parents=True)
+            without_dir.mkdir(parents=True)
+            pairs = list(sb.paired_run_bases(runs, "case", "with_skill", "without_skill"))
+        self.assertEqual([(run, left is None, right is None) for _, run, left, right in pairs],
+                         [(1, True, False), (2, False, True)])
+
+    def test_token_overhead_reports_missing_and_unscorable_pairs_as_blocked(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            manifest = self.make_manifest(root)
+            runs = root / "repo" / "eval-runs" / "latest"
+            with_base = runs / "case-1" / "with_skill"
+            with_base.mkdir(parents=True)
+            (with_base / "output.md").write_text("alpha beta", encoding="utf-8")
+            (with_base / "metrics.json").write_text(json.dumps({
+                "provider": "test-provider", "model": "test-model", "billing_scope": "run",
+                "usage_normalized": {"total_tokens": 10, "source": "provider_reported"},
+            }), encoding="utf-8")
+            missing_report = sb.paired_token_overhead_report(manifest, runs=runs)
+            self.assertEqual(missing_report["pairs"], [])
+            self.assertEqual(missing_report["blocked_pairs"][0]["pair_status"]["reason"], "missing_right")
+            self.assertEqual(missing_report["summary"]["cost_delta_coverage"]["blocked_reason_counts"], {"missing_right": 1})
+
+            without_base = runs / "case-1" / "without_skill"
+            without_base.mkdir(parents=True)
+            # Empty output is an unscorable arm, but it remains an auditable blocked pair.
+            (without_base / "output.md").write_text("", encoding="utf-8")
+            (without_base / "metrics.json").write_text(json.dumps({
+                "provider": "test-provider", "model": "test-model", "billing_scope": "run", "returncode": 1,
+                "usage_normalized": {"total_tokens": 5, "source": "provider_reported"},
+            }), encoding="utf-8")
+            unscorable_report = sb.paired_token_overhead_report(manifest, runs=runs)
+        self.assertEqual(unscorable_report["pairs"], [])
+        self.assertEqual(unscorable_report["blocked_pairs"][0]["pair_status"]["reason"], "unscorable_arm")
+        self.assertEqual(unscorable_report["summary"]["cost_delta_coverage"]["blocked_reason_counts"], {"unscorable_arm": 1})
 
     def test_command_assertions_match_command_inputs_not_outputs(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_smoke_supported_clis.py
+++ b/tests/test_smoke_supported_clis.py
@@ -1,0 +1,77 @@
+"""Offline contract tests for the opt-in supported-CLI live-smoke runner."""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "smoke_supported_clis.py"
+_spec = importlib.util.spec_from_file_location("smoke_supported_clis", SCRIPT)
+assert _spec and _spec.loader
+smoke = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(smoke)
+
+
+class SupportedCliSmokeTests(unittest.TestCase):
+    def test_minimal_disposable_manifest_has_one_answer_and_both_trigger_polarities(self):
+        with tempfile.TemporaryDirectory() as td:
+            manifest_path = smoke.make_smoke_repo(Path(td))
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            answer = [case for case in manifest["cases"] if case["kind"] != "trigger"]
+            triggers = [case for case in manifest["cases"] if case["kind"] == "trigger"]
+            self.assertEqual(len(answer), 1)
+            self.assertEqual(len(triggers), 2)
+            self.assertEqual({case["id"] for case in triggers}, {"trig-pos-review-change", "trig-neg-unrelated-question"})
+            self.assertTrue((manifest_path.parent.parent / "skills" / "demo" / "SKILL.md").exists())
+
+    def test_trigger_assessment_requires_the_exact_positive_and_negative_fixture_rows(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "pi-trigger.json"
+            report = {"checks": []}
+            path.write_text(json.dumps({"results": [{
+                "query": smoke.SMOKE_TRIGGER_EXPECTATIONS[0][0], "should_trigger": True,
+                "observation_complete": True, "returncode": 0, "pass": True,
+            }]}), encoding="utf-8")
+            self.assertFalse(smoke.assess_trigger_report(path, report))
+            self.assertFalse(report["checks"][0]["passed"])
+
+    def test_failed_prepare_short_circuits_before_any_answer_call(self):
+        with tempfile.TemporaryDirectory() as td:
+            args = argparse.Namespace(out_dir=str(Path(td) / "out"), live=True, agents="claude",
+                                      claude_model="haiku", codex_model="unused", vibe_model="unused",
+                                      pi_model="unused", timeout=1)
+            with mock.patch.object(smoke, "parse_args", return_value=args), \
+                 mock.patch.object(smoke.shutil, "which", return_value="/mock/claude"), \
+                 mock.patch.object(smoke, "run", return_value=False) as run:
+                self.assertEqual(smoke.main(), 1)
+            self.assertEqual(run.call_count, 1)
+            self.assertEqual(run.call_args.kwargs["label"], "claude:prepare")
+
+    def test_live_acknowledgement_is_required_before_any_cli_call(self):
+        with tempfile.TemporaryDirectory() as td:
+            completed = subprocess.run(
+                [sys.executable, str(SCRIPT), "--out-dir", str(Path(td) / "out")],
+                text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False,
+            )
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("--live", completed.stderr)
+
+    def test_live_smoke_rejects_an_empty_agent_selection(self):
+        with tempfile.TemporaryDirectory() as td:
+            completed = subprocess.run(
+                [sys.executable, str(SCRIPT), "--live", "--agents", " , ", "--out-dir", str(Path(td) / "out")],
+                text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False,
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("at least one", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_telemetry_domain.py
+++ b/tests/test_telemetry_domain.py
@@ -1,0 +1,142 @@
+"""Telemetry availability/comparability domain contract.
+
+These are deliberately boundary- and behavior-focused: they prove a measured zero,
+an unavailable observation, and a non-comparable pair remain different states.
+"""
+from __future__ import annotations
+
+import unittest
+from decimal import Decimal
+
+from telemetry import (
+    Aggregate,
+    Comparison,
+    Measurement,
+    Money,
+    aggregate_money_by_currency,
+    aggregate_numeric,
+    compare_cost_pair,
+    lift_per_dollar,
+)
+
+
+class MeasurementModelTests(unittest.TestCase):
+    def test_available_zero_is_not_unavailable(self):
+        measurement = Measurement.available(0, provenance="provider_reported")
+        self.assertEqual(measurement.availability, "available")
+        self.assertEqual(measurement.value, 0)
+        self.assertEqual(measurement.to_dict()["value"], 0)
+
+    def test_model_rejects_invalid_states(self):
+        with self.assertRaises(ValueError):
+            Measurement("available", None, provenance="provider_reported")
+        with self.assertRaises(ValueError):
+            Measurement("unavailable", 0, reason="missing")
+        with self.assertRaises(ValueError):
+            Measurement.available(-1, provenance="provider_reported")
+        with self.assertRaises(ValueError):
+            Money(Decimal("-0.01"), "USD")
+        with self.assertRaises(ValueError):
+            Money(Decimal("0.01"), "usd")
+        with self.assertRaises(ValueError):
+            Aggregate("complete", value=float("nan"))
+        with self.assertRaises(ValueError):
+            Comparison.comparable(float("nan"))
+
+
+class AggregateTests(unittest.TestCase):
+    def test_zero_complete_partial_and_unavailable_are_distinct(self):
+        zero = aggregate_numeric([Measurement.available(0, provenance="provider_reported")])
+        partial = aggregate_numeric([
+            Measurement.available(0, provenance="provider_reported"),
+            Measurement.unavailable("runner_does_not_report_cost"),
+        ])
+        absent = aggregate_numeric([Measurement.unavailable("trace_absent")])
+
+        self.assertEqual(zero.availability, "complete")
+        self.assertEqual(zero.value, 0)
+        self.assertEqual(partial.availability, "partial")
+        self.assertEqual(partial.known_subtotal, 0)
+        self.assertEqual(absent.availability, "unavailable")
+        self.assertIsNone(absent.value)
+
+    def test_incompatible_bases_cannot_claim_one_complete_total(self):
+        aggregate = aggregate_numeric([
+            Measurement.available(3, provenance="provider_reported", basis={"population": "answer", "billing_scope": "run"}),
+            Measurement.available(7, provenance="trace_normalized", basis={"population": "answer", "billing_scope": "run"}),
+        ])
+        self.assertEqual(aggregate.availability, "unavailable")
+        self.assertEqual(aggregate.reason_counts, {"basis_mismatch": 2})
+
+    def test_currency_buckets_do_not_turn_each_other_into_missing_values(self):
+        basis = {"population": "answer", "billing_scope": "run"}
+        buckets = aggregate_money_by_currency([
+            Measurement.available(Money(Decimal("1.00"), "USD"), provenance="provider_reported", basis=basis),
+            Measurement.available(Money(Decimal("2.00"), "EUR"), provenance="provider_reported", basis=basis),
+        ])
+        self.assertEqual(buckets["USD"].availability, "complete")
+        self.assertEqual(buckets["USD"].value, Decimal("1.00"))
+        self.assertEqual(buckets["EUR"].availability, "complete")
+        self.assertEqual(buckets["EUR"].value, Decimal("2.00"))
+
+    def test_unavailable_rows_do_not_change_known_subtotal(self):
+        complete = aggregate_numeric([
+            Measurement.available(3, provenance="provider_reported"),
+            Measurement.available(7, provenance="provider_reported"),
+        ])
+        partial = aggregate_numeric([
+            Measurement.available(3, provenance="provider_reported"),
+            Measurement.available(7, provenance="provider_reported"),
+            Measurement.unavailable("trace_absent"),
+        ])
+        self.assertEqual(complete.value, 10)
+        self.assertEqual(partial.known_subtotal, 10)
+        self.assertEqual(partial.unavailable_count, 1)
+
+
+class CostComparisonTests(unittest.TestCase):
+    def test_lift_per_dollar_requires_complete_comparable_basis(self):
+        basis = {
+            "population": "answer", "provider": "anthropic", "model": "claude-test",
+            "billing_scope": "run", "case_id": "case-1", "run_number": 1,
+            "pricing_model": "claude-test", "pricing_table_version": "2026-07",
+        }
+        with_cost = Measurement.available(Money(Decimal("0.30"), "USD"), provenance="provider_reported", basis=basis)
+        without_cost = Measurement.available(Money(Decimal("0.10"), "USD"), provenance="provider_reported", basis=basis)
+        delta = compare_cost_pair(with_cost, without_cost)
+        ratio = lift_per_dollar(Comparison.comparable(1.0), delta)
+
+        self.assertEqual(delta.availability, "comparable")
+        self.assertEqual(delta.value.amount, Decimal("0.20"))
+        self.assertEqual(ratio.availability, "comparable")
+        self.assertEqual(ratio.value, 5.0)
+
+    def test_lift_per_dollar_blocks_missing_mismatched_and_nonpositive_cost(self):
+        basis = {
+            "population": "answer", "provider": "anthropic", "model": "claude-test",
+            "billing_scope": "run", "case_id": "case-1", "run_number": 1,
+            "pricing_model": "claude-test", "pricing_table_version": "2026-07",
+        }
+        with_cost = Measurement.available(Money(Decimal("0.30"), "USD"), provenance="provider_reported", basis=basis)
+        missing = Measurement.unavailable("runner_does_not_report_cost")
+        other_currency = Measurement.available(Money(Decimal("0.10"), "EUR"), provenance="provider_reported", basis=basis)
+        same_cost = Measurement.available(Money(Decimal("0.30"), "USD"), provenance="provider_reported", basis=basis)
+
+        self.assertEqual(compare_cost_pair(with_cost, missing).reason, "missing_right")
+        self.assertEqual(compare_cost_pair(with_cost, other_currency).reason, "currency_mismatch")
+        self.assertEqual(lift_per_dollar(Comparison.comparable(1.0), compare_cost_pair(with_cost, same_cost)).reason,
+                         "non_positive_denominator")
+        saving = Measurement.available(Money(Decimal("0.40"), "USD"), provenance="provider_reported", basis=basis)
+        saving_delta = compare_cost_pair(with_cost, saving)
+        self.assertEqual(saving_delta.value.amount, Decimal("-0.10"))
+        self.assertEqual(lift_per_dollar(Comparison.comparable(1.0), saving_delta).reason, "non_positive_denominator")
+        other_case = Measurement.available(
+            Money(Decimal("0.10"), "USD"), provenance="provider_reported",
+            basis={**basis, "case_id": "other-case"},
+        )
+        self.assertEqual(compare_cost_pair(with_cost, other_case).reason, "pair_key_mismatch")
+        self.assertEqual(compare_cost_pair(with_cost, same_cost, left_scorable=False).reason, "unscorable_arm")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_telemetry_properties.py
+++ b/tests/test_telemetry_properties.py
@@ -1,0 +1,84 @@
+"""Property and finite-state tests for the telemetry boundary.
+
+The type constructors make invalid internal states hard to express; these tests
+exercise the remaining untyped JSON/numeric boundary and algebraic laws.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from itertools import permutations
+
+import pytest
+from hypothesis import given, strategies as st
+
+from telemetry import (
+    AVAILABLE,
+    BLOCKED,
+    COMPARABLE,
+    Comparison,
+    Measurement,
+    Money,
+    aggregate_numeric,
+    compare_cost_pair,
+    lift_per_dollar,
+    measurement_from_cost_block,
+)
+
+
+@given(st.lists(st.integers(min_value=0, max_value=1_000_000), max_size=8))
+def test_numeric_aggregate_is_permutation_invariant(values):
+    measurements = [Measurement.available(value, provenance="provider_reported") for value in values]
+    expected = aggregate_numeric(measurements).to_dict()
+    # Testing every permutation becomes impractical above a few rows; these
+    # deterministic orderings still prove the property over the broad numeric
+    # input space and the finite-state test below exhausts availability states.
+    assert aggregate_numeric(list(reversed(measurements))).to_dict() == expected
+    assert aggregate_numeric(sorted(measurements, key=lambda measurement: measurement.value)).to_dict() == expected
+
+
+@given(st.one_of(st.none(), st.booleans(), st.text(), st.floats(allow_nan=True, allow_infinity=True),
+                 st.dictionaries(st.text(max_size=12), st.integers())))
+def test_cost_parser_is_valid_or_explicitly_unavailable(raw):
+    measurement = measurement_from_cost_block({"source": "provider_reported", "total_cost": raw})
+    assert measurement.availability in {"available", "unavailable", "not_applicable"}
+    if measurement.availability == AVAILABLE:
+        assert isinstance(measurement.value, Money)
+        assert measurement.value.amount >= 0
+        assert measurement.value.amount.is_finite()
+    else:
+        assert measurement.value is None
+        assert measurement.reason
+
+
+@pytest.mark.parametrize("left_state", ["available", "unavailable", "not_applicable"])
+@pytest.mark.parametrize("right_state", ["available", "unavailable", "not_applicable"])
+@pytest.mark.parametrize("same_currency", [True, False])
+@pytest.mark.parametrize("increment", [Decimal("-0.10"), Decimal("0"), Decimal("0.10")])
+def test_every_availability_currency_and_denominator_combination_is_safe(left_state, right_state, same_currency, increment):
+    basis = {"population": "answer", "provider": "p", "model": "m", "billing_scope": "run",
+             "case_id": "case-1", "run_number": 1}
+
+    def measurement(state, amount, currency):
+        if state == "available":
+            return Measurement.available(Money(amount, currency), provenance="provider_reported", basis=basis)
+        if state == "unavailable":
+            return Measurement.unavailable("missing", basis=basis)
+        return Measurement.not_applicable("offline", basis=basis)
+
+    without = measurement(right_state, Decimal("1.00"), "USD")
+    # A negative increment still leaves a non-negative observed treatment cost.
+    with_amount = Decimal("1.00") + increment
+    with_cost = measurement(left_state, with_amount, "USD" if same_currency else "EUR")
+    delta = compare_cost_pair(with_cost, without)
+    ratio = lift_per_dollar(Comparison.comparable(1.0), delta)
+
+    if left_state == right_state == "available" and same_currency:
+        assert delta.availability == COMPARABLE
+        if increment > 0:
+            assert ratio.availability == COMPARABLE
+        else:
+            assert ratio.availability == BLOCKED
+            assert ratio.reason == "non_positive_denominator"
+    else:
+        assert delta.availability == BLOCKED
+        assert ratio.availability == BLOCKED

--- a/tests/test_trigger_matrix.py
+++ b/tests/test_trigger_matrix.py
@@ -76,6 +76,20 @@ class TriggerRowBoundaryTests(unittest.TestCase):
         self.assertNotEqual(Path(seen["cwd"]).resolve(), ROOT.resolve())
 
 
+    def test_pi_timeout_with_parseable_partial_trace_is_not_telemetry_complete(self):
+        def timed_out(*args, **kwargs):
+            return {"stdout": json.dumps({"type": "command", "command": "partial"}) + "\n",
+                    "stderr": "timeout", "returncode": 124, "timed_out": True,
+                    "elapsed_ms": 10, "observation_complete": False}
+
+        with tempfile.TemporaryDirectory() as td, mock.patch.object(tr, "run_argv_with_timeout", side_effect=timed_out):
+            trace_dir = Path(td) / "trace"
+            tr.run_query(DEMO_MANIFEST, "ordinary chat", False, 1, None, trace_dir=trace_dir)
+            meta = json.loads((trace_dir / "metadata.json").read_text(encoding="utf-8"))
+        self.assertFalse(meta["observation_complete"])
+        self.assertEqual(meta["telemetry"]["measurements"]["commands"]["availability"], "unavailable")
+
+
 class StubMatrixOfflineTests(unittest.TestCase):
     def test_demo_manifest_has_both_polarities(self):
         rows = demo_trigger_rows()
@@ -108,6 +122,8 @@ class StubMatrixOfflineTests(unittest.TestCase):
             self.assertTrue((trace_dir / "metrics.json").is_file())
             meta = json.loads((trace_dir / "metadata.json").read_text(encoding="utf-8"))
             self.assertEqual(meta["provider"], "stub")
+            self.assertEqual(meta["population"], "trigger")
+            self.assertEqual(meta["telemetry"]["population"], "trigger")
             self.assertEqual(meta["measurement"], "raw_measurement")
             self.assertEqual(report["results"][0]["measurement"], "raw_measurement")
             self.assertTrue(trace_dir.is_relative_to(trace_root))


### PR DESCRIPTION
## Summary

- Add a typed telemetry v3 domain: zero, unavailable, not-applicable, partial aggregates, and blocked comparisons are distinct and serializable.
- Route telemetry through artifacts, trace assertions, cost summaries/budgets/exports, rankings, paired lift calculations, and `migrate-telemetry` for legacy run trees.
- Add `scripts/smoke_supported_clis.py`, an opt-in, non-destructive low-cost smoke that makes a disposable one-answer/two-trigger demo and checks Claude/Codex/Vibe answer paths plus Pi trigger behavior.

## Validation

- [x] `git diff --check`
- [x] `./.venv/bin/python -m pytest -q` — **708 passed, 5 skipped, 96 subtests passed**.
- [x] Fresh CI-style install: `uv pip install --python /tmp/skill-eval-harness-ci-clean/bin/python -e '.[test]' && /tmp/skill-eval-harness-ci-clean/bin/python -m unittest discover tests -v` — **650 passed, 5 skipped**.
- [x] `uv build --out-dir /tmp/skill-eval-harness-dist-final` — succeeds; wheel contains `telemetry.py`.
- [x] Cheapest comprehensive live attempt:
  `./.venv/bin/python scripts/smoke_supported_clis.py --live --out-dir /tmp/skill-eval-cli-smoke-20260710-final --timeout 90`
  - Claude `haiku`: artifact and treatment-fixture checks passed.
  - Codex `gpt-5.4-mini`: artifact and treatment-fixture checks passed.
  - Vibe `devstral-small-latest`: correctly failed (both arms execution-invalid) because `MISTRAL_API_KEY` is absent from this environment.
  - Pi `mistral/ministral-3b-latest`: observations completed; negative control passed, positive activation failed. The script exits nonzero and preserves this result rather than treating a zero harness subprocess status as success.

## Eval / docs impact

- [x] README/docs/spec and contributor/CI setup updated; CI installs `.[test]`.
- [x] Tests cover availability invariants/properties, migration rollback, object/mixed currency, mismatched run pairing, trace-completeness fail-closed behavior, smoke planning, and trigger population.
- [x] Existing manifests remain answer-key safe. The live smoke generates a disposable public demo fixture.

## Multi-agent audit

Three independent reviewers audited telemetry integrity, CLI/producer integration, and test quality. Addressed findings included atomic migration rollback, raw currency propagation/bucketing, false singleton pairing, non-finite values, trace/metadata precedence, timeout partial-trace handling, test-extra CI install, smoke output deletion, stub elapsed capability, code-reference drift, USD-only history coverage, and empty/stale/partial smoke success paths.

## Notes / risks

- Live smoke is intentionally opt-in and can spend provider budget. Its current environmental/model failures above are actionable evidence, not PR blockers hidden by the runner.
- Legacy numeric telemetry remains readable but becomes `legacy_unverified` and cannot establish causal efficiency comparisons.
