### PR TITLE
Prevent incomplete evidence from becoming valid measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable public changes are listed here. Release tags are the source of truth
 
 ## Unreleased
 
+- Evidence boundaries: add a typed four-axis observation contract for process exit, provider response, trace, and committed artifact set. Full-run operation evidence exists only when process, provider response, and trace are independently complete; callers cannot overwrite derived evidence fields. New answer and Jetty run directories carry a digest inventory in `artifact-commit.json`, written last and verified when artifacts are read.
+- Fail-closed adapters: malformed zero-exit Claude envelopes and Vibe streams without a final assistant message remain diagnostics rather than candidate answers; actual subprocess return codes are preserved separately from provider-response failure. Failed Jetty trajectories cannot certify operation telemetry, and empty legacy `events.json` files no longer count as command evidence.
+- Judges and budgets: schema-invalid newly produced judge output fails in both report and strict modes; incomplete judge-panel cost is a partial known subtotal rather than complete spend; suite budget history is accepted only when v3 scalar totals, aggregate values, and coverage counts agree.
+
 ## v0.6.0 — 2026-07-10
 
 - Telemetry: keep successful provider completion separate from trace completeness. Provider-reported usage and cost remain available when a CLI returns no trace, while tool/command/file/error/retry/skill-invocation measurements stay unavailable instead of becoming false zeros. The live release smoke now checks this schema-v3 invariant.

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -443,13 +443,16 @@ Latest allowlisted Pi generation cost snapshot (`safe-suite-20260630-201448-pi`;
 
 ## 2026-07-10 — Evidence channels form a product, not a success ladder
 
-**Problem:** A successful subprocess was allowed to certify an absent trace. The same audit found the pattern elsewhere: malformed Claude bytes became an answer, Vibe tool events became an answer, failed Jetty events became complete operation telemetry, one observed judge cost became complete panel spend, and an empty events file became command coverage.
+**Problem:** A successful subprocess was allowed to certify an absent trace. The same audit found the pattern elsewhere: malformed Claude bytes became an answer, Vibe tool events became an answer, failed Jetty events became complete operation telemetry, one observed judge cost became complete panel spend, an empty events file became command coverage, and internally contradictory budget-history fields could establish an estimate.
 
-**Lesson:** Process exit, provider response, trace, and artifact durability are independent evidence channels. Success on one axis cannot upgrade another. A decision that needs several channels must derive its eligibility from their product.
+**Lesson:** Process exit, provider response, trace, artifact durability, and aggregate coverage are independent evidence channels. Success on one axis cannot upgrade another. A decision that needs several channels must derive its eligibility from their product.
 
 **Rule:**
-- Represent each channel explicitly as complete, incomplete, or unknown. Derive operation evidence only when process, provider response, and trace are all complete.
+- Represent process, provider-response, trace, and artifact-set state explicitly as complete, incomplete, or unknown. Derive operation evidence only when process, provider response, and trace are all complete.
 - Preserve actual process facts. A zero-exit protocol failure keeps return code zero and carries a separate failed provider-response state.
-- Reserve derived evidence keys so caller extras cannot overwrite them. Parse malformed provider output into diagnostics, never into an answer/verdict fallback.
-- Commit run artifacts with a last-written digest inventory. New readers require a valid commit marker before treating the artifact set as complete.
-- Test the full finite state product and the monotonicity rule: changing one axis to complete must not change another axis or make a multi-axis claim eligible by itself.
+- Treat legacy generic completion as provider-response evidence only. Without explicit process or trace facts, those channels stay unknown; compatibility is not permission to invent provenance.
+- Reserve derived evidence keys so caller extras cannot overwrite them. Parse malformed provider output into diagnostics, never into an answer/verdict fallback. A reporting mode may retain diagnostics, but it must not let a schema-invalid verdict pass.
+- Keep partial aggregates partial. One observed panel cost is a known subtotal, not the panel total; a cached scalar may establish a budget estimate only when its aggregate value, observed count, and coverage agree.
+- Build run artifacts in a staging directory, write the digest inventory last, and atomically replace the destination. Restore the prior committed run if installation fails; stale or mixed-generation files must never look like one durable observation.
+- Verify the producer-owned inventory when reading. Files added later by downstream grading do not retroactively invalidate the committed producer set, while legacy directories without a marker remain readable with artifact-set state unknown.
+- Test the full finite-state product and the monotonicity rule: changing one axis to complete must not change another axis or make a multi-axis claim eligible by itself. Add provider-shaped malformed-wire, tamper, stale-file, and fault-injected rollback cases—not only happy paths.

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -440,3 +440,16 @@ Latest allowlisted Pi generation cost snapshot (`safe-suite-20260630-201448-pi`;
 - Give manifest migration and telemetry migration different names and commands. Do not let a version-1 → version-2 manifest guide stand in for a package upgrade.
 - Make rollback restore whole artifacts rather than delete newly added fields. The old report must be reproducible from the same bytes it originally read.
 - Add the version-specific section to the single upgrade runbook before the release tag, then verify every install command against the published package before marking the release complete.
+
+## 2026-07-10 — Evidence channels form a product, not a success ladder
+
+**Problem:** A successful subprocess was allowed to certify an absent trace. The same audit found the pattern elsewhere: malformed Claude bytes became an answer, Vibe tool events became an answer, failed Jetty events became complete operation telemetry, one observed judge cost became complete panel spend, and an empty events file became command coverage.
+
+**Lesson:** Process exit, provider response, trace, and artifact durability are independent evidence channels. Success on one axis cannot upgrade another. A decision that needs several channels must derive its eligibility from their product.
+
+**Rule:**
+- Represent each channel explicitly as complete, incomplete, or unknown. Derive operation evidence only when process, provider response, and trace are all complete.
+- Preserve actual process facts. A zero-exit protocol failure keeps return code zero and carries a separate failed provider-response state.
+- Reserve derived evidence keys so caller extras cannot overwrite them. Parse malformed provider output into diagnostics, never into an answer/verdict fallback.
+- Commit run artifacts with a last-written digest inventory. New readers require a valid commit marker before treating the artifact set as complete.
+- Test the full finite state product and the monotonicity rule: changing one axis to complete must not change another axis or make a multi-axis claim eligible by itself.

--- a/README.md
+++ b/README.md
@@ -361,7 +361,14 @@ runs/<case_id>/<variant>/run-1/trace.jsonl       # raw runner event stream
 runs/<case_id>/<variant>/run-1/events.json       # normalized events used by process assertions
 runs/<case_id>/<variant>/run-1/metrics.json      # tokens, commands, tool calls, elapsed time, retries
 runs/<case_id>/<variant>/run-1/environment.json  # runner/model/sandbox details where available
+runs/<case_id>/<variant>/run-1/artifact-commit.json # required-file SHA-256 inventory, written last by current runners
 ```
+
+Current answer and Jetty writers record independent process, provider-response, trace,
+and artifact-set evidence. Tool/command/file/retry/skill measurements are available only
+when the first three channels are complete; readers derive artifact completeness by
+verifying `artifact-commit.json`. Legacy directories without a marker remain readable but
+cannot acquire committed-artifact provenance.
 
 `metadata.json` is optional, but include what your runner can capture:
 

--- a/TODO.md
+++ b/TODO.md
@@ -71,7 +71,7 @@ Jetty runbooks emit a standardized machine-readable `validation_report.json` per
 (`jettyio/jettyio-skills`, `skills/create-runbook/SKILL.md`). Rubric evaluation scores 3-7
 dimensions on a 1-5 scale; programmatic evaluation returns `PASS` / `PARTIAL` / `FAIL`. The
 items below map that report onto the harness judge-result row `{judge_task_id, passed, score,
-threshold, evidence}` (`load_judge_results:5316`, merged in `grade_case_variant:6467`).
+threshold, evidence}` (`load_judge_results:5519`, merged in `grade_case_variant:6686`).
 
 - [ ] Export qualitative judge tasks to Jetty workflows using `simple_judge` where useful.
       Carry `judge_task_id` (`case::variant::run-n::assertion`) into the Jetty task so the

--- a/ablation_model.py
+++ b/ablation_model.py
@@ -78,6 +78,10 @@ def execution_valid(metadata: dict[str, Any] | None, text: str | None) -> bool:
         return False
     if m.get("timed_out") or m.get("timeout"):
         return False
+    if m.get("provider_response_complete") is False:
+        return False
+    if m.get("artifact_contract_version") == 1 and m.get("artifact_set_complete") is not True:
+        return False
     return not (text or "").lstrip().startswith(RUNNER_FAILURE_MARKERS)
 
 
@@ -104,6 +108,7 @@ RUNNER_FAILURE_MARKER_BY_PROVIDER = {
 from runner_contracts import (
     AnswerOutcome, Completed, OutcomeContext, Provider, ProviderFailed, RunnerOutcome,
     SpawnFailed, TimedOut, outcome_context, outcome_with_context,
+    process_observation_complete, provider_response_complete,
 )
 
 

--- a/docs/abstractions.md
+++ b/docs/abstractions.md
@@ -139,10 +139,10 @@ editor. This boundary is the main extension seam in the codebase.
 ## Runner / adapter
 
 An **answer runner** consumes prepared task rows and produces the run-output contract. The repo
-ships Pi answer smoke (`examples/adewale-workspace/run_pi_smoke.py`), Codex (`run_codex:4678`), Claude (`run_claude:4796`, capturing real
+ships Pi answer smoke (`examples/adewale-workspace/run_pi_smoke.py`), Codex (`run_codex:4877`), Claude (`run_claude:4999`, capturing real
 per-run cost), Mistral Vibe (`run-agent --agent vibe`, using isolated `VIBE_HOME` outside the workdir), the in-process
-subagent runner (`run_subagent:6048`, which hosts record/replay tool I/O via `ToolReplayStore`),
-Jetty (`JettyClient:2247` and the export/run/import commands), and any runner that writes the
+subagent runner (`run_subagent:6267`, which hosts record/replay tool I/O via `ToolReplayStore`),
+Jetty (`JettyClient:2249` and the export/run/import commands), and any runner that writes the
 contract directly. Each answer runner registers a workspace builder so one cross-runner invariant
 proves its `without_skill` arm is skill-free (CF.2). Autonomous trigger runners are separate: they
 read trigger cases from the manifest directly, never consume answer task rows, and emit trigger
@@ -198,7 +198,7 @@ those pairs; missing/ineligible arms remain in `pairing` diagnostics and duplica
 `build_slice_summary` breaks results down
 by domain, difficulty, trigger type, and success goal. Case flags mark saturated, no-lift,
 flaky, and with-skill-failed cases. These flags, the leakage lint
-(`prompt_assertion_leakage_findings:390`), and the split discipline are the part of the tool
+(`prompt_assertion_leakage_findings:392`), and the split discipline are the part of the tool
 no surveyed eval framework copies.
 
 ## What changes when you extend the tool

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,6 +79,7 @@ the interior. Each external boundary has one parser and a closed value:
 ```text
 prepared row -> PreparedTaskDraft -> PreparedTask
 provider result -> Completed | TimedOut | SpawnFailed | ProviderFailed
+run evidence -> process × provider-response × trace × artifact-set state
 judge row -> Boolean | Scored | Dimension | Dynamic | Consensus verdict
 trace status -> Completed | InProgress | Failed | Unknown
 Jetty status -> Queued | Running | Succeeded | Failed | TimedOut | ProtocolInvalid
@@ -86,8 +87,12 @@ result arms -> ExperimentalPair | BlockedExperimentalPair
 ```
 
 Booleans such as execution success, verdict pass, Jetty success, and comparability are derived from
-those variants. When a persisted row is read back, its parser re-establishes the invariant rather
-than trusting fields that happened to serialize together. The detailed inventory and residual risks
+those variants. `ObservationEvidence` keeps process exit, provider response, trace, and artifact-set
+state independent (`complete | incomplete | unknown`); full-run operation evidence requires the
+first three to be complete. A zero-exit protocol failure therefore preserves return code zero while
+remaining unscorable, and a valid answer with no trace can carry provider usage/cost without
+claiming zero commands. When a persisted row is read back, its parser re-establishes the invariant
+rather than trusting fields that happened to serialize together. The detailed inventory and residual risks
 are in [`correctness-by-construction-audit.md`](correctness-by-construction-audit.md).
 
 ## The runner boundary
@@ -118,7 +123,7 @@ flowchart TB
     PI -.-> RAW
     CX -.-> RAW
     JT -.-> RAW
-    NORM --> CONTRACT[(Run-output contract\noutput.md + metadata\n+ events/metrics)]
+    NORM --> CONTRACT[(Run-output contract\noutput.md + metadata\n+ events/metrics\n+ artifact-commit.json)]
 
     CONTRACT --> GR[grade reads from disk]
 ```
@@ -127,8 +132,10 @@ Each runner emits its own event shape. `normalize_trace_records` collapses those
 one schema-versioned `events.json` and `metrics.json` so a process assertion like
 `command_order` reads the same fields no matter who produced the run. Lifecycle status is parsed
 into a closed event state first; only completed operations count as commands, tools, reads, writes,
-or skill invocation. When the evidence is missing or unknown, the assertion fails rather than
-guessing from the answer text.
+or skill invocation. Caller extras cannot overwrite the derived evidence fields. New runner and
+Jetty artifact sets write `artifact-commit.json` last with the required-file inventory and SHA-256
+digests; readers classify a missing or stale marker as an incomplete artifact set. When evidence is
+missing or unknown, the assertion fails rather than guessing from the answer text.
 
 ## How a judge defers
 

--- a/docs/correctness-by-construction-audit.md
+++ b/docs/correctness-by-construction-audit.md
@@ -76,10 +76,34 @@ Completed | TimedOut | SpawnFailed | ProviderFailed
 
 `OutcomeContext` owns the closed provider enum, recursively freezes JSON-shaped context, and
 validates finite non-negative elapsed time, usage, and cost. `Completed` requires a non-empty final
-answer; raw trace bytes are never promoted to candidate output. Timeout return code 124, spawn return code 127, normal completion return code 0,
-and provider failure are mutually exclusive. `write_runner_outcome` exhaustively adapts the union to
-artifacts; backends cannot repair or mutate status booleans while writing files. `RunnerOutcome`
-remains only as a strict compatibility factory that constructs one of the four variants.
+answer; raw trace bytes are never promoted to candidate output. Timeout return code 124 and spawn
+return code 127 remain reserved. `ProviderFailed` preserves the subprocess's actual exit code,
+including zero when the process succeeded but its provider envelope was malformed or lacked a final
+answer; provider-response failure is not encoded by inventing return code 1. `write_runner_outcome`
+exhaustively adapts the union to artifacts; backends cannot repair or mutate status booleans while
+writing files. `RunnerOutcome` remains only as a strict compatibility factory that constructs one
+of the four variants.
+
+## Orthogonal run evidence and artifact commit
+
+`telemetry.ObservationEvidence` is the product of four independent states:
+
+```text
+process × provider_response × trace × artifact_set
+where each state is complete | incomplete | unknown
+```
+
+Operation evidence is derived and complete only when process, provider response, and trace are all
+complete. Completing one axis never promotes another. `write_trace_artifacts` owns trace derivation
+and rejects caller extras that collide with any derived evidence field. Provider adapters may retain
+usage/cost from a valid provider envelope independently of trace availability.
+
+New answer-runner and Jetty directories declare artifact contract version 1 and write
+`artifact-commit.json` last. The marker lists the required files plus a SHA-256 inventory. Readers
+verify the marker and inventory before deriving `artifact_set_complete`; an interrupted write,
+missing or changed committed file, unsafe inventory path, or stale marker remains incomplete and
+unscorable. Later downstream artifacts such as `grading.json` do not alter the committed producer
+inventory.
 
 ## Imported judge verdicts
 
@@ -100,8 +124,8 @@ BooleanVerdict | ScoredVerdict | DimensionVerdict | DynamicVerdict | ConsensusVe
 - Stored result loading rejects missing, conflicting, and duplicate task IDs. Repetition/panel
   merging requires one task identity; panel models must be non-empty and unique. Consensus is
   serialized as its own verdict kind.
-- Provider output that violates semantic invariants is retained only as diagnostic raw payload; the
-  stored verdict is one valid failed boolean verdict.
+- Provider output that violates schema or semantic invariants is retained only as diagnostic raw
+  payload; both report and strict modes store one valid failed boolean verdict.
 
 ## Draft versus executable tasks
 

--- a/docs/eval-framework-roadmap-spec.md
+++ b/docs/eval-framework-roadmap-spec.md
@@ -17,7 +17,7 @@ One invariant governs every item: core grading stays local and deterministic and
 model, and the harness never picks a model for the user. Anything that needs a model lives
 behind an opt-in command or the external `--judge-cmd`. Two abstractions absorb most of the
 work, so the spec returns to them often: the assertion result shape in `assertion_result`
-(`skill_benchmark.py:5101`) and the fan-out in `prepared_task_rows` (`:769`).
+(`skill_benchmark.py:5304`) and the fan-out in `prepared_task_rows` (`:771`).
 
 ## Testing baseline
 
@@ -40,7 +40,7 @@ tests are where that claim is checked rather than trusted.
 
 The buckets below extend what the harness can measure. This floor decides whether the number it
 already prints can be believed. The harness reports one thing: lift, `with_skill` minus
-`without_skill` on the same case (`build_paired_summary` (`:7112`)). That number is believable only
+`without_skill` on the same case (`build_paired_summary` (`:7342`)). That number is believable only
 when three preconditions hold, each intended today, none enforced, and each restating a claim from
 `evals-are-not-tests.md`:
 
@@ -60,22 +60,22 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
   hiding the quantity the tool exists to measure.
 - **Abstractions used or changed:** none in the engine. Adds
   `tests/fixtures/detectors/<detector_id>/should-fire.*` and `should-pass.*` that exercise
-  `assertion_result` (`:5101`) directly. That function has no direct unit test today, and its
+  `assertion_result` (`:5304`) directly. That function has no direct unit test today, and its
   `contains_any`, `excludes_any`, and `not_regex` branches go unexercised even though their types
-  are declared in the assertion registries (`TEXT_ASSERTIONS:94`).
+  are declared in the assertion registries (`TEXT_ASSERTIONS:96`).
 - **Design:** one table-driven test loads every pair and asserts the detector fires on `should-fire`
   and stays silent on `should-pass`. A `should-pass` twin is mandatory: it enforces the
   false-positive bar `authoring-evals.md` already sets for skill authors ("check both presence and
   absence"). Each `should-pass` set includes a case where the baseline echoes the prompt, because a
   detector that passes on echoed prompt text is a false oracle; this ties the fixtures to leakage
-  lint (`prompt_assertion_leakage_findings` (`:390`)). Every detector bug then becomes a permanent
+  lint (`prompt_assertion_leakage_findings` (`:392`)). Every detector bug then becomes a permanent
   fixture pair, and `test_command_assertions_match_command_inputs_not_outputs` is the first.
 - **Why it is the keystone:** the fixture pair is also the registration contract. It is what lets a
   harvested or third-party detector be trusted on entry, so it gates the exapted detector library
   (TODO, end of 2026), and it raises the oracle-strength ladder (1.7) so that "strong" means
   fixture-verified, not only deterministic.
 - **Testing:** the fixtures are the test. A meta-test asserts every name in `OBJECTIVE_ASSERTIONS`
-  (`:122`) has a fixture pair, so a new detector cannot land unverified.
+  (`:124`) has a fixture pair, so a new detector cannot land unverified.
 
 ### CF.2 — One cross-runner baseline-isolation invariant
 - **Goal:** prove the baseline is skill-free by construction, so a measured lift is the skill's
@@ -101,7 +101,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 ### CF.4 — A guard that the core grade path calls no model and no network
 - **Goal:** make the governing invariant — "core grading stays local and deterministic and never
   calls a model" — executable rather than aspirational.
-- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:6467`).
+- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:6686`).
 - **Design:** patch `urllib` and `subprocess` to raise, then grade a fixture covering every
   objective family (text, process, efficiency) and assert it completes. The sanctioned exceptions —
   `script` oracles and `judge` plumbing — are excluded from this path by design and keep their own
@@ -111,7 +111,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 
 ### Boundary
 The set stops here deliberately. Report-level correctness — whether the saturation, no-lift, flaky,
-and negative-delta flags (`build_benchmark_report` (`:8035`)) are computed right — sits a layer
+and negative-delta flags (`build_benchmark_report` (`:8265`)) are computed right — sits a layer
 above the raw measurement, where the golden-report tests the buckets already plan (1.2, 2.6) cover
 it. CF.1–CF.4 are the floor underneath that work: once they pass, a printed lift carries a checked
 measurement, and every feature in the buckets builds on a number that has been verified rather than
@@ -125,9 +125,9 @@ assumed.
 - **Goal:** ship graders authors reach for often, so they stop hand-rolling rubrics.
 - **Abstractions used or changed:** `tool_call` and `structured_output` are deterministic, so
   they become new types in `TEXT_ASSERTIONS` / `PROCESS_ASSERTIONS` and gain a branch in
-  `assertion_result`. `tool_call` reuses `command_events` (`:2903`) and the `command_order`
+  `assertion_result`. `tool_call` reuses `command_events` (`:2938`) and the `command_order`
   logic; `structured_output` extends `json_field_equals` with JSON-Schema validation.
-  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:5383`) renders
+  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:5586`) renders
   and still runs through `--judge-cmd`.
 - **Design:** a preset expands to either a deterministic objective assertion or a `judge`
   assertion with a canned rubric and threshold. No new execution path.
@@ -146,7 +146,7 @@ assumed.
 ### 1.3 Judge config slot and the "judge is not the model under test" guard
 - **Goal:** make an existing convention enforceable.
 - **Abstractions used or changed:** read an optional `judge` block in the manifest; add a check
-  in `audit_manifest_report` (`:9965`) comparing the declared judge model against `jetty.model`
+  in `audit_manifest_report` (`:10195`) comparing the declared judge model against `jetty.model`
   or the run metadata `model`.
 - **Design:** warn by default, error under `--strict-judge`.
 - **Testing:** unit tests for matching and differing model ids.
@@ -163,7 +163,7 @@ assumed.
 - **Status:** `docs/authoring-evals.md` shipped, alongside `architecture.md` and
   `abstractions.md`.
 - **Follow-on:** surface the guide's rules where they are checkable. Extend the messaging in
-  `prompt_assertion_leakage_findings` (`:390`) and `fixture_recommendations` (`:9691`) to point
+  `prompt_assertion_leakage_findings` (`:392`) and `fixture_recommendations` (`:9921`) to point
   at the relevant section.
 - **Testing:** assert the new hint strings appear for crafted manifests.
 
@@ -172,8 +172,8 @@ assumed.
   In `adewale/pythonbyexample` and `adewale/xampler` an example *is* an eval case: an input, an
   expected output, and a check that the output still matches. The harness has no equivalent of
   "this output equals this reference."
-- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:94`), implemented in
-  `assertion_result` (`:5101`). It reads `output.md` (or a named artifact), applies an optional
+- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:96`), implemented in
+  `assertion_result` (`:5304`). It reads `output.md` (or a named artifact), applies an optional
   normalization (trim, collapse whitespace, or a named normalizer), and compares to a reference
   file under the manifest dir. Evidence is a unified diff on mismatch.
 - **Design:** normalization is the whole game, so it is explicit and per-assertion, never
@@ -188,9 +188,9 @@ assumed.
   not name it.
 - **Abstractions used or changed:** an optional `oracle` tier on an assertion
   (`strong` / `demo` / `live`), defaulting by type (deterministic text/process are `strong`,
-  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:8035`)
+  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:8265`)
   reports, per case, the share of its pass rate carried by `strong` oracles;
-  `audit_manifest_report` (`:9965`) warns when a case passes only on weak ones. This extends
+  `audit_manifest_report` (`:10195`) warns when a case passes only on weak ones. This extends
   leakage lint (`:164`) from prompts to oracles.
 - **Strongest tier — the rendered-artifact oracle:** the top of the ladder is an oracle that
   builds or renders the artifact and inspects the result, not the source text.
@@ -205,8 +205,8 @@ assumed.
   splits "good poster" into seven `script` oracles, but each is forced all-or-nothing by the
   exit-code-only contract: a poster with six of seven drama carriers fails `drama_oracle` exactly
   like one with zero. That is the binary-saturation problem inside a single oracle.
-- **Abstractions used or changed:** extend `run_script_assertion` (`:4998`) and
-  `assertion_result` (`:5101`) to optionally parse a score from the oracle's stdout — a JSON line
+- **Abstractions used or changed:** extend `run_script_assertion` (`:5201`) and
+  `assertion_result` (`:5304`) to optionally parse a score from the oracle's stdout — a JSON line
   such as `{"score": 6, "max_score": 7}` (normalized to 0-1) — beside the existing
   `pass_exit_code`. The parsed score flows into the `score`/`severity` channel from 2.2, so a
   script oracle becomes a graded dimension while staying fully deterministic and model-free.
@@ -223,9 +223,9 @@ assumed.
   past it — either way, question it. This is the inverse of the saturation flag: saturation marks
   a case as too easy *now*; staleness marks a case that has never discriminated *over time*.
 - **Abstractions used or changed:** reads the cross-run history from 2.6. A `prune` report (or a
-  flag in `build_benchmark_report` (`:8035`)) marks a case a removal candidate when, across the
+  flag in `build_benchmark_report` (`:8265`)) marks a case a removal candidate when, across the
   last N runs, it never failed and never showed lift (`with_skill` == `without_skill` every time).
-  `audit_manifest_report` (`:9965`) lists the candidates; removal stays a human decision.
+  `audit_manifest_report` (`:10195`) lists the candidates; removal stays a human decision.
 - **Design:** the harness suggests, never deletes. A case may be kept deliberately as a
   regression guard even when stale; the report says so rather than acting.
 - **Depends on:** 2.6 (needs run history to judge "never failed over time").
@@ -239,12 +239,12 @@ assumed.
 ### 2.1 Multi-model fan-out (priority)
 - **Goal:** run the same cases across several models and compare lift per model. No surveyed
   framework does this; vitest-evals, eve, and viteval all push it onto the test runner.
-- **Abstractions used or changed:** `prepared_task_rows` (`:769`) gains a `model` dimension
+- **Abstractions used or changed:** `prepared_task_rows` (`:771`) gains a `model` dimension
   beside `variant` and `run_number`. Each row carries its target `model`, and `run_dir` gains a
   model segment (`<case>/<model>/<variant>/run-<n>`), kept backward-compatible when one model
   runs. Runners pass the row `model` through; per-run `model` already lands in `metadata.json`,
-  so grading needs no change. `build_benchmark_report` (`:8035`) groups `by_variant` within
-  `by_model`, and `build_paired_summary` (`:7112`) computes lift per (case, model).
+  so grading needs no change. `build_benchmark_report` (`:8265`) groups `by_variant` within
+  `by_model`, and `build_paired_summary` (`:7342`) computes lift per (case, model).
 - **Design:** model is a third axis, not a new variant. Variants stay orthogonal, giving a
   model-by-variant grid. CLI: `--models a,b,c` on `prepare`.
 - **Testing:** a fan-out test asserting row count equals cases × variants × runs × models with
@@ -261,7 +261,7 @@ assumed.
   no-regression floor. This spec ports those shapes into the harness rather than inventing new
   ones.
 - **Abstractions used or changed:**
-  - `assertion_result` (`:5101`) gains an optional `score` (0-1 or a normalized 1-5) and
+  - `assertion_result` (`:5304`) gains an optional `score` (0-1 or a normalized 1-5) and
     `severity` (`critical` / `gate` / `soft`), read from `critical`/`gate`/`soft`/`atLeast` on the
     assertion.
   - **`critical` (absorbing-barrier) tier — valley-dodging.** From the Jetty "valley-dodging"
@@ -276,13 +276,13 @@ assumed.
   - **Anchored `graded_dimensions`** as a `judge` assertion shape:
     `{name, scale: "1-5", rubric: "5 = …observable…; 1 = …observable…"}`. Anchors name what each
     score level looks like, so a judge scores against criteria, not a vibe. `judge_prompt`
-    (`:5383`) renders the dimensions; the result carries per-dimension scores in `evidence`.
+    (`:5586`) renders the dimensions; the result carries per-dimension scores in `evidence`.
   - **`dynamic_rubric`** as a second `judge` shape: `{instruction, minimum_criteria}`. The judge
     drafts 3-5 case-specific criteria before grading and must meet at least `minimum_criteria`.
-  - `grade_case_variant` (`:6467`) splits totals into critical, gated, and soft. A `critical`
+  - `grade_case_variant` (`:6686`) splits totals into critical, gated, and soft. A `critical`
     failure vetoes the case; a `gate` failure lowers the pass rate; a `soft` failure lowers
     neither and fills a `scored` bucket. A `--strict` flag promotes soft to gate.
-  - **Statistical lift** in `build_paired_summary` (`:7112`): alongside the raw delta, compute a
+  - **Statistical lift** in `build_paired_summary` (`:7342`): alongside the raw delta, compute a
     significance test over the per-case graded scores (paired bootstrap or sign-flip
     permutation, mirroring `score_delta.py`), so lift is tested, not eyeballed.
   - **Reference-anchor floor:** an optional `reference_score` / `reference_graded_score` on a
@@ -315,7 +315,7 @@ assumed.
 - **Goal:** deterministic re-runs that pay nothing for external dependencies, by recording tool
   inputs and outputs.
 - **Abstractions used or changed:** this lives in the runner, not core grading. Recording sits
-  beside `write_trace_artifacts` (`:3929`): a `tool-replay.json` keyed per tool, with
+  beside `write_trace_artifacts` (`:3970`): a `tool-replay.json` keyed per tool, with
   `sanitize` and `version`. Modes (`auto`, `record`, `off`, `strict`) come from an environment
   variable that `run_codex` and the Pi and subagent runners read.
 - **Design:** orthogonal to the disk re-grade the harness already does. Replay makes the agent
@@ -326,8 +326,8 @@ assumed.
 
 ### 2.4 OpenTelemetry GenAI normalization target
 - **Goal:** make the trace adapter boundary a standard rather than a bespoke schema.
-- **Abstractions used or changed:** `normalize_trace_record` (`:3536`) and
-  `normalize_trace_records` (`:3658`) keep their inputs but emit OTel GenAI semantic-key
+- **Abstractions used or changed:** `normalize_trace_record` (`:3577`) and
+  `normalize_trace_records` (`:3699`) keep their inputs but emit OTel GenAI semantic-key
   attributes; the `events.json` schema version bumps. Process and efficiency assertions read the
   new keys with backward-compatible fallbacks.
 - **Design:** additive schema. An old `events.json` still grades.
@@ -337,7 +337,7 @@ assumed.
 ### 2.5 Dataset abstraction
 - **Goal:** fan one case template over many rows instead of hand-authoring each case.
 - **Abstractions used or changed:** a new optional manifest construct (`datasets`, plus a case
-  `template` referencing a dataset id). `iter_cases` (`:287`) materializes template by row into
+  `template` referencing a dataset id). `iter_cases` (`:289`) materializes template by row into
   concrete cases before fan-out; `validate_manifest` validates rows and runs leakage lint per
   materialized case.
 - **Design:** materialization happens early, so prepare, grade, and report stay unchanged.
@@ -351,7 +351,7 @@ assumed.
 - **Goal:** watch lift, saturation, and token drift over time.
 - **Abstractions used or changed:** a consumer of `build_benchmark_report`. Add an append-only
   history store and a `trend` subcommand that diffs successive `benchmark.json` files, reusing
-  the `compare_results` (`:8504`) logic.
+  the `compare_results` (`:8734`) logic.
 - **Severity-weighted ranking (from the macro-evals notebook):** when surfacing recurring
   failures across runs, rank them by `prevalence × severity`, not raw count, so a rare but severe
   failure outranks a common trivial one. This is the floor-raising principle made quantitative;
@@ -377,8 +377,8 @@ assumed.
   it dispatches a subagent with a rubric whose "criteria [are] deliberately absent from
   generation rules."
 - **Abstractions used or changed:** mostly a discipline made first-class, not new machinery.
-  `prepared_task_rows` (`:769`) already omits `review_rubric` from generation payloads unless
-  `--include-answer-key`; extend `validate_manifest` (`:548`) to require that a `holdout`/
+  `prepared_task_rows` (`:771`) already omits `review_rubric` from generation payloads unless
+  `--include-answer-key`; extend `validate_manifest` (`:550`) to require that a `holdout`/
   `holdback` case's rubric stays out of the skill and public eval text, and pair it with the
   subagent judge from 2.7 and the graded scoring from 2.2. Track which rubrics were held out so
   the report can separate held-out scores from tune-visible ones.
@@ -390,7 +390,7 @@ assumed.
 ### 2.8 Interactive served report and richer artifacts
 - **Goal:** capture feedback in the browser and render image, PDF, and xlsx artifacts, beyond the
   static `render_viewer`.
-- **Abstractions used or changed:** extend `render_viewer` (`:9211`) with a `serve` mode and
+- **Abstractions used or changed:** extend `render_viewer` (`:9441`) with a `serve` mode and
   artifact encoders. Anthropic's `eval-viewer/generate_review.py` is the blueprint, including
   `feedback.json` persistence and a `--previous-workspace` diff.
 - **Testing:** unit-test the artifact embedding and categorization and the feedback round trip;
@@ -422,7 +422,7 @@ assumed.
 - **Goal:** evaluate conversational skills across a send/respond sequence.
 - **Abstractions changed (core contract):** a case gains an optional `turns` list. The
   run-output contract grows from one `output.md` to a turn-indexed transcript, so
-  `read_output_base` (`:2802`) and `discover_run_bases` learn the turn layout; runners drive the
+  `read_output_base` (`:2817`) and `discover_run_bases` learn the turn layout; runners drive the
   sequence; `grade_case_variant` grades per turn and aggregates.
 - **Design:** single-shot stays the default, so existing manifests are untouched.
 - **Testing:** a fixture multi-turn run asserting per-turn grading and aggregate, plus a
@@ -435,7 +435,7 @@ assumed.
   the model axis, plus a viewer panel.
 - **Slice-lift concentration (from the macro-evals notebook):** compute, per slice, where lift (or
   a failure) concentrates — `slice share ÷ overall share`, the macro-eval `lift` metric one level
-  up from per-case lift. `build_slice_summary` (`:7245`) already groups by domain/difficulty/
+  up from per-case lift. `build_slice_summary` (`:7475`) already groups by domain/difficulty/
   trigger/goal, so this is a ratio over groups it already forms, not new plumbing.
 - **Testing:** a report test over a two-model by two-variant fixture grid, plus a concentration
   test asserting a failure confined to one slice scores a high ratio there.
@@ -548,7 +548,7 @@ and upgrading to the new features should be something an agent can drive.
 
 ### Abstractions used or changed
 
-- `version` on the manifest (`validate_manifest:548`) becomes meaningful: `validate` accepts both
+- `version` on the manifest (`validate_manifest:550`) becomes meaningful: `validate` accepts both
   1 and 2, and warns (not errors) on a `version: 1` manifest once 2.2 has landed, pointing at
   `migrate`.
 - No grading abstraction changes for migration itself; it is a source-rewrite plus a guide.

--- a/docs/skill-ablation-spec.md
+++ b/docs/skill-ablation-spec.md
@@ -362,7 +362,7 @@ Opt in with `"invalid_skill": true` on the ablation: the run is tagged
 
 ## Validation additions
 
-`validate_manifest` (`skill_benchmark.py:548`), per ablation:
+`validate_manifest` (`skill_benchmark.py:550`), per ablation:
 
 - `id` unique and slug-formatted; keep `removed_component`.
 - If a removal is declared: exactly one of `mechanism`+`target` or `components`;

--- a/docs/telemetry-availability-and-comparability-spec.md
+++ b/docs/telemetry-availability-and-comparability-spec.md
@@ -67,7 +67,17 @@ Aggregate[T] =
 Comparison[T] =
     Comparable(value, basis)
   | Blocked(reason, left_state, right_state)
+
+ObservationEvidence =
+    process(complete | incomplete | unknown)
+  × provider_response(complete | incomplete | unknown)
+  × trace(complete | incomplete | unknown)
+  × artifact_set(complete | incomplete | unknown)
 ```
+
+`operation_evidence_complete` is derived only when process, provider response, and trace are all
+complete. The artifact-set axis is committed separately by a last-written digest inventory. No
+channel can promote another channel.
 
 ### Measurement rules
 
@@ -85,8 +95,13 @@ Comparison[T] =
   called `cost_usd`.
 - Token/count values and milliseconds are non-negative integers. Rates are finite and
   within `[0, 1]` when available.
-- A count or boolean derived from a trace is available only when the observation is
-  complete. A completed trace with zero tool calls is different from no trace.
+- A count or boolean derived from a trace is available only when process, provider
+  response, and trace are independently complete. A completed trace with zero tool
+  calls is different from no trace, and a parseable partial trace from a failed
+  provider response cannot support a complete-run negative assertion.
+- New runner/Jetty artifact sets are available only when `artifact-commit.json`
+  verifies every required file and digest. File existence proves artifact presence,
+  not committed evidence.
 
 ### Basis and population
 
@@ -295,8 +310,11 @@ The implementation is maintained against these invariants:
 6. every ratio carries eligible/blocked counts and stable blocked reasons;
 7. unknown/incompatible values cannot affect rankings, audits, trends, or budget passes
    as if they were zero;
-8. legacy artifacts remain readable without acquiring false provenance; and
-9. property, fixture-contract, CLI E2E, doc-sync, and targeted mutation gates pass.
+8. legacy artifacts remain readable without acquiring false provenance;
+9. process, provider-response, trace, and artifact-set states remain independent, and
+   caller extras cannot override their derived fields;
+10. new run directories are complete only with a valid artifact commit inventory; and
+11. property, fixture-contract, CLI E2E, doc-sync, and targeted mutation gates pass.
 
 ## Follow-on: cross-lab CLI wrappers
 

--- a/docs/trace-aware-eval-spec.md
+++ b/docs/trace-aware-eval-spec.md
@@ -336,8 +336,8 @@ Dataset/oracle audit work should continue as warnings and report hygiene before 
 ## Structured judge results
 
 The harness keeps the judge-command model: it exports prompts and reads user-supplied model output.
-Canonical boolean/scored/dimension/dynamic verdict schemas are validated locally; strict mode turns
-schema errors into failed verdicts:
+Canonical boolean/scored/dimension/dynamic verdict schemas are validated locally. Schema-invalid
+new judge output fails closed in both report and strict modes; report mode retains the diagnostics:
 
 ```json
 {
@@ -405,7 +405,7 @@ This adopts the SkillsBench lesson that focused 2–3-module skills often outper
 
 - [x] Add viewer panels and richer artifacts, plus human feedback export (`render-viewer --serve` with `feedback.json` capture, image/pdf/xlsx artifact embedding, and a `--previous-workspace` iteration diff).
 - [x] Add blind pairwise comparison (`compare-tasks` / `compare-results`, keyed by stable IDs with model-facing blinding).
-- [x] Add optional JSON Schema validation for judge-result files (`verdict_schema_for` post-hoc validation; `--strict-judge-schema` / manifest `judge.schema_enforcement` makes it a gate).
+- [x] Add JSON Schema validation for newly produced judge results (`verdict_schema_for` post-hoc validation always fails malformed evidence closed; `--strict-judge-schema` / manifest `judge.schema_enforcement` controls strict diagnostics/handling compatibility).
 
 ### Phase 5 — broader runner import
 

--- a/runner_contracts.py
+++ b/runner_contracts.py
@@ -27,6 +27,14 @@ def _finite_nonnegative(value: Any, label: str, *, integer: bool = False) -> int
     return value
 
 
+_RESERVED_EVIDENCE_KEYS = frozenset({
+    "observation_complete", "process_observation_complete",
+    "provider_response_complete", "trace_observation_complete",
+    "operation_observation_complete", "artifact_set_complete",
+    "observation_evidence", "telemetry", "telemetry_schema_version",
+})
+
+
 class FrozenDict(dict):
     """JSON-serializable recursively immutable mapping."""
     def _immutable(self, *args: Any, **kwargs: Any) -> None:
@@ -95,6 +103,11 @@ class OutcomeContext:
                 raise TypeError("usage must be a mapping or None")
             _validate_usage(self.usage, "usage")
             object.__setattr__(self, "usage", _freeze_mapping(self.usage, "usage"))
+        for label, values in (("metadata_extra", self.metadata_extra),
+                              ("metrics_extra", self.metrics_extra)):
+            collisions = _RESERVED_EVIDENCE_KEYS & set(values)
+            if collisions:
+                raise ValueError(f"{label} cannot override derived evidence: {', '.join(sorted(collisions))}")
         object.__setattr__(self, "metadata_extra", _freeze_mapping(self.metadata_extra, "metadata_extra"))
         object.__setattr__(self, "metrics_extra", _freeze_mapping(self.metrics_extra, "metrics_extra"))
         if self.environment is not None:
@@ -171,10 +184,12 @@ class ProviderFailed:
     def __post_init__(self) -> None:
         if not isinstance(self.context, OutcomeContext):
             raise TypeError("ProviderFailed context must be OutcomeContext")
-        if isinstance(self.returncode, bool) or not isinstance(self.returncode, int) or self.returncode in {0, 124, 127}:
-            raise ValueError("ProviderFailed requires a non-zero non-timeout spawned returncode")
+        if isinstance(self.returncode, bool) or not isinstance(self.returncode, int) or self.returncode in {124, 127}:
+            raise ValueError("ProviderFailed requires an actual exited-process returncode")
         if self.reason is not None and (not isinstance(self.reason, str) or not self.reason.strip()):
             raise ValueError("provider failure reason must be non-empty or None")
+        if self.returncode == 0 and self.reason is None:
+            raise ValueError("zero-exit provider failure requires a protocol reason")
         if not isinstance(self.answer, str):
             raise TypeError("provider failure answer must be a string")
 
@@ -184,6 +199,16 @@ AnswerOutcome: TypeAlias = Completed | TimedOut | SpawnFailed | ProviderFailed
 
 def outcome_context(outcome: AnswerOutcome) -> OutcomeContext:
     return outcome.context
+
+
+def process_observation_complete(outcome: AnswerOutcome) -> bool:
+    """Whether the subprocess reached an actual exit (success or failure)."""
+    return isinstance(outcome, (Completed, ProviderFailed))
+
+
+def provider_response_complete(outcome: AnswerOutcome) -> bool:
+    """Whether a validated final provider answer exists."""
+    return isinstance(outcome, Completed)
 
 
 def outcome_with_context(outcome: AnswerOutcome, context: OutcomeContext) -> AnswerOutcome:
@@ -219,9 +244,9 @@ def RunnerOutcome(*, provider: str, answer: str | None = None,
     if code == 127:
         return SpawnFailed(context, reason=error or stderr or "process spawn failed")
     if code != 0 or error:
-        return ProviderFailed(context, returncode=code if code != 0 else 1, reason=error, answer=answer or "")
+        return ProviderFailed(context, returncode=code, reason=error, answer=answer or "")
     if not answer:
-        return ProviderFailed(context, returncode=1, reason="provider produced no final answer")
+        return ProviderFailed(context, returncode=0, reason="provider produced no final answer")
     return Completed(context, answer=answer)
 
 

--- a/scripts/smoke_supported_clis.py
+++ b/scripts/smoke_supported_clis.py
@@ -26,6 +26,7 @@ if str(ROOT) not in sys.path:
 from agent_capabilities import SMOKE_TARGETS  # noqa: E402
 from skill_benchmark import invoke_argv_with_timeout  # noqa: E402
 from trigger_contracts import TriggerObservation  # noqa: E402
+from telemetry import ObservationEvidence  # noqa: E402
 
 DEFAULT_MODELS = {name: target.resolved_model(os.environ) for name, target in SMOKE_TARGETS.items()}
 ANSWER_AGENTS = tuple(name for name, target in SMOKE_TARGETS.items() if target.population == "answer")
@@ -114,10 +115,16 @@ def assess_answer_benchmark(path: Path, agent: str, report: dict[str, Any]) -> b
                     and isinstance(measurements, Mapping)):
                 telemetry_ok = False
                 break
-            trace_complete = metadata.get("trace_observation_complete") is True
-            expected = "available" if trace_complete else "unavailable"
-            if any(not isinstance(measurements.get(key), Mapping)
-                   or measurements[key].get("availability") != expected for key in trace_keys):
+            try:
+                evidence = ObservationEvidence.from_dict(envelope.get("observation_evidence"))
+            except (TypeError, ValueError):
+                telemetry_ok = False
+                break
+            expected = "available" if evidence.operation_complete else "unavailable"
+            if (not evidence.artifact_complete
+                    or any(not isinstance(measurements.get(key), Mapping)
+                           or measurements[key].get("availability") != expected
+                           for key in trace_keys)):
                 telemetry_ok = False
                 break
         report["checks"].append({"label": f"{agent}:artifact-contract", "passed": executions_ok,

--- a/skill_benchmark.py
+++ b/skill_benchmark.py
@@ -81,6 +81,8 @@ from ablation_model import (
     TimedOut,
     outcome_context,
     outcome_with_context,
+    process_observation_complete,
+    provider_response_complete,
     TIMEOUT_FAILURE,
     TreeIdentity,
     causal_confirmation,
@@ -2566,6 +2568,9 @@ def normalized_jetty_metadata(record: dict[str, Any], *, success: bool) -> dict[
         "errors_encountered": 0 if success else 1,
         "returncode": 0 if success else 1,
         "timed_out": observation.timed_out,
+        "observation_complete": success,
+        "process_observation_complete": not observation.timed_out,
+        "provider_response_complete": success,
         "jetty_lifecycle": observation.lifecycle.kind,
         **({"jetty_protocol_error": observation.lifecycle.reason}
            if isinstance(observation.lifecycle, ProtocolInvalid) else {}),
@@ -2625,7 +2630,11 @@ def import_jetty_results(args: argparse.Namespace) -> int:
             die("invalid Jetty result: successful trajectory requires non-blank trajectory_id")
         validated_records.append((record, harness, base))
     for record, harness, base in validated_records:
-        base.mkdir(parents=True, exist_ok=True)
+        destination = base
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        base = Path(tempfile.mkdtemp(prefix=f".{destination.name}.artifact-stage-",
+                                     dir=destination.parent))
+        (base / ARTIFACT_COMMIT_NAME).unlink(missing_ok=True)
         write_json(base / "jetty_raw.json", record)
         artifacts = record.get("artifacts") or []
         if not artifacts and isinstance(record.get("trajectory"), dict):
@@ -2647,6 +2656,7 @@ def import_jetty_results(args: argparse.Namespace) -> int:
             "run_number": harness.get("run_number", 1),
             "variant": harness.get("variant"),
             "billing_scope": "run",
+            "artifact_contract_version": ARTIFACT_CONTRACT_VERSION,
         })
         # Persist the harness-only ablation provenance into the run metadata so the
         # benchmark report can VERIFY (mode/population/skill_hash/components) that a
@@ -2664,7 +2674,12 @@ def import_jetty_results(args: argparse.Namespace) -> int:
             metadata=meta,
             environment={"runner": "jetty", "jetty": record.get("jetty", {}), "trajectory_id": record.get("trajectory_id")},
             write_metadata=True,
+            process_observation_complete=not observation.timed_out,
+            provider_response_complete=success,
+            artifact_set_complete=None,
         )
+        write_artifact_commit(base)
+        _install_staged_run(destination, base)
     return 0
 
 
@@ -2821,20 +2836,40 @@ def read_output(runs: Path, case_id: str, variant: str) -> tuple[str | None, Pat
     return read_output_base(base)
 
 
+def _with_committed_artifact_state(base: Path, data: dict[str, Any]) -> dict[str, Any]:
+    if data.get("artifact_contract_version") != ARTIFACT_CONTRACT_VERSION:
+        return data
+    committed = artifact_commit_valid(base)
+    current = telemetry_domain.ObservationEvidence.from_run(data)
+    evidence = telemetry_domain.ObservationEvidence(
+        current.process, current.provider_response, current.trace,
+        telemetry_domain.ObservationEvidence.state(committed),
+    )
+    enriched = dict(data)
+    enriched["artifact_set_complete"] = committed
+    enriched["observation_evidence"] = evidence.to_dict()
+    envelope = enriched.get("telemetry")
+    if isinstance(envelope, dict):
+        envelope = dict(envelope)
+        envelope["observation_evidence"] = evidence.to_dict()
+        enriched["telemetry"] = envelope
+    return enriched
+
+
 def read_metadata_base(base: Path) -> dict[str, Any]:
     for name in ["metadata.json", "timing.json", "metrics.json"]:
         p = base / name
         if p.exists():
             try:
                 data = json.loads(p.read_text(encoding="utf-8"))
-                return data if isinstance(data, dict) else {}
+                return _with_committed_artifact_state(base, data) if isinstance(data, dict) else {}
             except json.JSONDecodeError:
                 return {"metadata_error": f"invalid JSON in {name}"}
     p = base / "outputs" / "metrics.json"
     if p.exists():
         try:
             data = json.loads(p.read_text(encoding="utf-8"))
-            return data if isinstance(data, dict) else {}
+            return _with_committed_artifact_state(base, data) if isinstance(data, dict) else {}
         except json.JSONDecodeError:
             return {"metadata_error": "invalid JSON in outputs/metrics.json"}
     return {}
@@ -2878,7 +2913,7 @@ def read_metrics_base(base: Path) -> dict[str, Any]:
         data = read_json_dict_or_list(base / rel)
         if isinstance(data, dict) and not data.get("_error"):
             merged.update(data)
-    return merged
+    return _with_committed_artifact_state(base, merged)
 
 
 def command_text(event: dict[str, Any]) -> str:
@@ -3272,6 +3307,12 @@ def process_or_efficiency_assertion_result(assertion: dict[str, Any], run_base: 
         raw = measurements.get(key) if isinstance(measurements, dict) else None
         if not isinstance(raw, dict):
             return True, None
+        if key in {"tool_calls", "commands", "file_reads", "file_writes",
+                   "errors", "retries", "repeated_command_max", "skill_invoked"}:
+            measurement = telemetry_domain.measurement_from_envelope_or_nonnegative(metrics, key)
+            if measurement.availability == telemetry_domain.AVAILABLE:
+                return True, None
+            return False, f"missing {key} evidence ({measurement.reason})"
         if raw.get("availability") == telemetry_domain.AVAILABLE:
             return True, None
         return False, f"missing {key} evidence ({raw.get('reason', raw.get('availability', 'unavailable'))})"
@@ -3939,7 +3980,15 @@ def write_trace_artifacts(
     out_metrics: Path | None = None,
     write_raw_trace: bool = True,
     pi_stream: PiStream | None = None,
+    process_observation_complete: bool | None = None,
+    provider_response_complete: bool | None = None,
+    artifact_set_complete: bool | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
+    for label, value in (("process_observation_complete", process_observation_complete),
+                         ("provider_response_complete", provider_response_complete),
+                         ("artifact_set_complete", artifact_set_complete)):
+        if value is not None and not isinstance(value, bool):
+            raise TypeError(f"{label} must be boolean or None")
     run_dir.mkdir(parents=True, exist_ok=True)
     if write_raw_trace:
         (run_dir / "trace.jsonl").write_text(trace_text, encoding="utf-8")
@@ -3952,11 +4001,43 @@ def write_trace_artifacts(
         metrics["parse_errors"] = parse_errors[:20]
         metrics["errors"] = int(metrics.get("errors", 0) or 0) + len(parse_errors)
     # A trace-derived count is observed only when at least one valid event was
-    # captured and parsing completed. Runners may override this with their own
-    # process-level observation state (for example a spawn failure).
-    metrics["trace_observation_complete"] = bool(records) and not parse_errors
+    # captured and parsing completed. Completion is derived here and reserved:
+    # arbitrary caller metrics cannot promote an absent trace.
+    trace_observation_complete = bool(records) and not parse_errors
+    reserved = {
+        "trace_observation_complete", "process_observation_complete",
+        "provider_response_complete", "operation_observation_complete",
+        "artifact_set_complete", "observation_evidence", "telemetry",
+        "telemetry_schema_version",
+    }
+    collisions = reserved & set(extra_metrics or {})
+    if collisions:
+        raise ValueError(f"extra_metrics cannot override derived evidence: {', '.join(sorted(collisions))}")
     if extra_metrics:
         metrics.update(extra_metrics)
+    generic_complete = metrics.get("observation_complete")
+    if not isinstance(generic_complete, bool):
+        generic_complete = (metadata or {}).get("observation_complete")
+    if process_observation_complete is None:
+        explicit = (metadata or {}).get("process_observation_complete")
+        process_observation_complete = explicit if isinstance(explicit, bool) else generic_complete if isinstance(generic_complete, bool) else None
+    if provider_response_complete is None:
+        explicit = (metadata or {}).get("provider_response_complete")
+        provider_response_complete = explicit if isinstance(explicit, bool) else generic_complete if isinstance(generic_complete, bool) else None
+    evidence = telemetry_domain.ObservationEvidence(
+        telemetry_domain.ObservationEvidence.state(process_observation_complete),
+        telemetry_domain.ObservationEvidence.state(provider_response_complete),
+        telemetry_domain.ObservationEvidence.state(trace_observation_complete),
+        telemetry_domain.ObservationEvidence.state(artifact_set_complete),
+    )
+    metrics.update({
+        "trace_observation_complete": trace_observation_complete,
+        "process_observation_complete": process_observation_complete,
+        "provider_response_complete": provider_response_complete,
+        "operation_observation_complete": evidence.operation_complete,
+        "artifact_set_complete": artifact_set_complete,
+        "observation_evidence": evidence.to_dict(),
+    })
     # Telemetry precedence: an explicit provider/estimated/not-applicable block
     # supplied by a runner wins over a trace-derived block. Both artifacts then
     # receive the same v3 envelope, including an explicit unavailable state when
@@ -3970,17 +4051,14 @@ def write_trace_artifacts(
     # for identity/basis but must not let an explicit `source: missing` erase a
     # usable trace-normalized observation.
     envelope_input = {**(metadata or {}), **metrics}
-    # Process completion and trace completeness are separate evidence. A
-    # successful provider call with no trace can support provider usage/cost,
-    # but it cannot prove that zero tools or commands ran. Conversely, a failed
-    # process cannot promote a syntactically valid partial trace to complete.
-    if envelope_input.get("observation_complete") is False:
-        envelope_input["trace_observation_complete"] = False
+    # Process, provider response, trace, and artifact-set completeness are
+    # independent axes. The typed evidence value above is the only owner of
+    # operation completeness; no generic success boolean promotes another axis.
     # A crash/timeout can leave a syntactically valid partial JSONL trace. Keep
     # its legacy debugging fields, but v3 must not present trace-derived usage
     # or cost as complete measurement evidence. Provider-reported blocks remain
     # valid independent observations.
-    if envelope_input.get("trace_observation_complete") is not True:
+    if not evidence.operation_complete:
         for key in ("usage_normalized", "cost_normalized"):
             block = envelope_input.get(key)
             if isinstance(block, dict) and block.get("source") == "trace_normalized":
@@ -4014,13 +4092,25 @@ def import_trace(args: argparse.Namespace) -> int:
     trace = Path(args.trace)
     run_dir = Path(args.run_dir)
     trace_text = trace.read_text(encoding="utf-8", errors="replace")
+    existing = read_metadata_base(run_dir)
+    output_text, _ = read_output_base(run_dir)
+    provider_complete = output_text is not None and execution_valid(existing, output_text)
+    returncode = existing.get("returncode")
+    process_complete = (
+        isinstance(returncode, int) and not isinstance(returncode, bool)
+        and returncode not in {124, 127}
+    ) if returncode is not None else provider_complete
     write_trace_artifacts(
         run_dir,
         trace_text,
         source=getattr(args, "source", "generic"),
+        metadata={**existing, "observation_complete": provider_complete,
+                  "evidence_provenance": "legacy_import_inferred"},
         # v3 requires a paired metadata/metrics envelope; importing a trace is
         # a producer, not a metrics-only convenience path.
         write_metadata=True,
+        process_observation_complete=process_complete,
+        provider_response_complete=provider_complete,
         out_events=Path(args.out_events) if getattr(args, "out_events", None) else None,
         out_metrics=Path(args.out_metrics) if getattr(args, "out_metrics", None) else None,
         write_raw_trace=False,
@@ -4040,7 +4130,85 @@ def final_answer_from_events(events: dict[str, Any]) -> str:
     return ""
 
 
-def write_runner_outcome(run_dir: Path, outcome: AnswerOutcome) -> tuple[dict[str, Any], dict[str, Any]]:
+ARTIFACT_COMMIT_NAME = "artifact-commit.json"
+ARTIFACT_CONTRACT_VERSION = 1
+ARTIFACT_REQUIRED_FILES = ("output.md", "events.json", "metrics.json", "metadata.json")
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_artifact_commit(run_dir: Path) -> None:
+    """Write the commit marker last; absence means an interrupted artifact set."""
+    missing = [name for name in ARTIFACT_REQUIRED_FILES if not (run_dir / name).is_file()]
+    if missing:
+        raise ValueError(f"cannot commit incomplete artifact set: {', '.join(missing)}")
+    inventory = {
+        path.relative_to(run_dir).as_posix(): _file_sha256(path)
+        for path in sorted(run_dir.rglob("*"))
+        if path.is_file() and path.name != ARTIFACT_COMMIT_NAME
+    }
+    write_json(run_dir / ARTIFACT_COMMIT_NAME, {
+        "schema_version": ARTIFACT_CONTRACT_VERSION,
+        "required_files": list(ARTIFACT_REQUIRED_FILES),
+        "inventory_sha256": inventory,
+    })
+
+
+def artifact_commit_valid(run_dir: Path) -> bool:
+    path = run_dir / ARTIFACT_COMMIT_NAME
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(raw, dict) or raw.get("schema_version") != ARTIFACT_CONTRACT_VERSION:
+        return False
+    required = raw.get("required_files")
+    inventory = raw.get("inventory_sha256")
+    if required != list(ARTIFACT_REQUIRED_FILES) or not isinstance(inventory, dict):
+        return False
+    if any(not isinstance(name, str) or not isinstance(digest, str)
+           or Path(name).is_absolute() or ".." in Path(name).parts
+           for name, digest in inventory.items()):
+        return False
+    if any(name not in inventory for name in ARTIFACT_REQUIRED_FILES):
+        return False
+    try:
+        return all(
+            (run_dir / name).is_file() and _file_sha256(run_dir / name) == digest
+            for name, digest in inventory.items())
+    except OSError:
+        return False
+
+
+def _install_staged_run(run_dir: Path, staged: Path) -> None:
+    """Atomically replace one run directory, restoring the old set on failure."""
+    run_dir.parent.mkdir(parents=True, exist_ok=True)
+    backup = Path(tempfile.mkdtemp(prefix=f".{run_dir.name}.artifact-backup-",
+                                   dir=run_dir.parent))
+    backup.rmdir()
+    moved_old = False
+    try:
+        if run_dir.exists():
+            os.replace(run_dir, backup)
+            moved_old = True
+        os.replace(staged, run_dir)
+    except OSError:
+        if moved_old and backup.exists() and not run_dir.exists():
+            os.replace(backup, run_dir)
+        raise
+    else:
+        if backup.exists():
+            shutil.rmtree(backup)
+
+
+def _write_runner_outcome_files(run_dir: Path, outcome: AnswerOutcome,
+                                sidecars: Path | None = None) -> tuple[dict[str, Any], dict[str, Any]]:
     """The ONE exhaustive adapter from a closed answer outcome to disk, shared by
     every answer runner (codex/claude/subagent). Provider-specific work — spawning
     the tool and parsing its wire format — happens in the runner; everything from
@@ -4061,6 +4229,7 @@ def write_runner_outcome(run_dir: Path, outcome: AnswerOutcome) -> tuple[dict[st
     `Completed` always carries a non-empty final answer; raw traces are telemetry,
     never a fallback candidate answer."""
     run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / ARTIFACT_COMMIT_NAME).unlink(missing_ok=True)
     context = outcome_context(outcome)
     trace_text = context.trace_text
     if isinstance(outcome, Completed):
@@ -4083,6 +4252,7 @@ def write_runner_outcome(run_dir: Path, outcome: AnswerOutcome) -> tuple[dict[st
         "returncode": returncode,
         "timed_out": timed_out,
         "stderr": context.stderr,
+        "artifact_contract_version": ARTIFACT_CONTRACT_VERSION,
         "usage_normalized": usage_block,
         "cost_normalized": cost_block,
         **({"elapsed_ms": elapsed} if elapsed is not None else {}),
@@ -4095,6 +4265,9 @@ def write_runner_outcome(run_dir: Path, outcome: AnswerOutcome) -> tuple[dict[st
         extra_metrics=extra_metrics,
         environment=dict(context.environment) if context.environment is not None else None,
         write_metadata=True, write_raw_trace=bool(trace_text),
+        process_observation_complete=process_observation_complete(outcome),
+        provider_response_complete=provider_response_complete(outcome),
+        artifact_set_complete=None,
     )
     marker = RUNNER_FAILURE_MARKER_BY_PROVIDER[context.provider.value]
     if isinstance(outcome, TimedOut):
@@ -4115,7 +4288,29 @@ def write_runner_outcome(run_dir: Path, outcome: AnswerOutcome) -> tuple[dict[st
     else:
         body = answer
     (run_dir / "output.md").write_text(body, encoding="utf-8")
+    if sidecars is not None and sidecars.is_dir():
+        for child in sidecars.iterdir():
+            destination = run_dir / child.name
+            if child.is_dir():
+                shutil.copytree(child, destination)
+            else:
+                shutil.copy2(child, destination)
+    write_artifact_commit(run_dir)
     return events, metrics
+
+
+def write_runner_outcome(run_dir: Path, outcome: AnswerOutcome,
+                         *, sidecars: Path | None = None) -> tuple[dict[str, Any], dict[str, Any]]:
+    run_dir.parent.mkdir(parents=True, exist_ok=True)
+    staged = Path(tempfile.mkdtemp(prefix=f".{run_dir.name}.artifact-stage-",
+                                   dir=run_dir.parent))
+    try:
+        result = _write_runner_outcome_files(staged, outcome, sidecars)
+        _install_staged_run(run_dir, staged)
+        return result
+    finally:
+        if staged.exists():
+            shutil.rmtree(staged)
 
 
 def safe_child_path(root: Path, relative: str) -> Path:
@@ -4424,17 +4619,18 @@ def _vibe_content_text(content: Any) -> str:
             elif isinstance(item, str):
                 parts.append(item)
         return "\n".join(parts)
-    return "" if content is None else str(content)
+    return ""
 
 
-def vibe_final_answer(messages: list[dict[str, Any]], fallback: str = "") -> str:
+def vibe_final_answer(messages: list[dict[str, Any]]) -> str:
+    """Return only a validated assistant message; trace bytes are not answers."""
     for msg in reversed(messages):
         if str(msg.get("role", "")).casefold() != "assistant":
             continue
         text = _vibe_content_text(msg.get("content")).strip()
         if text:
             return text
-    return fallback.strip()
+    return ""
 
 
 def _walk_dicts(value: Any) -> Iterable[dict[str, Any]]:
@@ -4521,10 +4717,11 @@ def vibe_cli_invoke(prompt: str, *, model: str | None = None, vibe_cmd: str | No
                     "model": model, "trace_text": "", "environment": env_meta}
         result = run_argv_capture(argv, input_text="", cwd=workspace, env=env, timeout=timeout)
     messages = parse_vibe_messages(result.stdout)
-    answer = vibe_final_answer(messages, result.stdout)
+    answer = vibe_final_answer(messages)
     usage, cost = vibe_usage_and_cost(messages)
     return {
         "answer": answer,
+        "provider_error": None if answer or result.returncode != 0 else "Vibe stream has no final assistant message",
         "stdout": result.stdout,
         "stderr": result.stderr,
         "returncode": result.returncode,
@@ -4578,6 +4775,7 @@ class ClaudeBackend(AgentBackend):
             provider="claude", answer=result.get("answer") or "",
             returncode=result.get("returncode"), timed_out=bool(result.get("timed_out", False)),
             timeout_s=request.timeout_s, elapsed_ms=result.get("elapsed_ms") if isinstance(result.get("elapsed_ms"), (int, float)) else None, stderr=result.get("stderr", ""),
+            error=result.get("parse_error"), trace_text=result.get("raw_response") or "",
             usage=result.get("usage"), cost_usd=result.get("cost_usd"), model=request.model,
             metadata_extra={"cost_usd": claude_metrics.get("cost_usd")}, metrics_extra=metrics_extra,
             environment={"runner": "claude", "command": "claude -p --output-format json --no-session-persistence", "cwd": "<isolated workspace>"})
@@ -4602,6 +4800,7 @@ class VibeBackend(AgentBackend):
             provider="vibe", answer=result.get("answer") or "",
             returncode=result.get("returncode"), timed_out=bool(result.get("timed_out", False)),
             timeout_s=request.timeout_s, elapsed_ms=result.get("elapsed_ms") if isinstance(result.get("elapsed_ms"), (int, float)) else None, stderr=result.get("stderr", ""),
+            error=result.get("provider_error"),
             usage=result.get("usage"), cost_usd=result.get("cost_usd"), model=request.model,
             trace_text=result.get("trace_text") or "",
             environment={"runner": "vibe", **env})
@@ -4703,18 +4902,20 @@ CLAUDE_USAGE_KEYS = {
 
 
 def parse_claude_cli_json(stdout: str) -> dict[str, Any]:
-    """Pure parser for the `claude -p --output-format json` envelope. Returns
-    {answer, cost_usd, usage, parse_error}. Tolerant: if the envelope isn't JSON
-    (e.g. --output-format text slipped through), the raw stdout IS the answer and
-    cost/usage are absent — never raises, so a runner never crashes on a verdict."""
+    """Parse the `claude -p --output-format json` envelope.
+
+    Malformed protocol bytes remain diagnostics and can never become a final
+    answer merely because the subprocess exited zero.
+    """
     text = stdout if isinstance(stdout, str) else ""
     try:
         env = extract_json_object(text)
     except Exception as exc:  # noqa: BLE001
-        return {"answer": text, "cost_usd": None, "usage": {}, "parse_error": str(exc)}
+        return {"answer": "", "raw_response": text, "cost_usd": None,
+                "usage": {}, "parse_error": str(exc)}
     if not isinstance(env, dict) or "result" not in env:
-        # Valid JSON but not the -p envelope; treat the whole thing as the answer.
-        return {"answer": text, "cost_usd": None, "usage": {}, "parse_error": "not a claude -p json envelope"}
+        return {"answer": "", "raw_response": text, "cost_usd": None,
+                "usage": {}, "parse_error": "not a claude -p json envelope"}
     raw_usage = env.get("usage") if isinstance(env.get("usage"), dict) else {}
     usage: dict[str, int] = {}
     for norm, aliases in CLAUDE_USAGE_KEYS.items():
@@ -4726,11 +4927,13 @@ def parse_claude_cli_json(stdout: str) -> dict[str, Any]:
     if "input_tokens" in usage and "output_tokens" in usage:
         usage.setdefault("total_tokens", usage["input_tokens"] + usage["output_tokens"])
     cost = env.get("total_cost_usd")
+    result = env.get("result")
+    result_error = None if isinstance(result, str) else "claude result must be a string"
     return {
-        "answer": env.get("result") or "",
+        "answer": result if isinstance(result, str) else "",
         "cost_usd": cost if isinstance(cost, (int, float)) else None,
         "usage": usage,
-        "parse_error": None,
+        "parse_error": result_error,
         "is_error": bool(env.get("is_error")),
         "api_error_status": env.get("api_error_status"),
     }
@@ -5475,7 +5678,7 @@ def judge_verdict_passed(verdict: dict[str, Any], *, default_threshold: float = 
         return False
 
 
-JUDGE_RESERVED_FILES = {"output.md", "events.json", "metrics.json", "metadata.json", "timing.json", "environment.json", "trace.jsonl", "result.json"}
+JUDGE_RESERVED_FILES = {"output.md", "events.json", "metrics.json", "metadata.json", "timing.json", "environment.json", "trace.jsonl", "result.json", ARTIFACT_COMMIT_NAME}
 # Never expose a grader answer key / rubric to a blind judge (G1 leakage guard).
 JUDGE_LEAK_MARKERS = ("grading", "answer", "rubric", "expected", "gold")
 
@@ -5669,12 +5872,11 @@ def run_one_judge_task(task: dict[str, Any], judge_cmd: str | None = None, trans
         parsed = {}
         parse_error = str(exc)
     assertion = task.get("assertion", {})
-    # G4: validate the verdict SHAPE against its canonical schema. extract_json_object
-    # accepts any JSON object, so a wrong-keys verdict (no `passed`, a graded verdict
-    # with no dimension_scores) would be silently coerced downstream. `report` (default)
-    # only surfaces the violation in schema_errors; `strict` fails it closed.
+    # Validate every newly produced verdict before it can establish pass/fail.
+    # `report` controls whether diagnostics are surfaced, not whether malformed
+    # provider evidence is accepted; both modes fail closed.
     schema_errors = json_schema_errors(parsed, verdict_schema_for(assertion)) if (parse_error is None and isinstance(parsed, dict)) else []
-    if schema_errors and schema_enforcement == "strict":
+    if schema_errors:
         parse_error = "verdict schema: " + "; ".join(schema_errors[:5])
     threshold = assertion.get("threshold", parsed.get("threshold", 1))
     score = parsed.get("score")
@@ -5824,10 +6026,19 @@ def merge_cross_judge_rows(rows: list[dict[str, Any]], *, quorum: int | None = N
     out["evidence"] = " | ".join(str(r.get("evidence", "")) for r in rows if r.get("evidence"))[:4000]
     out["agreement"] = {"concur": concur, "n": n, "concur_fraction": round(concur / n, 4),
                         "unanimous": concur in (0, n), "unresolved": unresolved}
-    member_cost = [r.get("cost_usd") for r in rows if isinstance(r.get("cost_usd"), (int, float))]
-    if member_cost:
-        out["cost_usd"] = sum(member_cost)
-        out["cost_normalized"] = normalize_cost(out["cost_usd"], source="provider_reported", pricing_model="consensus")
+    member_cost = [telemetry_domain.measurement_from_envelope_or_cost(
+        row, source="judge", population="judge") for row in rows]
+    cost_buckets = telemetry_domain.aggregate_money_by_currency(member_cost)
+    out["cost_aggregate"] = {currency: aggregate.to_dict()
+                             for currency, aggregate in cost_buckets.items()}
+    usd = cost_buckets.get("USD")
+    if usd is not None and usd.availability == telemetry_domain.COMPLETE and len(cost_buckets) == 1:
+        out["cost_usd"] = float(usd.value)
+        out["cost_normalized"] = normalize_cost(
+            out["cost_usd"], source="provider_reported", pricing_model="consensus")
+    else:
+        out["cost_usd"] = None
+        out["cost_normalized"] = {"source": "missing"}
     out["judge_panel"] = rows
     for key in ("threshold", "dimension_scores", "criteria", "minimum_criteria"):
         out.pop(key, None)
@@ -5943,7 +6154,8 @@ def run_subagent_tasks(
         pt = PreparedTask.from_row(task)
         row_model = task.get("model") or model
         base = safe_child_path(runs, pt.run_dir)
-        base.mkdir(parents=True, exist_ok=True)
+        base.parent.mkdir(parents=True, exist_ok=True)
+        sidecars = Path(tempfile.mkdtemp(prefix=f".{base.name}.sidecars-", dir=base.parent))
         prov_extra = {
             "population": "answer",
             "case_id": pt.case_id,
@@ -5953,7 +6165,11 @@ def run_subagent_tasks(
             **({"ablation": pt.ablation.as_dict()} if pt.ablation else {}),
             **({"skill_tree_hash": pt.skill_tree_hash} if pt.skill_tree_hash else {}),
         }
-        store = ToolReplayStore(base / "tool-replay.json", mode) if mode != "off" else None
+        replay_path = sidecars / "tool-replay.json"
+        existing_replay = base / "tool-replay.json"
+        if mode in {"replay", "strict", "auto"} and existing_replay.is_file():
+            shutil.copy2(existing_replay, replay_path)
+        store = ToolReplayStore(replay_path, mode) if mode != "off" else None
 
         def tool_executor(tool: str, payload: Any) -> Any:
             live = (live_tools or {}).get(tool)
@@ -5982,7 +6198,7 @@ def run_subagent_tasks(
                         sent = prompt if n == 1 else turn_prompt
                         outcome = agent_fn(prompt=sent, workspace=ws, model=row_model, tool_executor=tool_executor, history=list(history)) or {}
                         turn_answer = str(outcome.get("answer") or "")
-                        turn_dir = base / f"turn-{n}"
+                        turn_dir = sidecars / f"turn-{n}"
                         turn_dir.mkdir(parents=True, exist_ok=True)
                         (turn_dir / "output.md").write_text(turn_answer, encoding="utf-8")
                         history.append({"prompt": sent, "answer": turn_answer})
@@ -6020,7 +6236,10 @@ def run_subagent_tasks(
             metadata_extra={"tool_replay_mode": mode, **prov_extra},
             metrics_extra={k: v for k, v in (raw_usage or {}).items() if isinstance(v, (int, float))},
             diagnose_returncode=False)
-        write_runner_outcome(base, ro)
+        try:
+            write_runner_outcome(base, ro, sidecars=sidecars)
+        finally:
+            shutil.rmtree(sidecars, ignore_errors=True)
     return 0
 
 
@@ -6822,12 +7041,23 @@ def telemetry_for_result(result: dict[str, Any]) -> dict[str, bool]:
     metrics_exists = (base / "metrics.json").exists()
     events, _ = read_events_base(base) if events_exists else (None, None)
     has_skill_event = bool(events and any(e.get("type") == "skill_load" for e in events))
+    has_command_event = bool(events and command_events(events))
     envelope = metrics.get("telemetry") if isinstance(metrics.get("telemetry"), dict) else {}
     measurements = envelope.get("measurements") if isinstance(envelope, dict) else {}
 
     def observed(key: str, fallback: bool) -> bool:
         measurement = measurements.get(key) if isinstance(measurements, dict) else None
         if isinstance(measurement, dict):
+            if key in {"commands", "skill_invoked"}:
+                try:
+                    evidence_raw = envelope.get("observation_evidence")
+                    evidence = (telemetry_domain.ObservationEvidence.from_dict(evidence_raw)
+                                if isinstance(evidence_raw, dict)
+                                else telemetry_domain.ObservationEvidence.from_run(metrics))
+                except (TypeError, ValueError):
+                    return False
+                if not evidence.operation_complete:
+                    return False
             return measurement.get("availability") == telemetry_domain.AVAILABLE
         return fallback
 
@@ -6836,7 +7066,7 @@ def telemetry_for_result(result: dict[str, Any]) -> dict[str, bool]:
         "events": events_exists,
         "metrics": metrics_exists,
         "tokens": observed("total_tokens", metric_number(metrics, "total_tokens") is not None),
-        "commands": observed("commands", metric_number(metrics, "commands", "command_count") is not None or events_exists),
+        "commands": observed("commands", metric_number(metrics, "commands", "command_count") is not None or has_command_event),
         "skill_invocation": observed("skill_invoked", isinstance(metrics.get("skill_invoked"), bool) or has_skill_event),
     }
 
@@ -10590,6 +10820,29 @@ def _run_suite_tier(scope: dict[str, Any], out_dir: Path) -> list[dict[str, Any]
     return commands
 
 
+def _validated_complete_history_value(totals: dict[str, Any], key: str,
+                                      expected_count: int) -> float | None:
+    """Read a complete aggregate only when its scalar/counts agree exactly."""
+    aggregate = totals.get(f"{key}_aggregate")
+    scalar = totals.get(key)
+    if (not isinstance(aggregate, dict)
+            or aggregate.get("availability") != telemetry_domain.COMPLETE
+            or aggregate.get("observed_count") != expected_count
+            or aggregate.get("unavailable_count") != 0
+            or aggregate.get("not_applicable_count") != 0
+            or isinstance(scalar, bool) or not isinstance(scalar, (int, float))
+            or not math.isfinite(float(scalar)) or float(scalar) < 0):
+        return None
+    value = aggregate.get("value")
+    try:
+        aggregate_value = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not math.isfinite(aggregate_value) or aggregate_value < 0 or aggregate_value != float(scalar):
+        return None
+    return float(scalar)
+
+
 def suite_cost_estimate(scope: dict[str, Any], *, history_dir: Path | None = None, assumed_tokens_per_run: float = 30000.0, assumed_cost_per_run_usd: float | None = None) -> dict[str, Any]:
     """Preflight cost projection (issue #21): historical per-run medians from
     previous cost-summary ledgers when available, otherwise a static
@@ -10616,16 +10869,18 @@ def suite_cost_estimate(scope: dict[str, Any], *, history_dir: Path | None = Non
                 continue
             coverage = doc.get("coverage") or {}
             doc_totals = doc.get("totals") or {}
-            seen = coverage.get("runs_seen") or 0
-            if not seen:
+            seen = coverage.get("runs_seen")
+            if isinstance(seen, bool) or not isinstance(seen, int) or seen <= 0:
                 continue
-            if (doc_totals.get("total_tokens_availability") == telemetry_domain.COMPLETE
-                    and isinstance(doc_totals.get("total_tokens"), (int, float))):
-                token_rates.append(doc_totals["total_tokens"] / seen)
-            costed = coverage.get("runs_with_dollar_cost") or 0
-            if (doc_totals.get("total_cost_usd_availability") == telemetry_domain.COMPLETE
-                    and costed and isinstance(doc_totals.get("total_cost_usd"), (int, float))):
-                cost_rates.append(doc_totals["total_cost_usd"] / costed)
+            tokens = _validated_complete_history_value(doc_totals, "total_tokens", seen)
+            if tokens is not None:
+                token_rates.append(tokens / seen)
+            costed = coverage.get("runs_with_dollar_cost")
+            if isinstance(costed, bool) or not isinstance(costed, int) or costed <= 0 or costed > seen:
+                continue
+            cost = _validated_complete_history_value(doc_totals, "total_cost_usd", costed)
+            if cost is not None:
+                cost_rates.append(cost / costed)
         if token_rates:
             per_run_tokens = statistics.median(token_rates)
             basis = "cost_history_median"

--- a/telemetry.py
+++ b/telemetry.py
@@ -32,6 +32,118 @@ PROVENANCE = {
 }
 CURRENCY_RE = re.compile(r"^[A-Z]{3}$")
 
+EVIDENCE_COMPLETE = "complete"
+EVIDENCE_INCOMPLETE = "incomplete"
+EVIDENCE_UNKNOWN = "unknown"
+_EVIDENCE_STATES = {EVIDENCE_COMPLETE, EVIDENCE_INCOMPLETE, EVIDENCE_UNKNOWN}
+
+
+@dataclass(frozen=True)
+class ObservationEvidence:
+    """Independent observation channels for one run.
+
+    A complete channel never promotes another channel. Full-run operation
+    evidence exists only when process exit, provider response, and trace are all
+    independently complete. Artifact completeness is committed separately after
+    the required files are durable.
+    """
+
+    process: str = EVIDENCE_UNKNOWN
+    provider_response: str = EVIDENCE_UNKNOWN
+    trace: str = EVIDENCE_UNKNOWN
+    artifact_set: str = EVIDENCE_UNKNOWN
+
+    def __post_init__(self) -> None:
+        for label, value in (("process", self.process),
+                             ("provider_response", self.provider_response),
+                             ("trace", self.trace),
+                             ("artifact_set", self.artifact_set)):
+            if value not in _EVIDENCE_STATES:
+                raise ValueError(f"unknown {label} evidence state {value!r}")
+
+    @staticmethod
+    def state(value: bool | None) -> str:
+        if value is True:
+            return EVIDENCE_COMPLETE
+        if value is False:
+            return EVIDENCE_INCOMPLETE
+        return EVIDENCE_UNKNOWN
+
+    @property
+    def operation_complete(self) -> bool:
+        return all(value == EVIDENCE_COMPLETE for value in (
+            self.process, self.provider_response, self.trace))
+
+    @property
+    def operation_incomplete_reason(self) -> str:
+        if self.process != EVIDENCE_COMPLETE:
+            return "process_observation_incomplete"
+        if self.provider_response != EVIDENCE_COMPLETE:
+            return "provider_response_incomplete"
+        if self.trace != EVIDENCE_COMPLETE:
+            return "trace_observation_incomplete"
+        return "operation_observation_complete"
+
+    @property
+    def artifact_complete(self) -> bool:
+        return self.artifact_set == EVIDENCE_COMPLETE
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "process": {"state": self.process},
+            "provider_response": {"state": self.provider_response},
+            "trace": {"state": self.trace},
+            "artifact_set": {"state": self.artifact_set},
+            "operation_evidence_complete": self.operation_complete,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "ObservationEvidence":
+        if not isinstance(raw, Mapping) or raw.get("schema_version") != 1:
+            raise ValueError("observation evidence must use schema_version 1")
+        values: dict[str, str] = {}
+        for key in ("process", "provider_response", "trace", "artifact_set"):
+            block = raw.get(key)
+            if not isinstance(block, Mapping):
+                raise ValueError(f"observation evidence {key} must be an object")
+            values[key] = str(block.get("state"))
+        evidence = cls(**values)
+        if raw.get("operation_evidence_complete") is not evidence.operation_complete:
+            raise ValueError("operation completeness contradicts its evidence channels")
+        return evidence
+
+    @classmethod
+    def from_run(cls, raw: Mapping[str, Any]) -> "ObservationEvidence":
+        explicit = raw.get("observation_evidence")
+        if isinstance(explicit, Mapping):
+            return cls.from_dict(explicit)
+        # Compatibility adapter for pre-contract artifacts. The generic field
+        # described answer/provider completeness; it cannot certify process or
+        # trace state. Derive process exit only from actual process fields and
+        # leave absent trace evidence unknown rather than preserving the old
+        # cross-channel promotion.
+        generic = raw.get("observation_complete")
+        process = raw.get("process_observation_complete")
+        provider = raw.get("provider_response_complete")
+        trace = raw.get("trace_observation_complete")
+        if not isinstance(process, bool):
+            returncode = raw.get("returncode")
+            timed_out = raw.get("timed_out") is True or raw.get("timeout") is True
+            if timed_out or returncode in {124, 127}:
+                process = False
+            elif isinstance(returncode, int) and not isinstance(returncode, bool):
+                process = True
+            else:
+                process = None
+        if not isinstance(provider, bool):
+            provider = generic if isinstance(generic, bool) else None
+        if not isinstance(trace, bool):
+            trace = None
+        artifact = raw.get("artifact_set_complete")
+        return cls(cls.state(process), cls.state(provider), cls.state(trace),
+                   cls.state(artifact if isinstance(artifact, bool) else None))
+
 
 def _decimal(value: Any) -> Decimal:
     """Parse a finite non-negative money scalar without accepting bool/NaN."""
@@ -499,24 +611,23 @@ def telemetry_envelope(raw: Mapping[str, Any] | None, *, source: str | None = No
         "elapsed_ms": measurement_from_nonnegative(raw.get("elapsed_ms", raw.get("duration_ms")),
                                                      unavailable_reason="missing_elapsed_ms", basis=basis).to_dict(),
     }
-    # Trace-derived counts/bools are trustworthy only when a complete trace was
-    # observed. Their old flat fields remain for assertion compatibility, while
-    # v3 prevents an empty/malformed trace from looking like zero activity.
-    trace_complete = raw.get("trace_observation_complete")
-    if not isinstance(trace_complete, bool):
-        # Legacy callers used observation_complete for trace completeness. New
-        # artifacts carry both process and trace state, so the trace-specific
-        # field takes precedence when present.
-        trace_complete = raw.get("observation_complete")
+    # Trace-derived counts/bools support complete-run claims only when process,
+    # provider response, and trace are independently complete. A successful
+    # provider response cannot promote an absent trace, and a parseable partial
+    # trace from a failed process cannot promote the process outcome.
+    observation_evidence = ObservationEvidence.from_run(raw)
+    operation_complete = observation_evidence.operation_complete
     for key in ("tool_calls", "commands", "file_reads", "file_writes", "errors", "retries", "repeated_command_max"):
-        if trace_complete is True:
+        if operation_complete:
             measurements[key] = measurement_from_nonnegative(raw.get(key), unavailable_reason=f"missing_{key}", basis=basis).to_dict()
         else:
-            measurements[key] = Measurement.unavailable("trace_observation_incomplete", basis=basis).to_dict()
-    if trace_complete is True and isinstance(raw.get("skill_invoked"), bool):
+            measurements[key] = Measurement.unavailable(
+                observation_evidence.operation_incomplete_reason, basis=basis).to_dict()
+    if operation_complete and isinstance(raw.get("skill_invoked"), bool):
         measurements["skill_invoked"] = Measurement.available(raw["skill_invoked"], provenance="trace_normalized", basis=basis).to_dict()
     else:
-        measurements["skill_invoked"] = Measurement.unavailable("trace_observation_incomplete", basis=basis).to_dict()
+        measurements["skill_invoked"] = Measurement.unavailable(
+            observation_evidence.operation_incomplete_reason, basis=basis).to_dict()
     if legacy_unverified:
         # Normalized v1/v2 fields can be useful historical observations but do
         # not establish the provider/billing basis needed for causal ratios.
@@ -532,6 +643,7 @@ def telemetry_envelope(raw: Mapping[str, Any] | None, *, source: str | None = No
         "schema_version": 3,
         "population": basis["population"],
         "basis": {key: value for key, value in basis.items() if value is not None},
+        "observation_evidence": observation_evidence.to_dict(),
         "measurements": measurements,
     }
 
@@ -556,6 +668,20 @@ def measurement_from_envelope_or_nonnegative(raw: Mapping[str, Any], key: str, *
     """Read a v3 local metric (duration/count) or adapt a legacy scalar."""
     envelope = raw.get("telemetry")
     if isinstance(envelope, Mapping) and envelope.get("schema_version") == 3:
+        operation_keys = {
+            "tool_calls", "commands", "file_reads", "file_writes",
+            "errors", "retries", "repeated_command_max", "skill_invoked",
+        }
+        if key in operation_keys:
+            try:
+                evidence_raw = envelope.get("observation_evidence")
+                evidence = (ObservationEvidence.from_dict(evidence_raw)
+                            if isinstance(evidence_raw, Mapping)
+                            else ObservationEvidence.from_run(raw))
+            except ValueError:
+                return Measurement.unavailable("invalid_observation_evidence")
+            if not evidence.operation_complete:
+                return Measurement.unavailable(evidence.operation_incomplete_reason)
         measurements = envelope.get("measurements")
         if isinstance(measurements, Mapping) and isinstance(measurements.get(key), Mapping):
             try:

--- a/tests/test_claude_adapter.py
+++ b/tests/test_claude_adapter.py
@@ -31,11 +31,17 @@ class ParseClaudeEnvelopeTests(unittest.TestCase):
         self.assertEqual(p["usage"]["total_tokens"], 10)          # derived
         self.assertEqual(p["usage"]["cache_read_tokens"], 9)
 
-    def test_tolerates_non_envelope(self):
+    def test_non_envelope_is_diagnostic_not_answer_evidence(self):
         p = sb.parse_claude_cli_json("just raw text, not json")
-        self.assertEqual(p["answer"], "just raw text, not json")
+        self.assertEqual(p["answer"], "")
+        self.assertEqual(p["raw_response"], "just raw text, not json")
         self.assertIsNone(p["cost_usd"])
         self.assertIsNotNone(p["parse_error"])
+
+    def test_non_string_result_is_protocol_error_not_answer(self):
+        p = sb.parse_claude_cli_json(json.dumps({"result": {"message": "diagnostic"}}))
+        self.assertEqual(p["answer"], "")
+        self.assertEqual(p["parse_error"], "claude result must be a string")
 
     def test_tolerates_fenced_json_envelope(self):
         out = "```json\n" + json.dumps({"result": "x", "total_cost_usd": 0.01, "usage": {}}) + "\n```"
@@ -103,6 +109,28 @@ class RunClaudeAdapterTests(unittest.TestCase):
             meta = json.loads((base / "metadata.json").read_text())
             self.assertEqual(meta["returncode"], 1)
             self.assertTrue(text.lstrip().startswith(sb.CLAUDE_FAILURE))
+            self.assertFalse(sb.execution_valid(meta, text))
+
+    def test_zero_exit_malformed_envelope_is_protocol_failure(self):
+        with tempfile.TemporaryDirectory() as t:
+            td = Path(t)
+            malformed = td / "malformed_claude.py"
+            malformed.write_text("#!/usr/bin/env python3\nprint('plain diagnostic, not an envelope')\n",
+                                 encoding="utf-8")
+            malformed.chmod(malformed.stat().st_mode | stat.S_IXUSR)
+            _, runs, run_dir = self._run(td)
+            sb.run_claude(argparse.Namespace(
+                tasks=str(td / "tasks.jsonl"), runs=str(runs),
+                model="claude-haiku-4-5-20251001", claude_bin=str(malformed), timeout=60))
+            base = runs / run_dir
+            text = (base / "output.md").read_text(encoding="utf-8")
+            meta = sb.read_metadata_base(base)
+            self.assertEqual(meta["returncode"], 0)
+            self.assertTrue(meta["process_observation_complete"])
+            self.assertFalse(meta["provider_response_complete"])
+            self.assertTrue(meta["artifact_set_complete"])
+            self.assertTrue(text.lstrip().startswith(sb.CLAUDE_FAILURE))
+            self.assertNotIn("plain diagnostic", text)
             self.assertFalse(sb.execution_valid(meta, text))
 
     def test_benchmark_totals_cost(self):

--- a/tests/test_cost_telemetry.py
+++ b/tests/test_cost_telemetry.py
@@ -132,11 +132,41 @@ class RunnerStampTests(unittest.TestCase):
                     self.assertEqual(measurements[key]["availability"], "unavailable")
                     self.assertEqual(measurements[key]["reason"], "trace_observation_incomplete")
 
+    def test_completeness_parameters_reject_truthy_non_booleans(self):
+        with tempfile.TemporaryDirectory() as td:
+            for field in ("process_observation_complete", "provider_response_complete",
+                          "artifact_set_complete"):
+                with self.subTest(field=field), self.assertRaises(TypeError):
+                    sb.write_trace_artifacts(
+                        Path(td) / field, "", source="codex", **{field: 1})
+
+    def test_caller_metrics_cannot_override_derived_evidence(self):
+        with tempfile.TemporaryDirectory() as td:
+            for key in ("trace_observation_complete", "process_observation_complete",
+                        "provider_response_complete", "operation_observation_complete",
+                        "artifact_set_complete", "observation_evidence", "telemetry"):
+                with self.subTest(key=key), self.assertRaisesRegex(ValueError, "derived evidence"):
+                    sb.write_trace_artifacts(
+                        Path(td) / key, "", source="codex", extra_metrics={key: True})
+
+    def test_empty_legacy_events_file_proves_artifact_presence_not_command_evidence(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            (base / "events.json").write_text(
+                json.dumps({"schema_version": 2, "events": []}), encoding="utf-8")
+            flags = sb.telemetry_for_result({"run_base": str(base)})
+        self.assertTrue(flags["events"])
+        self.assertFalse(flags["commands"])
+
     def test_trace_derived_usage_is_stamped_when_no_provider_block(self):
         with tempfile.TemporaryDirectory() as td:
             run_dir = Path(td) / "run"
             trace = json.dumps({"type": "usage", "usage": {"input_tokens": 30, "output_tokens": 12}})
-            sb.write_trace_artifacts(run_dir, trace, source="codex")
+            sb.write_trace_artifacts(
+                run_dir, trace, source="codex",
+                process_observation_complete=True,
+                provider_response_complete=True,
+            )
             metrics = json.loads((run_dir / "metrics.json").read_text(encoding="utf-8"))
             self.assertEqual(metrics["usage_normalized"]["total_tokens"], 42)
             self.assertEqual(metrics["usage_normalized"]["source"], "trace_normalized")
@@ -145,9 +175,13 @@ class RunnerStampTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             run_dir = Path(td) / "run"
             trace = json.dumps({"type": "usage", "usage": {"input_tokens": 3, "output_tokens": 2}})
-            sb.write_trace_artifacts(run_dir, trace, source="codex",
-                                     metadata={"usage_normalized": {"source": "missing"},
-                                               "cost_normalized": {"source": "missing"}})
+            sb.write_trace_artifacts(
+                run_dir, trace, source="codex",
+                metadata={"usage_normalized": {"source": "missing"},
+                          "cost_normalized": {"source": "missing"}},
+                process_observation_complete=True,
+                provider_response_complete=True,
+            )
             metrics = json.loads((run_dir / "metrics.json").read_text(encoding="utf-8"))
             self.assertEqual(metrics["usage_normalized"]["total_tokens"], 5)
             measured = metrics["telemetry"]["measurements"]["total_tokens"]
@@ -178,7 +212,7 @@ class RunnerStampTests(unittest.TestCase):
             passed, evidence = sb.process_or_efficiency_assertion_result(
                 {"type": "command_not_ran", "pattern": "rm -rf"}, base, {})
         self.assertFalse(passed)
-        self.assertIn("trace_observation_incomplete", evidence)
+        self.assertIn("process_observation_incomplete", evidence)
 
     def test_timed_out_runner_trace_is_incomplete_even_when_it_has_events(self):
         with tempfile.TemporaryDirectory() as td:
@@ -194,7 +228,7 @@ class RunnerStampTests(unittest.TestCase):
             passed, evidence = sb.process_or_efficiency_assertion_result(
                 {"type": "command_not_ran", "pattern": "rm -rf"}, base, {})
         self.assertFalse(passed)
-        self.assertIn("trace_observation_incomplete", evidence)
+        self.assertIn("process_observation_incomplete", evidence)
 
     def test_write_trace_artifacts_metadata_is_current_run_only(self):
         with tempfile.TemporaryDirectory() as td:
@@ -698,8 +732,16 @@ class SuiteBudgetGateTests(unittest.TestCase):
                 (history / f"ledger-{i}.json").write_text(json.dumps({
                     "telemetry_schema_version": 3,
                     "coverage": {"runs_seen": runs_n, "runs_with_dollar_cost": runs_n},
-                    "totals": {"total_tokens": tokens, "total_tokens_availability": "complete",
-                               "total_cost_usd": cost, "total_cost_usd_availability": "complete"},
+                    "totals": {
+                        "total_tokens": tokens, "total_tokens_availability": "complete",
+                        "total_tokens_aggregate": {"availability": "complete", "value": tokens,
+                                                   "observed_count": runs_n, "unavailable_count": 0,
+                                                   "not_applicable_count": 0, "reason_counts": {}},
+                        "total_cost_usd": cost, "total_cost_usd_availability": "complete",
+                        "total_cost_usd_aggregate": {"availability": "complete", "value": str(cost),
+                                                     "observed_count": runs_n, "unavailable_count": 0,
+                                                     "not_applicable_count": 0, "reason_counts": {}},
+                    },
                 }), encoding="utf-8")
             scope = {"totals": {"selected_tier_rows": 10}, "include_ablations": False}
             estimate = sb.suite_cost_estimate(scope, history_dir=history)
@@ -721,11 +763,43 @@ class SuiteBudgetGateTests(unittest.TestCase):
             history.mkdir()
             (history / "ledger.json").write_text(json.dumps({
                 "telemetry_schema_version": 3, "coverage": summary["coverage"],
-                "totals": {"total_tokens": 20, "total_tokens_availability": "complete",
-                           "total_cost_usd": 10.0, "total_cost_usd_availability": "complete"},
+                "totals": {
+                    "total_tokens": 20, "total_tokens_availability": "complete",
+                    "total_tokens_aggregate": {"availability": "complete", "value": 20,
+                                               "observed_count": 2, "unavailable_count": 0,
+                                               "not_applicable_count": 0, "reason_counts": {}},
+                    "total_cost_usd": 10.0, "total_cost_usd_availability": "complete",
+                    "total_cost_usd_aggregate": {"availability": "complete", "value": "10.0",
+                                                 "observed_count": 1, "unavailable_count": 0,
+                                                 "not_applicable_count": 0, "reason_counts": {}},
+                },
             }), encoding="utf-8")
             estimate = sb.suite_cost_estimate({"totals": {"selected_tier_rows": 2}, "include_ablations": False}, history_dir=history)
         self.assertEqual(estimate["estimated_cost_usd"], 20.0)
+
+    def test_internally_contradictory_v3_history_cannot_establish_budget_evidence(self):
+        with tempfile.TemporaryDirectory() as td:
+            history = Path(td)
+            (history / "forged.json").write_text(json.dumps({
+                "telemetry_schema_version": 3,
+                "coverage": {"runs_seen": 10, "runs_with_dollar_cost": 10},
+                "totals": {
+                    "total_tokens": 100, "total_tokens_availability": "complete",
+                    "total_tokens_aggregate": {"availability": "complete", "value": 999,
+                                               "observed_count": 10, "unavailable_count": 0,
+                                               "not_applicable_count": 0},
+                    "total_cost_usd": 1.0, "total_cost_usd_availability": "complete",
+                    "total_cost_usd_aggregate": {"availability": "complete", "value": "2.0",
+                                                 "observed_count": 10, "unavailable_count": 0,
+                                                 "not_applicable_count": 0},
+                },
+            }), encoding="utf-8")
+            estimate = sb.suite_cost_estimate(
+                {"totals": {"selected_tier_rows": 2}, "include_ablations": False},
+                history_dir=history,
+            )
+        self.assertEqual(estimate["basis"], "static_assumption")
+        self.assertIsNone(estimate["per_run_cost_usd"])
 
     def test_estimate_static_fallback_has_no_dollar_guess(self):
         estimate = sb.suite_cost_estimate({"totals": {"selected_tier_rows": 4}, "include_ablations": False})

--- a/tests/test_jetty_contracts.py
+++ b/tests/test_jetty_contracts.py
@@ -1,3 +1,6 @@
+import json
+from pathlib import Path
+import tempfile
 import unittest
 
 import jetty_contracts as jc
@@ -78,6 +81,29 @@ class JettyBoundaryIntegrationTests(unittest.TestCase):
         self.assertEqual(record["lifecycle"]["kind"], "failed")
         self.assertIn("trajectory_id", record["error"])
         self.assertFalse(client.polled)
+
+    def test_failed_trajectory_cannot_promote_partial_events_to_complete_operations(self):
+        record = {
+            "status": "failed", "trajectory_id": "t", "error": "boom",
+            "trajectory": {"events": [{"type": "command_end", "command": "echo partial"}]},
+            "jetty": {},
+        }
+        metadata = sb.normalized_jetty_metadata(record, success=False)
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            sb.write_trace_artifacts(
+                base,
+                sb.jsonl_from_records(sb.jetty_trace_records(record, [], success=False)),
+                source="jetty", metadata=metadata,
+                process_observation_complete=True,
+                provider_response_complete=False,
+            )
+            metrics = json.loads((base / "metrics.json").read_text(encoding="utf-8"))
+        self.assertTrue(metrics["trace_observation_complete"])
+        self.assertFalse(metrics["operation_observation_complete"])
+        command = metrics["telemetry"]["measurements"]["commands"]
+        self.assertEqual(command["availability"], "unavailable")
+        self.assertEqual(command["reason"], "provider_response_incomplete")
 
     def test_poller_preserves_status_state_conflict_as_protocol_invalid(self):
         class Client(sb.JettyClient):

--- a/tests/test_judging.py
+++ b/tests/test_judging.py
@@ -195,8 +195,8 @@ class VerdictSchemaTests(unittest.TestCase):
             strict_row = sb.run_one_judge_task(task, judge_cmd=cmd, schema_enforcement="strict")
         self.assertIn("schema_errors", report_row)   # violation surfaced in both modes
         self.assertIn("schema_errors", strict_row)
-        self.assertTrue(report_row["passed"])         # report: verdict resolves exactly as today (score>=threshold)
-        self.assertFalse(strict_row["passed"])        # strict: forced closed via the parse-error channel
+        self.assertFalse(report_row["passed"])        # report surfaces diagnostics but cannot promote malformed evidence
+        self.assertFalse(strict_row["passed"])        # strict is also fail-closed
 
     def test_wellformed_verdict_stays_clean_and_default_is_report(self):
         with tempfile.TemporaryDirectory() as td:
@@ -490,6 +490,20 @@ class CrossJudgeConsensusTests(unittest.TestCase):
     def test_cost_is_panel_summed_once(self):
         out = sb.merge_cross_judge_rows([self._row("m1", True, 5, cost=0.10), self._row("m2", True, 5, cost=0.20)])
         self.assertAlmostEqual(out["cost_usd"], 0.30)          # summed on the top row, not double-counted
+
+    def test_partial_panel_cost_remains_a_known_subtotal_not_complete_spend(self):
+        rows = [
+            {**self._row("m1", True, 5, cost=0.10),
+             "cost_normalized": {"currency": "USD", "total_cost": 0.10,
+                                 "source": "provider_reported"}},
+            {**self._row("m2", True, 5), "cost_normalized": {"source": "missing"}},
+        ]
+        out = sb.merge_cross_judge_rows(rows)
+        self.assertIsNone(out["cost_usd"])
+        self.assertEqual(out["cost_normalized"], {"source": "missing"})
+        self.assertEqual(out["cost_aggregate"]["USD"]["availability"], "partial")
+        self.assertEqual(out["cost_aggregate"]["USD"]["known_subtotal"], "0.1")
+        self.assertEqual(out["cost_aggregate"]["USD"]["unavailable_count"], 1)
 
     def test_panel_rejects_duplicate_models_and_mixed_task_ids(self):
         with self.assertRaises(ValueError):

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -190,6 +190,14 @@ class ClosedRunnerOutcomeTests(unittest.TestCase):
             with self.subTest(kwargs=kwargs), self.assertRaises((TypeError, ValueError)):
                 rc.OutcomeContext(**kwargs)
 
+    def test_context_rejects_derived_evidence_overrides(self):
+        for field in ("metadata_extra", "metrics_extra"):
+            with self.subTest(field=field), self.assertRaisesRegex(ValueError, "derived evidence"):
+                rc.OutcomeContext(
+                    provider="codex",
+                    **{field: {"trace_observation_complete": True}},
+                )
+
     def test_context_and_outcome_are_recursively_immutable(self):
         source = {"x": 1, "nested": {"value": 2}, "items": [{"value": 3}]}
         context = rc.OutcomeContext(provider="codex", metadata_extra=source)
@@ -486,9 +494,10 @@ class RunnerOutcomeContractTests(unittest.TestCase):
             sb.write_runner_outcome(base, outcome)
             meta = json.loads((base / "metadata.json").read_text(encoding="utf-8"))
             text = (base / "output.md").read_text(encoding="utf-8")
-            self.assertEqual(meta["returncode"], 1)
+            self.assertEqual(meta["returncode"], 0)  # actual process exit is preserved
+            self.assertFalse(meta["provider_response_complete"])
             self.assertNotIn(trace, text)
-            self.assertFalse(sb.execution_valid(meta, text))
+            self.assertFalse(sb.execution_valid(sb.read_metadata_base(base), text))
 
     def test_write_runner_outcome_encodes_timeout_uniformly(self):
         # One timeout encoding for every provider: timed_out + returncode 124, a
@@ -504,6 +513,54 @@ class RunnerOutcomeContractTests(unittest.TestCase):
             self.assertTrue(text.lstrip().startswith(am.CLAUDE_FAILURE))
             self.assertNotIn("None", text)
             self.assertFalse(am.execution_valid(meta, text))
+
+    def test_atomic_run_replacement_drops_stale_provider_artifacts(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td) / "run"
+            sb.write_runner_outcome(
+                base, am.RunnerOutcome(provider="subagent", answer="first", returncode=0,
+                                       trace_text=json.dumps({"type": "usage", "usage": {"input_tokens": 1}})))
+            self.assertTrue((base / "trace.jsonl").exists())
+            (base / "grading.json").write_text("stale", encoding="utf-8")
+            sb.write_runner_outcome(
+                base, am.RunnerOutcome(provider="subagent", answer="second", returncode=0))
+            self.assertEqual((base / "output.md").read_text(encoding="utf-8"), "second")
+            self.assertFalse((base / "trace.jsonl").exists())
+            self.assertFalse((base / "grading.json").exists())
+            self.assertTrue(sb.read_metadata_base(base)["artifact_set_complete"])
+
+    def test_atomic_run_replacement_restores_previous_commit_on_install_failure(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td) / "run"
+            sb.write_runner_outcome(
+                base, am.RunnerOutcome(provider="subagent", answer="old", returncode=0))
+            real_replace = os.replace
+
+            def fail_stage_install(src, dst):
+                if ".artifact-stage-" in Path(src).name and Path(dst) == base:
+                    raise OSError("simulated install failure")
+                return real_replace(src, dst)
+
+            with mock.patch.object(sb.os, "replace", side_effect=fail_stage_install), \
+                 self.assertRaisesRegex(OSError, "install failure"):
+                sb.write_runner_outcome(
+                    base, am.RunnerOutcome(provider="subagent", answer="new", returncode=0))
+            self.assertEqual((base / "output.md").read_text(encoding="utf-8"), "old")
+            self.assertTrue(sb.read_metadata_base(base)["artifact_set_complete"])
+
+    def test_artifact_commit_is_required_and_detects_post_commit_mutation(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td) / "run"
+            sb.write_runner_outcome(
+                base, am.RunnerOutcome(provider="subagent", answer="hi", returncode=0))
+            text = (base / "output.md").read_text(encoding="utf-8")
+            committed = sb.read_metadata_base(base)
+            self.assertTrue(committed["artifact_set_complete"])
+            self.assertTrue(am.execution_valid(committed, text))
+            (base / "output.md").write_text("tampered", encoding="utf-8")
+            tampered = sb.read_metadata_base(base)
+            self.assertFalse(tampered["artifact_set_complete"])
+            self.assertFalse(am.execution_valid(tampered, "tampered"))
 
     def test_write_runner_outcome_marks_missing_telemetry_explicit(self):
         # No provider usage/cost and no trace → explicit missing, never zero/absent.
@@ -540,8 +597,9 @@ class RunnerOutcomeContractTests(unittest.TestCase):
             self.assertNotIn("LEAKED FROM TRACE", text)
             self.assertTrue(text.lstrip().startswith(am.CLAUDE_FAILURE))
             meta = json.loads((base / "metadata.json").read_text(encoding="utf-8"))
-            self.assertEqual(meta["returncode"], 1)
-            self.assertFalse(am.execution_valid(meta, text))
+            self.assertEqual(meta["returncode"], 0)  # protocol failure does not rewrite process evidence
+            self.assertFalse(meta["provider_response_complete"])
+            self.assertFalse(am.execution_valid(sb.read_metadata_base(base), text))
 
     def test_run_agent_dispatches_registered_vibe_backend(self):
         with tempfile.TemporaryDirectory() as td:
@@ -623,6 +681,8 @@ class RunnerOutcomeContractTests(unittest.TestCase):
         self.assertEqual(sb.normalize_usage(usage, source="provider_reported")["total_tokens"], 3)
         streaming = json.dumps({"role": "assistant", "content": "streamed"}) + "\n"
         self.assertEqual(sb.vibe_final_answer(sb.parse_vibe_messages(streaming)), "streamed")
+        self.assertEqual(sb.vibe_final_answer([{"role": "tool", "content": "trace only"}]), "")
+        self.assertEqual(sb.vibe_final_answer([{"role": "assistant", "content": {"error": "bad shape"}}]), "")
 
     def test_vibe_missing_binary_uses_vibe_failure_marker(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_skill_benchmark.py
+++ b/tests/test_skill_benchmark.py
@@ -626,8 +626,15 @@ class SkillBenchmarkTests(unittest.TestCase):
                 base = runs / "case-1" / variant
                 base.mkdir(parents=True)
                 (base / "output.md").write_text("alpha beta", encoding="utf-8")
-                sb.write_trace_artifacts(base, json.dumps({"type": "message", "role": "assistant", "content": "done"}),
-                                         source="test", extra_metrics={"skill_invoked": invoked, "skill_invocation_evidence": [variant] if invoked else []}, write_metadata=True)
+                sb.write_trace_artifacts(
+                    base, json.dumps({"type": "message", "role": "assistant", "content": "done"}),
+                    source="test",
+                    extra_metrics={"skill_invoked": invoked,
+                                   "skill_invocation_evidence": [variant] if invoked else []},
+                    write_metadata=True,
+                    process_observation_complete=True,
+                    provider_response_complete=True,
+                )
             report = sb.build_benchmark_report(manifest, runs)
             by_variant = {r["variant"]: r for r in report["results"]}
             self.assertEqual(by_variant["with_skill"]["objective_total"], 1)

--- a/tests/test_smoke_supported_clis.py
+++ b/tests/test_smoke_supported_clis.py
@@ -79,9 +79,20 @@ class SupportedCliSmokeTests(unittest.TestCase):
                 "metadata": {
                     "observation_complete": True,
                     "trace_observation_complete": False,
-                    "telemetry": {"schema_version": 3, "measurements": {
-                        key: {"availability": availability} for key in trace_keys
-                    }},
+                    "telemetry": {
+                        "schema_version": 3,
+                        "observation_evidence": {
+                            "schema_version": 1,
+                            "process": {"state": "complete"},
+                            "provider_response": {"state": "complete"},
+                            "trace": {"state": "incomplete"},
+                            "artifact_set": {"state": "complete"},
+                            "operation_evidence_complete": False,
+                        },
+                        "measurements": {
+                            key: {"availability": availability} for key in trace_keys
+                        },
+                    },
                 },
             }
 

--- a/tests/test_telemetry_domain.py
+++ b/tests/test_telemetry_domain.py
@@ -13,11 +13,69 @@ from telemetry import (
     Comparison,
     Measurement,
     Money,
+    ObservationEvidence,
+    EVIDENCE_COMPLETE,
+    EVIDENCE_INCOMPLETE,
+    EVIDENCE_UNKNOWN,
     aggregate_money_by_currency,
     aggregate_numeric,
     compare_cost_pair,
     lift_per_dollar,
+    measurement_from_envelope_or_nonnegative,
 )
+
+
+class ObservationEvidenceTests(unittest.TestCase):
+    def test_full_state_product_never_promotes_an_independent_axis(self):
+        states = (EVIDENCE_COMPLETE, EVIDENCE_INCOMPLETE, EVIDENCE_UNKNOWN)
+        for process in states:
+            for provider in states:
+                for trace in states:
+                    for artifacts in states:
+                        with self.subTest(process=process, provider=provider,
+                                          trace=trace, artifacts=artifacts):
+                            evidence = ObservationEvidence(process, provider, trace, artifacts)
+                            self.assertEqual(
+                                evidence.operation_complete,
+                                process == provider == trace == EVIDENCE_COMPLETE,
+                            )
+                            self.assertEqual(
+                                evidence.artifact_complete,
+                                artifacts == EVIDENCE_COMPLETE,
+                            )
+                            self.assertEqual(
+                                ObservationEvidence.from_dict(evidence.to_dict()), evidence)
+
+    def test_wire_cannot_override_derived_operation_completeness(self):
+        wire = ObservationEvidence(
+            EVIDENCE_COMPLETE, EVIDENCE_INCOMPLETE,
+            EVIDENCE_COMPLETE, EVIDENCE_COMPLETE).to_dict()
+        wire["operation_evidence_complete"] = True
+        with self.assertRaisesRegex(ValueError, "contradicts"):
+            ObservationEvidence.from_dict(wire)
+
+    def test_legacy_generic_completion_cannot_certify_process_or_trace(self):
+        evidence = ObservationEvidence.from_run({"observation_complete": True})
+        self.assertEqual(evidence.provider_response, EVIDENCE_COMPLETE)
+        self.assertEqual(evidence.process, EVIDENCE_UNKNOWN)
+        self.assertEqual(evidence.trace, EVIDENCE_UNKNOWN)
+        self.assertFalse(evidence.operation_complete)
+
+    def test_available_operation_scalar_cannot_override_incomplete_evidence(self):
+        evidence = ObservationEvidence(
+            EVIDENCE_COMPLETE, EVIDENCE_INCOMPLETE,
+            EVIDENCE_COMPLETE, EVIDENCE_COMPLETE)
+        raw = {"telemetry": {
+            "schema_version": 3,
+            "observation_evidence": evidence.to_dict(),
+            "measurements": {"commands": {
+                "availability": "available", "value": 0,
+                "provenance": "trace_normalized",
+            }},
+        }}
+        measurement = measurement_from_envelope_or_nonnegative(raw, "commands")
+        self.assertEqual(measurement.availability, "unavailable")
+        self.assertEqual(measurement.reason, "provider_response_incomplete")
 
 
 class MeasurementModelTests(unittest.TestCase):


### PR DESCRIPTION
## What

Prevent incomplete or malformed evidence from becoming valid answers, operation telemetry, verdicts, aggregate costs, or committed run artifacts.

## Why

The telemetry fix in v0.6.0 separated process success from trace completeness, but the same evidence-promotion pattern remained at adjacent boundaries. Independent facts could still certify one another: exit zero could promote malformed provider output, a partial panel could look fully costed, and individually valid files from different attempts could look like one complete run.

These failures are dangerous because they produce plausible measurements rather than obvious crashes.

## How

- Model process, provider-response, trace, and artifact-set evidence independently as `complete`, `incomplete`, or `unknown`.
- Require complete process, provider response, and trace evidence before exposing operation measurements.
- Treat legacy `observation_complete` as provider-response evidence only; it cannot establish process or trace provenance.
- Reserve derived evidence fields against caller overrides and preserve real subprocess return codes for protocol failures.
- Fail malformed Claude/Vibe output, failed Jetty trajectories, and schema-invalid judge verdicts closed.
- Keep incomplete panel costs as known subtotals and reject contradictory cached budget histories.
- Stage answer and Jetty run directories, write a SHA-256 inventory last, then atomically install the committed set with rollback.

The regression tests directly construct the previously accepted malformed states, including all 81 process × response × trace × artifact combinations, tampered inventories, stale files, and injected replacement failures.

## Testing

- [x] `./.venv/bin/python -m pytest -q` — **814 passed, 5 skipped, 374 subtests passed**
- [x] Python 3.10, 3.11, and 3.12 CI
- [x] Provider-shaped Claude, Vibe, Jetty, judge, and panel-cost regressions
- [x] Artifact tamper, stale-file replacement, and atomic rollback fault injection
- [x] Documentation link/reference guards and `git diff --check`
- [x] Wheel/sdist build and `twine check`

No paid live smoke was rerun; deterministic provider-shaped fixtures cover the changed wire boundaries.

## Risk

This intentionally tightens acceptance at shared runner, telemetry, judge, budget, and artifact-read boundaries. Legacy artifacts remain readable, but absent evidence now stays unknown instead of inheriting a generic success flag. Judge `schema_enforcement: report` still records diagnostics but no longer allows malformed verdicts to pass.

Current answer and Jetty writers add `artifact-commit.json`. The inventory covers the producer-owned artifact set; downstream files such as `grading.json` do not invalidate it. Atomic replacement retains the last committed run if installation fails.
