### PR TITLE
Fix Pi trigger observations and telemetry

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -71,7 +71,7 @@ Jetty runbooks emit a standardized machine-readable `validation_report.json` per
 (`jettyio/jettyio-skills`, `skills/create-runbook/SKILL.md`). Rubric evaluation scores 3-7
 dimensions on a 1-5 scale; programmatic evaluation returns `PASS` / `PARTIAL` / `FAIL`. The
 items below map that report onto the harness judge-result row `{judge_task_id, passed, score,
-threshold, evidence}` (`load_judge_results:5029`, merged in `grade_case_variant:6127`).
+threshold, evidence}` (`load_judge_results:5108`, merged in `grade_case_variant:6206`).
 
 - [ ] Export qualitative judge tasks to Jetty workflows using `simple_judge` where useful.
       Carry `judge_task_id` (`case::variant::run-n::assertion`) into the Jetty task so the

--- a/docs/abstractions.md
+++ b/docs/abstractions.md
@@ -133,9 +133,9 @@ editor. This boundary is the main extension seam in the codebase.
 
 A runner consumes task rows and produces the contract. The repo ships seven paths plus a
 generic one: Pi smoke (`examples/adewale-workspace/run_pi_smoke.py`), Pi trigger
-(`run_pi_trigger_eval.py`), Codex (`run_codex:4395`), Claude (`run_claude:4513`, capturing real
+(`run_pi_trigger_eval.py`), Codex (`run_codex:4474`), Claude (`run_claude:4592`, capturing real
 per-run cost), Mistral Vibe (`run-agent --agent vibe`, using isolated `VIBE_HOME` outside the workdir), the in-process
-subagent runner (`run_subagent:5714`, which hosts record/replay tool I/O via `ToolReplayStore`),
+subagent runner (`run_subagent:5793`, which hosts record/replay tool I/O via `ToolReplayStore`),
 Jetty (`JettyClient:2219` and the export/run/import commands), and any runner that writes the
 contract directly. Each runner registers a workspace builder so
 one cross-runner invariant proves its `without_skill` arm is skill-free (CF.2). The harness

--- a/docs/agent-cli-control-plane.md
+++ b/docs/agent-cli-control-plane.md
@@ -83,10 +83,11 @@ caller-owned directory.
 ```
 
 `--live` is required because this spends provider budget. Defaults are intentionally
-small (`haiku`, `gpt-5.4-mini`, `devstral-small-latest`, and
-`mistral/ministral-3b-latest`); override any model with
+small (`haiku`, `gpt-5.4-mini`, `devstral-small-latest`, and Pi's
+`openai-codex/gpt-5.4-mini`); override any model with
 `--claude-model`, `--codex-model`, `--vibe-model`, or `--pi-model` (or the matching
-`SMOKE_*_MODEL` environment variable). Jetty is an API/import surface, not a local
+`SMOKE_*_MODEL` environment variable). Pi's Codex-backed default requires Pi's OpenAI Codex
+authentication. Jetty is an API/import surface, not a local
 CLI; retain its separate token-backed smoke. The command exits nonzero unless every selected
 CLI completes its artifact contract and the demo fixtures pass, so incomplete or substituted
 trigger rows and failed provider runs are never reported as a smoke success.

--- a/docs/eval-framework-roadmap-spec.md
+++ b/docs/eval-framework-roadmap-spec.md
@@ -17,7 +17,7 @@ One invariant governs every item: core grading stays local and deterministic and
 model, and the harness never picks a model for the user. Anything that needs a model lives
 behind an opt-in command or the external `--judge-cmd`. Two abstractions absorb most of the
 work, so the spec returns to them often: the assertion result shape in `assertion_result`
-(`skill_benchmark.py:4818`) and the fan-out in `prepared_task_rows` (`:740`).
+(`skill_benchmark.py:4897`) and the fan-out in `prepared_task_rows` (`:740`).
 
 ## Testing baseline
 
@@ -40,7 +40,7 @@ tests are where that claim is checked rather than trusted.
 
 The buckets below extend what the harness can measure. This floor decides whether the number it
 already prints can be believed. The harness reports one thing: lift, `with_skill` minus
-`without_skill` on the same case (`build_paired_summary` (`:6759`)). That number is believable only
+`without_skill` on the same case (`build_paired_summary` (`:6838`)). That number is believable only
 when three preconditions hold, each intended today, none enforced, and each restating a claim from
 `evals-are-not-tests.md`:
 
@@ -60,7 +60,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
   hiding the quantity the tool exists to measure.
 - **Abstractions used or changed:** none in the engine. Adds
   `tests/fixtures/detectors/<detector_id>/should-fire.*` and `should-pass.*` that exercise
-  `assertion_result` (`:4818`) directly. That function has no direct unit test today, and its
+  `assertion_result` (`:4897`) directly. That function has no direct unit test today, and its
   `contains_any`, `excludes_any`, and `not_regex` branches go unexercised even though their types
   are declared in the assertion registries (`TEXT_ASSERTIONS:69`).
 - **Design:** one table-driven test loads every pair and asserts the detector fires on `should-fire`
@@ -101,7 +101,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 ### CF.4 — A guard that the core grade path calls no model and no network
 - **Goal:** make the governing invariant — "core grading stays local and deterministic and never
   calls a model" — executable rather than aspirational.
-- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:6127`).
+- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:6206`).
 - **Design:** patch `urllib` and `subprocess` to raise, then grade a fixture covering every
   objective family (text, process, efficiency) and assert it completes. The sanctioned exceptions —
   `script` oracles and `judge` plumbing — are excluded from this path by design and keep their own
@@ -111,7 +111,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 
 ### Boundary
 The set stops here deliberately. Report-level correctness — whether the saturation, no-lift, flaky,
-and negative-delta flags (`build_benchmark_report` (`:7634`)) are computed right — sits a layer
+and negative-delta flags (`build_benchmark_report` (`:7713`)) are computed right — sits a layer
 above the raw measurement, where the golden-report tests the buckets already plan (1.2, 2.6) cover
 it. CF.1–CF.4 are the floor underneath that work: once they pass, a printed lift carries a checked
 measurement, and every feature in the buckets builds on a number that has been verified rather than
@@ -127,7 +127,7 @@ assumed.
   they become new types in `TEXT_ASSERTIONS` / `PROCESS_ASSERTIONS` and gain a branch in
   `assertion_result`. `tool_call` reuses `command_events` (`:2828`) and the `command_order`
   logic; `structured_output` extends `json_field_equals` with JSON-Schema validation.
-  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:5083`) renders
+  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:5162`) renders
   and still runs through `--judge-cmd`.
 - **Design:** a preset expands to either a deterministic objective assertion or a `judge`
   assertion with a canned rubric and threshold. No new execution path.
@@ -146,7 +146,7 @@ assumed.
 ### 1.3 Judge config slot and the "judge is not the model under test" guard
 - **Goal:** make an existing convention enforceable.
 - **Abstractions used or changed:** read an optional `judge` block in the manifest; add a check
-  in `audit_manifest_report` (`:9541`) comparing the declared judge model against `jetty.model`
+  in `audit_manifest_report` (`:9620`) comparing the declared judge model against `jetty.model`
   or the run metadata `model`.
 - **Design:** warn by default, error under `--strict-judge`.
 - **Testing:** unit tests for matching and differing model ids.
@@ -163,7 +163,7 @@ assumed.
 - **Status:** `docs/authoring-evals.md` shipped, alongside `architecture.md` and
   `abstractions.md`.
 - **Follow-on:** surface the guide's rules where they are checkable. Extend the messaging in
-  `prompt_assertion_leakage_findings` (`:365`) and `fixture_recommendations` (`:9283`) to point
+  `prompt_assertion_leakage_findings` (`:365`) and `fixture_recommendations` (`:9362`) to point
   at the relevant section.
 - **Testing:** assert the new hint strings appear for crafted manifests.
 
@@ -173,7 +173,7 @@ assumed.
   expected output, and a check that the output still matches. The harness has no equivalent of
   "this output equals this reference."
 - **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:69`), implemented in
-  `assertion_result` (`:4818`). It reads `output.md` (or a named artifact), applies an optional
+  `assertion_result` (`:4897`). It reads `output.md` (or a named artifact), applies an optional
   normalization (trim, collapse whitespace, or a named normalizer), and compares to a reference
   file under the manifest dir. Evidence is a unified diff on mismatch.
 - **Design:** normalization is the whole game, so it is explicit and per-assertion, never
@@ -188,9 +188,9 @@ assumed.
   not name it.
 - **Abstractions used or changed:** an optional `oracle` tier on an assertion
   (`strong` / `demo` / `live`), defaulting by type (deterministic text/process are `strong`,
-  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:7634`)
+  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:7713`)
   reports, per case, the share of its pass rate carried by `strong` oracles;
-  `audit_manifest_report` (`:9541`) warns when a case passes only on weak ones. This extends
+  `audit_manifest_report` (`:9620`) warns when a case passes only on weak ones. This extends
   leakage lint (`:164`) from prompts to oracles.
 - **Strongest tier — the rendered-artifact oracle:** the top of the ladder is an oracle that
   builds or renders the artifact and inspects the result, not the source text.
@@ -205,8 +205,8 @@ assumed.
   splits "good poster" into seven `script` oracles, but each is forced all-or-nothing by the
   exit-code-only contract: a poster with six of seven drama carriers fails `drama_oracle` exactly
   like one with zero. That is the binary-saturation problem inside a single oracle.
-- **Abstractions used or changed:** extend `run_script_assertion` (`:4715`) and
-  `assertion_result` (`:4818`) to optionally parse a score from the oracle's stdout — a JSON line
+- **Abstractions used or changed:** extend `run_script_assertion` (`:4794`) and
+  `assertion_result` (`:4897`) to optionally parse a score from the oracle's stdout — a JSON line
   such as `{"score": 6, "max_score": 7}` (normalized to 0-1) — beside the existing
   `pass_exit_code`. The parsed score flows into the `score`/`severity` channel from 2.2, so a
   script oracle becomes a graded dimension while staying fully deterministic and model-free.
@@ -223,9 +223,9 @@ assumed.
   past it — either way, question it. This is the inverse of the saturation flag: saturation marks
   a case as too easy *now*; staleness marks a case that has never discriminated *over time*.
 - **Abstractions used or changed:** reads the cross-run history from 2.6. A `prune` report (or a
-  flag in `build_benchmark_report` (`:7634`)) marks a case a removal candidate when, across the
+  flag in `build_benchmark_report` (`:7713`)) marks a case a removal candidate when, across the
   last N runs, it never failed and never showed lift (`with_skill` == `without_skill` every time).
-  `audit_manifest_report` (`:9541`) lists the candidates; removal stays a human decision.
+  `audit_manifest_report` (`:9620`) lists the candidates; removal stays a human decision.
 - **Design:** the harness suggests, never deletes. A case may be kept deliberately as a
   regression guard even when stale; the report says so rather than acting.
 - **Depends on:** 2.6 (needs run history to judge "never failed over time").
@@ -243,8 +243,8 @@ assumed.
   beside `variant` and `run_number`. Each row carries its target `model`, and `run_dir` gains a
   model segment (`<case>/<model>/<variant>/run-<n>`), kept backward-compatible when one model
   runs. Runners pass the row `model` through; per-run `model` already lands in `metadata.json`,
-  so grading needs no change. `build_benchmark_report` (`:7634`) groups `by_variant` within
-  `by_model`, and `build_paired_summary` (`:6759`) computes lift per (case, model).
+  so grading needs no change. `build_benchmark_report` (`:7713`) groups `by_variant` within
+  `by_model`, and `build_paired_summary` (`:6838`) computes lift per (case, model).
 - **Design:** model is a third axis, not a new variant. Variants stay orthogonal, giving a
   model-by-variant grid. CLI: `--models a,b,c` on `prepare`.
 - **Testing:** a fan-out test asserting row count equals cases × variants × runs × models with
@@ -261,7 +261,7 @@ assumed.
   no-regression floor. This spec ports those shapes into the harness rather than inventing new
   ones.
 - **Abstractions used or changed:**
-  - `assertion_result` (`:4818`) gains an optional `score` (0-1 or a normalized 1-5) and
+  - `assertion_result` (`:4897`) gains an optional `score` (0-1 or a normalized 1-5) and
     `severity` (`critical` / `gate` / `soft`), read from `critical`/`gate`/`soft`/`atLeast` on the
     assertion.
   - **`critical` (absorbing-barrier) tier — valley-dodging.** From the Jetty "valley-dodging"
@@ -276,13 +276,13 @@ assumed.
   - **Anchored `graded_dimensions`** as a `judge` assertion shape:
     `{name, scale: "1-5", rubric: "5 = …observable…; 1 = …observable…"}`. Anchors name what each
     score level looks like, so a judge scores against criteria, not a vibe. `judge_prompt`
-    (`:5083`) renders the dimensions; the result carries per-dimension scores in `evidence`.
+    (`:5162`) renders the dimensions; the result carries per-dimension scores in `evidence`.
   - **`dynamic_rubric`** as a second `judge` shape: `{instruction, minimum_criteria}`. The judge
     drafts 3-5 case-specific criteria before grading and must meet at least `minimum_criteria`.
-  - `grade_case_variant` (`:6127`) splits totals into critical, gated, and soft. A `critical`
+  - `grade_case_variant` (`:6206`) splits totals into critical, gated, and soft. A `critical`
     failure vetoes the case; a `gate` failure lowers the pass rate; a `soft` failure lowers
     neither and fills a `scored` bucket. A `--strict` flag promotes soft to gate.
-  - **Statistical lift** in `build_paired_summary` (`:6759`): alongside the raw delta, compute a
+  - **Statistical lift** in `build_paired_summary` (`:6838`): alongside the raw delta, compute a
     significance test over the per-case graded scores (paired bootstrap or sign-flip
     permutation, mirroring `score_delta.py`), so lift is tested, not eyeballed.
   - **Reference-anchor floor:** an optional `reference_score` / `reference_graded_score` on a
@@ -315,7 +315,7 @@ assumed.
 - **Goal:** deterministic re-runs that pay nothing for external dependencies, by recording tool
   inputs and outputs.
 - **Abstractions used or changed:** this lives in the runner, not core grading. Recording sits
-  beside `write_trace_artifacts` (`:3696`): a `tool-replay.json` keyed per tool, with
+  beside `write_trace_artifacts` (`:3775`): a `tool-replay.json` keyed per tool, with
   `sanitize` and `version`. Modes (`auto`, `record`, `off`, `strict`) come from an environment
   variable that `run_codex` and the Pi and subagent runners read.
 - **Design:** orthogonal to the disk re-grade the harness already does. Replay makes the agent
@@ -327,7 +327,7 @@ assumed.
 ### 2.4 OpenTelemetry GenAI normalization target
 - **Goal:** make the trace adapter boundary a standard rather than a bespoke schema.
 - **Abstractions used or changed:** `normalize_trace_record` (`:3442`) and
-  `normalize_trace_records` (`:3552`) keep their inputs but emit OTel GenAI semantic-key
+  `normalize_trace_records` (`:3557`) keep their inputs but emit OTel GenAI semantic-key
   attributes; the `events.json` schema version bumps. Process and efficiency assertions read the
   new keys with backward-compatible fallbacks.
 - **Design:** additive schema. An old `events.json` still grades.
@@ -351,7 +351,7 @@ assumed.
 - **Goal:** watch lift, saturation, and token drift over time.
 - **Abstractions used or changed:** a consumer of `build_benchmark_report`. Add an append-only
   history store and a `trend` subcommand that diffs successive `benchmark.json` files, reusing
-  the `compare_results` (`:8101`) logic.
+  the `compare_results` (`:8180`) logic.
 - **Severity-weighted ranking (from the macro-evals notebook):** when surfacing recurring
   failures across runs, rank them by `prevalence × severity`, not raw count, so a rare but severe
   failure outranks a common trivial one. This is the floor-raising principle made quantitative;
@@ -390,7 +390,7 @@ assumed.
 ### 2.8 Interactive served report and richer artifacts
 - **Goal:** capture feedback in the browser and render image, PDF, and xlsx artifacts, beyond the
   static `render_viewer`.
-- **Abstractions used or changed:** extend `render_viewer` (`:8808`) with a `serve` mode and
+- **Abstractions used or changed:** extend `render_viewer` (`:8887`) with a `serve` mode and
   artifact encoders. Anthropic's `eval-viewer/generate_review.py` is the blueprint, including
   `feedback.json` persistence and a `--previous-workspace` diff.
 - **Testing:** unit-test the artifact embedding and categorization and the feedback round trip;
@@ -435,7 +435,7 @@ assumed.
   the model axis, plus a viewer panel.
 - **Slice-lift concentration (from the macro-evals notebook):** compute, per slice, where lift (or
   a failure) concentrates — `slice share ÷ overall share`, the macro-eval `lift` metric one level
-  up from per-case lift. `build_slice_summary` (`:6894`) already groups by domain/difficulty/
+  up from per-case lift. `build_slice_summary` (`:6973`) already groups by domain/difficulty/
   trigger/goal, so this is a ratio over groups it already forms, not new plumbing.
 - **Testing:** a report test over a two-model by two-variant fixture grid, plus a concentration
   test asserting a failure confined to one slice scores a high ratio there.

--- a/run_pi_trigger_eval.py
+++ b/run_pi_trigger_eval.py
@@ -33,6 +33,7 @@ from skill_benchmark import (
     load_manifest_source,
     materialize_trigger_ablation,
     mount_skill_tree,
+    pi_stream_terminal_error,
     repo_root_for_manifest,
     run_argv_with_timeout,
     safe_trace_label,
@@ -86,6 +87,21 @@ def copy_skill_to_config(manifest_path: Path, manifest: dict[str, Any], config_d
     return mount_skill_tree(Path(tree), skills_dir), {"mode": "baseline", "skill_tree_hash": canonical_skill_tree_hash(repo_root, manifest)}
 
 
+def pi_terminal_error(raw_text: str) -> str | None:
+    """Compatibility name for the shared Pi stream terminal-error parser."""
+    return pi_stream_terminal_error(raw_text)
+
+
+def pi_invoke_result(run: dict[str, Any]) -> dict[str, Any]:
+    """Normalize Pi's process result into a trustworthy observation state."""
+    result = dict(run)
+    provider_error = pi_terminal_error(str(result.get("stdout") or ""))
+    if provider_error:
+        result["provider_error"] = provider_error
+        result["observation_complete"] = False
+    return result
+
+
 def pi_argv(query: str, model: str | None = None) -> list[str]:
     """THE Pi CLI invocation for trigger evals — isolated JSON-stream mode with
     read-only tools. The trigger matrix's Pi adapter uses this same argv, so the
@@ -125,13 +141,13 @@ def run_query(manifest_path: Path, query: str, should_trigger: bool, timeout: in
         copied, abl_prov = copy_skill_to_config(manifest_path, manifest, config_dir, ablation_id=ablation)
         env = os.environ.copy()
         env["PI_CODING_AGENT_DIR"] = str(config_dir)
-        run = run_argv_with_timeout(pi_argv(query, model), cwd=config_dir, env=env, timeout=timeout)
+        run = pi_invoke_result(run_argv_with_timeout(pi_argv(query, model), cwd=config_dir, env=env, timeout=timeout))
         stdout, stderr = run["stdout"], run["stderr"]
         returncode, timed_out, elapsed_ms = run["returncode"], run["timed_out"], run["elapsed_ms"]
         triggered, evidence = detect_trigger(stdout, copied)
         # Trigger runs now persist token/cost telemetry like the answer paths
         # (issue #21): parsed off the same Pi JSON stream the detector reads.
-        usage_normalized, cost_normalized = stream_usage_and_cost(stdout)
+        usage_normalized, cost_normalized = stream_usage_and_cost(stdout, source="pi")
         is_ablation = bool(ablation) and abl_prov is not None and abl_prov.get("mode") != "baseline"
         # The materialized ablation's provenance goes through Provenance (one
         # schema); the canonical (parent) tree hash is recorded on BOTH arms under
@@ -154,7 +170,7 @@ def run_query(manifest_path: Path, query: str, should_trigger: bool, timeout: in
             # autonomous-trigger outcome. The harness does not yet pair baseline vs
             # ablation here, so do not read a "pass" as a provenance-verified
             # causal ablation result (unlike the answer-population path).
-            "pass": returncode == 0 and triggered == should_trigger,
+            "pass": bool(run.get("observation_complete", returncode == 0 and not timed_out)) and triggered == should_trigger,
             "measurement": EvidenceClass.RAW_MEASUREMENT.value,
             "elapsed_ms": elapsed_ms,
             "observation_complete": bool(run.get("observation_complete", returncode == 0 and not timed_out)),
@@ -167,6 +183,8 @@ def run_query(manifest_path: Path, query: str, should_trigger: bool, timeout: in
             "skill_tree_hash": skill_tree_hash,
             "stderr": stderr[-1000:] if stderr else "",
         }
+        if isinstance(run.get("provider_error"), str):
+            result["provider_error"] = run["provider_error"]
         if trace_dir is not None:
             write_trigger_trace_artifacts(trace_dir, stdout, result)
         return result

--- a/run_trigger_matrix.py
+++ b/run_trigger_matrix.py
@@ -84,13 +84,14 @@ from skill_benchmark import (
     write_json,
     write_trace_artifacts,
 )
-from run_pi_trigger_eval import cases_from_manifest, eval_rows_from_args, load_manifest, pi_argv, skill_name_from_manifest, seed_config_dir, validate_trigger_rows
+from run_pi_trigger_eval import cases_from_manifest, eval_rows_from_args, load_manifest, pi_argv, pi_invoke_result, skill_name_from_manifest, seed_config_dir, validate_trigger_rows
 from ablation_model import TRIGGER_MEASUREMENT_EVIDENCE_CLASS, EvidenceClass, Provenance
 
 STOPWORDS = {"this", "that", "with", "have", "what", "your", "from", "each", "then", "them", "were", "will", "would", "should", "could", "please", "give", "tell"}
 DEFAULT_CODEX_CMD = "codex exec --json --sandbox read-only --skip-git-repo-check --ephemeral --ignore-user-config --ignore-rules"
 INVOKE_RESULT_KEYS = ("stdout", "stderr", "returncode", "timed_out", "elapsed_ms", "observation_complete")
 INVOKE_RESULT_METADATA_KEYS = (
+    "provider_error",
     "config_isolated", "config_isolation_warning",
     "codex_home_files_copied", "codex_home_outside_workdir",
     "vibe_env_file_copied", "vibe_home_outside_workdir",
@@ -397,7 +398,7 @@ class PiAdapter(AgentAdapter):
     def invoke(self, query: str, model: str | None, workspace: Path, timeout: int) -> dict[str, Any]:
         env = os.environ.copy()
         env["PI_CODING_AGENT_DIR"] = str(workspace / ".pi-config")
-        return self._run_argv(pi_argv(query, model), cwd=workspace, env=env, timeout=timeout)
+        return pi_invoke_result(self._run_argv(pi_argv(query, model), cwd=workspace, env=env, timeout=timeout))
 
 
 class VibeAdapter(AgentAdapter):
@@ -551,7 +552,7 @@ def run_cell_query(adapter: AgentAdapter, tree_dir: Path, query: str, should_tri
     redacted_stderr = redact_sensitive_text(str(result["stderr"] or ""), secrets)
     telemetry_error = None
     try:
-        usage, cost = stream_usage_and_cost(stdout)
+        usage, cost = stream_usage_and_cost(stdout, source=adapter.name)
     except Exception as exc:
         telemetry_error = f"{type(exc).__name__}: {exc}"
         usage, cost = {"source": "missing"}, {"source": "missing"}

--- a/scripts/smoke_supported_clis.py
+++ b/scripts/smoke_supported_clis.py
@@ -25,7 +25,8 @@ DEFAULT_MODELS = {
     "claude": os.environ.get("SMOKE_CLAUDE_MODEL", "haiku"),
     "codex": os.environ.get("SMOKE_CODEX_MODEL", "gpt-5.4-mini"),
     "vibe": os.environ.get("SMOKE_VIBE_MODEL", "devstral-small-latest"),
-    "pi": os.environ.get("SMOKE_PI_MODEL", "mistral/ministral-3b-latest"),
+    # The Pi default uses the authenticated Codex provider; override if unavailable.
+    "pi": os.environ.get("SMOKE_PI_MODEL", "openai-codex/gpt-5.4-mini"),
 }
 ANSWER_AGENTS = ("claude", "codex", "vibe")
 SMOKE_TRIGGER_EXPECTATIONS = (

--- a/skill_benchmark.py
+++ b/skill_benchmark.py
@@ -3447,7 +3447,10 @@ def normalize_trace_record(record: dict[str, Any], *, source: str, index: int, l
     command = stringify_trace_value(raw_trace_value(record, "command", "cmd", "args"))
     content = stringify_trace_value(raw_trace_value(record, "content", "text", "message"))
     status = str(raw_trace_value(record, "status", "state") or "completed")
-    event_type = "tool_call"
+    # Unknown session/lifecycle events are not tool calls. Defaulting them to
+    # tool_call inflated Pi's process telemetry even when its trace had no
+    # model tool use at all.
+    event_type = "event"
     name = stringify_trace_value(raw_trace_value(record, "tool", "tool_name", "name"))
     if "skill" in raw_type and ("load" in raw_type or "read" in raw_type):
         event_type = "skill_load"
@@ -3456,6 +3459,8 @@ def normalize_trace_record(record: dict[str, Any], *, source: str, index: int, l
     elif "command" in raw_type or "exec" in raw_type or command:
         event_type = "command"
         name = name or "bash"
+    elif "tool" in raw_type or raw_trace_value(record, "tool", "tool_name", "tool_call_id") is not None:
+        event_type = "tool_call"
     elif "file_write" in raw_type or "write" in raw_type or "edit" in raw_type:
         event_type = "file_write"
     elif "file_read" in raw_type or "read" in raw_type:
@@ -3554,26 +3559,37 @@ def normalize_trace_records(records: list[dict[str, Any]], *, source: str = "gen
     commands = [command_text(e) for e in command_events(events)]
     token_totals = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
     elapsed_ms = 0.0
-    for record, event in zip(records, events):
-        usage = raw_trace_value(record, "usage", "tokens")
-        if isinstance(usage, dict):
-            input_tokens = usage_number(usage, "input_tokens")
-            output_tokens = usage_number(usage, "output_tokens")
-            total_tokens = usage_number(usage, "total_tokens")
-            if total_tokens is None and input_tokens is not None and output_tokens is not None:
-                total_tokens = input_tokens + output_tokens
-            for key, value in [("input_tokens", input_tokens), ("output_tokens", output_tokens), ("total_tokens", total_tokens)]:
-                if isinstance(value, (int, float)):
-                    token_totals[key] += value
-        duration = _num(raw_trace_value(record, "duration_ms", "elapsed_ms"))
-        if duration is not None:
-            elapsed_ms += duration
-        tokens = event.get("tokens")
-        if isinstance(tokens, dict) and not isinstance(usage, dict):
-            for key in token_totals:
-                value = tokens.get(key)
-                if isinstance(value, (int, float)):
-                    token_totals[key] += value
+    is_pi = source.casefold() == "pi"
+    pi_error = _pi_terminal_error(records) if is_pi else None
+    pi_terminal_usage = _pi_terminal_usage(records) if is_pi and not pi_error else None
+    if pi_terminal_usage is not None:
+        # Pi repeats final cumulative usage on message_end, turn_end, and
+        # agent_end. It is one response, not several token deltas.
+        for key in token_totals:
+            value = usage_number(pi_terminal_usage, key)
+            if value is not None:
+                token_totals[key] = value
+    elif not pi_error:
+        for record, event in zip(records, events):
+            usage = raw_trace_value(record, "usage", "tokens")
+            if isinstance(usage, dict):
+                input_tokens = usage_number(usage, "input_tokens")
+                output_tokens = usage_number(usage, "output_tokens")
+                total_tokens = usage_number(usage, "total_tokens")
+                if total_tokens is None and input_tokens is not None and output_tokens is not None:
+                    total_tokens = input_tokens + output_tokens
+                for key, value in [("input_tokens", input_tokens), ("output_tokens", output_tokens), ("total_tokens", total_tokens)]:
+                    if isinstance(value, (int, float)):
+                        token_totals[key] += value
+            duration = _num(raw_trace_value(record, "duration_ms", "elapsed_ms"))
+            if duration is not None:
+                elapsed_ms += duration
+            tokens = event.get("tokens")
+            if isinstance(tokens, dict) and not isinstance(usage, dict):
+                for key in token_totals:
+                    value = tokens.get(key)
+                    if isinstance(value, (int, float)):
+                        token_totals[key] += value
     skill_events = [e for e in events if e.get("type") == "skill_load" or event_mentions_skill_file(e)]
     metrics: dict[str, Any] = {
         "schema_version": 2,
@@ -3607,6 +3623,59 @@ def normalize_trace_records(records: list[dict[str, Any]], *, source: str = "gen
         metrics["otel"] = otel_usage
     event_doc = {"schema_version": 2, "source": source, "events": events}
     return event_doc, metrics
+
+
+def _pi_terminal_error(records: list[dict[str, Any]]) -> str | None:
+    """Read Pi's terminal provider status from its retrying JSON stream."""
+    last_agent_end: dict[str, Any] | None = None
+    fallback: dict[str, Any] | None = None
+    for record in records:
+        event_type = str(record.get("type") or "")
+        if event_type == "agent_end":
+            last_agent_end = record
+        elif event_type == "turn_end":
+            fallback = record
+
+    def error_from(record: dict[str, Any] | None) -> str | None:
+        if not isinstance(record, dict):
+            return None
+        candidates: list[Any] = [record.get("message")]
+        messages = record.get("messages")
+        if isinstance(messages, list) and messages:
+            candidates.append(messages[-1])
+        for candidate in candidates:
+            if not isinstance(candidate, dict):
+                continue
+            error = candidate.get("errorMessage") or candidate.get("error")
+            if isinstance(error, str) and error.strip():
+                return error.strip()
+            if str(candidate.get("stopReason") or "").casefold() == "error":
+                return "Pi provider ended the turn with stopReason:error"
+        return None
+
+    return error_from(last_agent_end) or error_from(fallback)
+
+
+def pi_stream_terminal_error(raw_text: str) -> str | None:
+    """Public Pi JSON boundary: provider errors cannot become zero telemetry."""
+    records = [record for record in iter_json_objects(raw_text) if isinstance(record, dict)]
+    return _pi_terminal_error(records)
+
+
+def _pi_terminal_usage(records: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return Pi's one final cumulative usage block, if this is a Pi stream."""
+    for record in reversed(records):
+        event_type = str(record.get("type") or "")
+        if event_type not in {"agent_end", "turn_end", "message_end"}:
+            continue
+        candidates: list[Any] = [record.get("message")]
+        messages = record.get("messages")
+        if isinstance(messages, list) and messages:
+            candidates.append(messages[-1])
+        for message in candidates:
+            if isinstance(message, dict) and isinstance(message.get("usage"), dict):
+                return message["usage"]
+    return None
 
 
 def _stream_usage_doc(record: dict[str, Any]) -> dict[str, Any] | None:
@@ -3648,12 +3717,22 @@ def _cost_value_from_record(record: dict[str, Any]) -> Any:
     return None
 
 
-def stream_usage_and_cost(raw_text: str) -> tuple[dict[str, Any], dict[str, Any]]:
+def stream_usage_and_cost(raw_text: str, *, source: str | None = None) -> tuple[dict[str, Any], dict[str, Any]]:
     """usage_normalized/cost_normalized straight from a runner's raw JSONL
     stream (issue #21). Prefer final cumulative result/completion usage when a
     provider emits it; otherwise sum per-event usage deltas. Missing stays
-    marked."""
+    marked. Pi's terminal events receive their special cumulative semantics
+    only when the caller identifies the stream as Pi."""
     records = [obj for obj in iter_json_objects(raw_text) if isinstance(obj, dict)]
+    is_pi = str(source or "").casefold() == "pi"
+    if is_pi and _pi_terminal_error(records):
+        return {"source": "missing"}, {"source": "missing"}
+    pi_terminal_usage = _pi_terminal_usage(records) if is_pi else None
+    if pi_terminal_usage is not None:
+        return (
+            normalize_usage(pi_terminal_usage, source="trace_normalized"),
+            normalize_cost(pi_terminal_usage.get("cost"), source="trace_normalized"),
+        )
     cumulative_usage: list[dict[str, Any]] = []
     for record in records:
         if not _is_cumulative_usage_record(record):

--- a/tests/test_cost_telemetry.py
+++ b/tests/test_cost_telemetry.py
@@ -197,6 +197,38 @@ class RunnerStampTests(unittest.TestCase):
         self.assertEqual(empty_usage, {"source": "missing"})
         self.assertEqual(empty_cost, {"source": "missing"})
 
+    def test_pi_terminal_usage_is_not_counted_once_per_lifecycle_event(self):
+        usage = {"input": 10, "output": 3, "cacheRead": 2, "totalTokens": 15,
+                 "cost": {"total": 0.015}}
+        assistant = {"role": "assistant", "content": [{"type": "text", "text": "done"}], "usage": usage}
+        records = [
+            {"type": "session"}, {"type": "agent_start"},
+            {"type": "message_end", "message": assistant},
+            {"type": "turn_end", "message": assistant},
+            {"type": "agent_end", "messages": [assistant]},
+        ]
+        stream = "\n".join(json.dumps(record) for record in records)
+        normalized_usage, normalized_cost = sb.stream_usage_and_cost(stream, source="pi")
+        self.assertEqual(normalized_usage["total_tokens"], 15)
+        self.assertEqual(normalized_cost["total_cost"], 0.015)
+        _, metrics = sb.normalize_trace_records(records, source="pi")
+        self.assertEqual(metrics["total_tokens"], 15)
+        self.assertEqual(metrics["tool_calls"], 0)
+
+    def test_non_pi_lifecycle_records_keep_their_existing_delta_semantics(self):
+        usage = {"input": 10, "output": 3, "totalTokens": 15}
+        assistant = {"role": "assistant", "usage": usage}
+        records = [
+            {"type": "message_end", "message": assistant},
+            {"type": "turn_end", "message": assistant},
+            {"type": "agent_end", "messages": [assistant]},
+        ]
+        stream = "\n".join(json.dumps(record) for record in records)
+        normalized_usage, _ = sb.stream_usage_and_cost(stream, source="codex")
+        self.assertEqual(normalized_usage["total_tokens"], 30)
+        _, metrics = sb.normalize_trace_records(records, source="codex")
+        self.assertEqual(metrics["total_tokens"], 30)
+
     def test_stream_usage_and_cost_tolerates_non_finite_json_numbers(self):
         usage, cost = sb.stream_usage_and_cost('{"type":"result","usage":{"input_tokens":1e999},"total_cost_usd":NaN}')
         self.assertEqual(usage, {"source": "missing"})

--- a/tests/test_smoke_supported_clis.py
+++ b/tests/test_smoke_supported_clis.py
@@ -31,6 +31,9 @@ class SupportedCliSmokeTests(unittest.TestCase):
             self.assertEqual({case["id"] for case in triggers}, {"trig-pos-review-change", "trig-neg-unrelated-question"})
             self.assertTrue((manifest_path.parent.parent / "skills" / "demo" / "SKILL.md").exists())
 
+    def test_pi_default_uses_the_codex_provider(self):
+        self.assertEqual(smoke.DEFAULT_MODELS["pi"], "openai-codex/gpt-5.4-mini")
+
     def test_trigger_assessment_requires_the_exact_positive_and_negative_fixture_rows(self):
         with tempfile.TemporaryDirectory() as td:
             path = Path(td) / "pi-trigger.json"

--- a/tests/test_trigger_matrix.py
+++ b/tests/test_trigger_matrix.py
@@ -76,6 +76,52 @@ class TriggerRowBoundaryTests(unittest.TestCase):
         self.assertNotEqual(Path(seen["cwd"]).resolve(), ROOT.resolve())
 
 
+    def test_pi_json_provider_error_cannot_pass_a_negative_trigger(self):
+        provider_error = json.dumps({
+            "type": "agent_end", "willRetry": False,
+            "messages": [{"role": "assistant", "content": [], "stopReason": "error",
+                          "errorMessage": "Mistral API error (400): Invalid model",
+                          "usage": {"input": 7, "output": 2, "totalTokens": 9,
+                                    "cost": {"total": 0.009}}}],
+        })
+
+        def failed_provider(*args, **kwargs):
+            return {"stdout": provider_error + "\n", "stderr": "", "returncode": 0, "timed_out": False,
+                    "elapsed_ms": 1, "observation_complete": True}
+
+        with tempfile.TemporaryDirectory() as td, mock.patch.object(tr, "run_argv_with_timeout", side_effect=failed_provider):
+            trace_dir = Path(td) / "trace"
+            result = tr.run_query(DEMO_MANIFEST, "ordinary chat", False, 12, None, trace_dir=trace_dir)
+            artifacts = [
+                json.loads((trace_dir / name).read_text(encoding="utf-8"))
+                for name in ("metrics.json", "metadata.json")
+            ]
+        self.assertFalse(result["observation_complete"])
+        self.assertFalse(result["pass"])
+        self.assertEqual(result["usage_normalized"], {"source": "missing"})
+        self.assertEqual(result["cost_normalized"], {"source": "missing"})
+        self.assertIn("Invalid model", result["provider_error"])
+        for artifact in artifacts:
+            self.assertEqual(artifact["usage_normalized"], {"source": "missing"})
+            self.assertEqual(artifact["cost_normalized"], {"source": "missing"})
+            measurements = artifact["telemetry"]["measurements"]
+            self.assertEqual(measurements["total_tokens"]["availability"], "unavailable")
+            self.assertEqual(measurements["cost"]["availability"], "unavailable")
+
+    def test_pi_adapter_propagates_json_provider_error_as_incomplete(self):
+        provider_error = json.dumps({
+            "type": "agent_end", "willRetry": False,
+            "messages": [{"stopReason": "error", "errorMessage": "provider rejected model"}],
+        })
+        run = {"stdout": provider_error, "stderr": "", "returncode": 0, "timed_out": False,
+               "elapsed_ms": 1, "observation_complete": True}
+        with tempfile.TemporaryDirectory() as td, mock.patch.object(tm.PiAdapter, "_run_argv", staticmethod(lambda *args, **kwargs: run)):
+            workspace = Path(td) / "workspace"
+            workspace.mkdir()
+            result = tm.PiAdapter().invoke("ordinary chat", None, workspace, 12)
+        self.assertFalse(result["observation_complete"])
+        self.assertEqual(result["provider_error"], "provider rejected model")
+
     def test_pi_timeout_with_parseable_partial_trace_is_not_telemetry_complete(self):
         def timed_out(*args, **kwargs):
             return {"stdout": json.dumps({"type": "command", "command": "partial"}) + "\n",


### PR DESCRIPTION
## Summary
- fail closed when Pi emits terminal provider errors despite a zero process exit, preserving unavailable usage/cost in rows and trace artifacts
- read Pi terminal cumulative usage once and classify unrecognized lifecycle records as events, not tool calls
- use Pi's Codex provider as the smoke default and document its authentication requirement

## Validation
- `python -m pytest -q` — 713 passed, 5 skipped, 96 subtests passed
- `uv build` and wheel integrity check
- `python scripts/smoke_supported_clis.py --live --agents pi --timeout 90` — passed