### PR TITLE
Update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
         python-version: ['3.10', '3.11', '3.12']
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Check out release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.release.tag_name || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## What

- Upgrade `actions/checkout` from `v4` to `v7` in CI and publishing.
- Upgrade `actions/setup-python` from `v5` to `v7` in CI and publishing.

## Why

PR #51's successful CI run emitted deprecation annotations because the old action majors target Node.js 20 and GitHub now forces them onto Node.js 24. The official `v7` manifests for both actions declare the Node.js 24 runtime, removing that compatibility warning instead of relying on GitHub's fallback.

- [`actions/checkout` v7.0.1](https://github.com/actions/checkout/releases/tag/v7.0.1)
- [`actions/setup-python` v7.0.0](https://github.com/actions/setup-python/releases/tag/v7.0.0)

## Testing

- Parsed every `.github/workflows/*.yml` file with PyYAML.
- Ran `git diff --check`.
- The PR's CI matrix exercises checkout and Python setup on Python 3.10, 3.11, and 3.12.

## Risk

Low: this is a four-line workflow-only change using the maintained major tags. The release-triggered PyPI workflow cannot be exercised safely from a pull request, so this PR validates its YAML and the same checkout/setup sequence through CI but does not publish a package.

No rendered or user-interface output changes.
