### PR TITLE
Automatically type-check every project module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,11 @@ python3 -m unittest discover tests -v
 
 (`pytest tests/` also works — `pyproject.toml` carries the pythonpath config — but CI runs `unittest discover`, so keep tests compatible with both.)
 
-`ty check` covers the central CLI plus the type-clean contract and registry modules listed in `pyproject.toml`. Keep new boundary modules in that gate; do not hide diagnostics behind broad rule exclusions, file exclusions, blanket ignores, or unsafe casts.
+`ty check` automatically covers every project-owned top-level Python module plus
+the static contracts under `type_tests/`. A new top-level boundary module enters
+the gate without another registry edit. Keep those contracts precise and do not
+hide diagnostics behind broad rule exclusions, file exclusions, blanket ignores,
+or unsafe casts.
 
 Tests are organized by subject — put new tests where their subject lives: manifest validation/hygiene in `tests/test_manifest.py`, grading in `tests/test_grading.py`, typed domain invariants in the corresponding `tests/test_*_contracts.py`, judge plumbing in `tests/test_judging.py`, report views in `tests/test_reporting.py`, statistics in `tests/test_stats.py`, runner adapters in `tests/test_runners.py`, ablations in `tests/test_ablations.py`, cost telemetry in `tests/test_cost_telemetry.py`, and the CLI/report grab-bag in `tests/test_skill_benchmark.py`. Build fixtures through `tests/helpers.py` (`make_eval_repo`, `write_run`, `result_row`, `stub_claude`) instead of hand-rolling repo/manifest/run-dir scaffolding — the suite once carried ~25 drifting copies of the same builder. If you add a CLI subcommand or assertion type, `tests/test_consolidation_guards.py` will fail until the README documents it; if you move code that docs cite by line, `tests/test_doc_refs.py` tells you the correct numbers and `python3 scripts/fix_doc_refs.py` rewrites them in place; if you add or move a doc and leave a relative link dangling, `tests/test_doc_links.py` fails. The confidence floor (detector fixtures under `tests/fixtures/detectors/`, baseline isolation, idempotence, the no-model/no-network guard) lives in `tests/test_confidence_floor.py` — a new objective assertion type must ship its should-fire/should-pass fixture pair, and a new runner must register its workspace builder.
 

--- a/docs/correctness-by-construction-audit.md
+++ b/docs/correctness-by-construction-audit.md
@@ -309,11 +309,12 @@ raw output string
   the same human-text view, including minimum-length and non-vacuity decisions. Protocol and
   machine-identity checks (`golden_output` by default, structured JSON, scripts, command text, tool
   names, and paths) remain exact; graded script scores still cross a finite 0-1 numeric boundary.
-- The project's focused `ty` gate includes `text_contracts.py`, so this module's constructors,
-  closed assertion union, and return types are statically checked without suppressions. That gate
-  complements rather than replaces runtime parsing: manifest dictionaries and external
-  embedding/script values remain untrusted wire data, while the legacy `skill_benchmark.py`
-  integration is not yet in ty's configured source set.
+- The project's `ty` gate automatically includes every project-owned top-level Python module,
+  including `text_contracts.py` and `skill_benchmark.py`, plus explicit static contract assertions
+  under `type_tests/`. Constructors, closed unions, return types, and exhaustive consumers are
+  therefore checked without a per-module registration step. That gate complements rather than
+  replaces runtime parsing: manifest dictionaries and external embedding/script values remain
+  untrusted wire data.
 
 ## Ablation provenance vocabulary
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,28 +45,9 @@ py-modules = ["skill_benchmark", "run_pi_trigger_eval", "run_trigger_matrix", "a
 pythonpath = ["."]
 
 [tool.ty.src]
-# Project-owned source gate for the central CLI and its type-clean contract,
-# registry, runner, telemetry, and observability seams.
-include = [
-  "agent_capabilities.py",
-  "ablation_model.py",
-  "experimental_pairs.py",
-  "gemini_contracts.py",
-  "jetty_contracts.py",
-  "judge_contracts.py",
-  "judge_verdict.py",
-  "json_contracts.py",
-  "run_pi_trigger_eval.py",
-  "run_trigger_matrix.py",
-  "runner_contracts.py",
-  "skill_benchmark.py",
-  "telemetry.py",
-  "trace_contracts.py",
-  "text_contracts.py",
-  "observability.py",
-  "trigger_contracts.py",
-  "trigger_reporting.py",
-]
+# Every project-owned top-level module is checked automatically. Type-only
+# contract assertions pin the precision and exhaustiveness of closed domains.
+include = ["*.py", "type_tests/*.py"]
 
 [tool.ruff]
 required-version = "==0.16.0"

--- a/tests/test_skill_benchmark.py
+++ b/tests/test_skill_benchmark.py
@@ -29,7 +29,8 @@ class SkillBenchmarkTests(unittest.TestCase):
     def test_central_cli_remains_in_the_project_ty_gate(self):
         project = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
         ty_sources = project.split("[tool.ty.src]", 1)[1].split("\n[", 1)[0]
-        self.assertIn('"skill_benchmark.py"', ty_sources)
+        self.assertIn('"*.py"', ty_sources)
+        self.assertIn('"type_tests/*.py"', ty_sources)
         self.assertNotIn("check_ty_regressions", project)
 
     def test_infra_failure_excluded_from_every_report_view(self):

--- a/tests/test_text_contracts.py
+++ b/tests/test_text_contracts.py
@@ -40,7 +40,7 @@ class ComparisonTextConstructionTests(unittest.TestCase):
         packaged = project.split("[tool.setuptools]", 1)[1].split("\n[", 1)[0]
         ty_sources = project.split("[tool.ty.src]", 1)[1].split("\n[", 1)[0]
         self.assertIn('"text_contracts"', packaged)
-        self.assertIn('"text_contracts.py"', ty_sources)
+        self.assertIn('"*.py"', ty_sources)
         self.assertIn('"regex==2026.7.19"', project)
 
     def test_rendered_v1_removes_issue_55_character_and_records_it(self):

--- a/type_tests/abstraction_contracts.py
+++ b/type_tests/abstraction_contracts.py
@@ -1,0 +1,89 @@
+"""Static contracts for the harness's closed domain values.
+
+This module is checked by ``ty`` but is not imported by the runtime or packaged.
+The functions deliberately have no callers: their bodies prove that every
+current union can be narrowed exhaustively and that its public fields retain
+the intended precise types.
+"""
+
+from typing import NoReturn
+
+from judge_verdict import (
+    BooleanVerdict,
+    ConsensusVerdict,
+    DimensionVerdict,
+    DynamicVerdict,
+    JudgeVerdict,
+    ScoredVerdict,
+)
+from runner_contracts import (
+    AnswerOutcome,
+    Completed,
+    ProviderFailed,
+    SpawnFailed,
+    TimedOut,
+)
+from trigger_contracts import (
+    CompleteTriggerResult,
+    IncompleteTriggerResult,
+    TriggerResult,
+)
+from trigger_reporting import (
+    CompleteTriggerCohort,
+    EmptyTriggerCohort,
+    IncompleteTriggerCohort,
+    TriggerCohort,
+)
+
+
+def _assert_never(value: NoReturn) -> NoReturn:
+    raise AssertionError(f"unhandled closed-domain value: {value!r}")
+
+
+def answer_outcome_is_exhaustive(outcome: AnswerOutcome) -> None:
+    if isinstance(outcome, Completed):
+        _answer: str = outcome.answer
+    elif isinstance(outcome, TimedOut):
+        _timeout_s: int | None = outcome.timeout_s
+    elif isinstance(outcome, SpawnFailed):
+        _reason: str = outcome.reason
+    elif isinstance(outcome, ProviderFailed):
+        _returncode: int = outcome.returncode
+    else:
+        _assert_never(outcome)
+
+
+def trigger_result_is_exhaustive(result: TriggerResult) -> None:
+    if isinstance(result, CompleteTriggerResult):
+        _passed: bool = result.passed
+        _triggered: bool = result.triggered
+    elif isinstance(result, IncompleteTriggerResult):
+        _state: str = result.state.value
+    else:
+        _assert_never(result)
+
+
+def trigger_cohort_is_exhaustive(cohort: TriggerCohort) -> None:
+    if isinstance(cohort, CompleteTriggerCohort):
+        _pass_rate: float = cohort.pass_rate
+    elif isinstance(cohort, IncompleteTriggerCohort):
+        _total: int = cohort.total
+    elif isinstance(cohort, EmptyTriggerCohort):
+        _empty: EmptyTriggerCohort = cohort
+    else:
+        _assert_never(cohort)
+
+
+def judge_verdict_is_exhaustive(verdict: JudgeVerdict) -> None:
+    if isinstance(verdict, BooleanVerdict):
+        _boolean_passed: bool = verdict.passed
+    elif isinstance(verdict, ScoredVerdict):
+        _score: float = verdict.score
+    elif isinstance(verdict, DimensionVerdict):
+        _dimension_score: float = verdict.score
+    elif isinstance(verdict, DynamicVerdict):
+        _dynamic_passed: bool = verdict.passed
+    elif isinstance(verdict, ConsensusVerdict):
+        _consensus_passed: bool = verdict.passed
+    else:
+        _assert_never(verdict)


### PR DESCRIPTION
## Summary

- make `ty` automatically check every project-owned top-level Python module
- add type-only exhaustiveness contracts for the harness's closed outcome, trigger, cohort, and judge domains
- document the automatic coverage rule and keep its configuration under test

This is the first migration layer and the safety net for the rest of the `ty` stack. It is stacked on #71 because every later layer also includes that provider boundary work.

## Why

The previous hand-maintained module list could silently omit a new abstraction from static analysis. The glob turns coverage into the default, while `type_tests/` pins exact field types and exhaustive consumers without adding runtime or package behavior.

## Risk

The intended tradeoff is stricter CI: adding a top-level Python module with type errors now fails `ty check` immediately. Runtime behavior, CLI output, report schemas, and packaging are unchanged.

## Testing

- `.venv/bin/ty check`
- `.venv/bin/ruff check .`
- `.venv/bin/python -m py_compile *.py examples/adewale-workspace/*.py type_tests/*.py`
- `.venv/bin/python -m unittest discover -s tests -q` — 1,217 tests passed, 7 skipped
- `python scripts/fix_doc_refs.py --check`
- `git diff --check`
