### PR TITLE
Type prepared task identities

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -71,7 +71,7 @@ Jetty runbooks emit a standardized machine-readable `validation_report.json` per
 (`jettyio/jettyio-skills`, `skills/create-runbook/SKILL.md`). Rubric evaluation scores 3-7
 dimensions on a 1-5 scale; programmatic evaluation returns `PASS` / `PARTIAL` / `FAIL`. The
 items below map that report onto the harness judge-result row `{judge_task_id, passed, score,
-threshold, evidence}` (`load_judge_results:11619`, merged in `grade_case_variant:13880`).
+threshold, evidence}` (`load_judge_results:11640`, merged in `grade_case_variant:13901`).
 
 - [ ] Export qualitative judge tasks to Jetty workflows using `simple_judge` where useful.
       Carry `judge_task_id` (`case::variant::run-n::assertion`) into the Jetty task so the

--- a/ablation_model.py
+++ b/ablation_model.py
@@ -40,6 +40,14 @@ from typing import Any
 
 from agent_capabilities import BACKENDS
 from json_contracts import freeze_json_value
+from manifest_contracts import (
+    ABLATION_VARIANT_PREFIX,
+    CaseKind,
+    ExecutionVariant,
+    Split,
+    ablation_id_of,
+    is_ablation_variant,
+)
 
 
 def _require(d: dict[str, Any], key: str, types: type | tuple[type, ...], ctx: str) -> Any:
@@ -192,22 +200,6 @@ class EvidenceClass(str, Enum):
     @property
     def is_confirmation(self) -> bool:
         return self is EvidenceClass.CONFIRMED_CAUSAL
-
-
-# The `ablation:<id>` variant-name encoding. These two helpers are the ONLY
-# reading of that prefix — every consumer (variant instructions, prepared rows,
-# cost ledgers, audits) routes through them instead of re-spelling
-# `variant.split(":", 1)[1]` inline (~14 copies before this owner existed).
-ABLATION_VARIANT_PREFIX = "ablation:"
-
-
-def is_ablation_variant(variant: Any) -> bool:
-    return str(variant).startswith(ABLATION_VARIANT_PREFIX)
-
-
-def ablation_id_of(variant: Any) -> str | None:
-    """The <id> of an `ablation:<id>` variant name, else None."""
-    return str(variant).split(":", 1)[1] if is_ablation_variant(variant) else None
 
 
 # The evidence label a whole autonomous-trigger REPORT carries. Per-row
@@ -678,9 +670,9 @@ class PreparedTask:
     dict is the only thing that crosses to disk — the type is the in-process owner."""
 
     case_id: str
-    split: str
-    kind: str
-    variant_truth: str
+    split: Split
+    kind: CaseKind
+    variant_truth: ExecutionVariant
     run_number: int
     skill_name: str
     repo_root: str
@@ -696,22 +688,19 @@ class PreparedTask:
     skill_root_keys: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "split", Split.parse(self.split))
+        object.__setattr__(self, "kind", CaseKind.parse(self.kind))
+        object.__setattr__(self, "variant_truth", ExecutionVariant.parse(self.variant_truth))
         for label, value in (("case_id", self.case_id), ("kind", self.kind),
                              ("skill_name", self.skill_name), ("repo_root", self.repo_root),
                              ("run_dir", self.run_dir)):
             if not isinstance(value, str) or not value.strip():
                 raise ValueError(f"PreparedTask.{label} must be non-empty")
-        if self.split not in {"tune", "holdout", "holdback"}:
-            raise ValueError("PreparedTask.split must be tune, holdout, or holdback")
         if (isinstance(self.run_number, bool) or not isinstance(self.run_number, int)
                 or self.run_number < 1):
             raise ValueError("PreparedTask.run_number must be a positive integer")
         if self.kind == "trigger":
             raise ValueError("PreparedTask is answer-population only; trigger cases use autonomous runners")
-        if not isinstance(self.variant_truth, str) or not self.variant_truth:
-            raise ValueError("PreparedTask.variant must be non-empty")
-        if self.variant_truth not in {"with_skill", "without_skill", "old_skill"} and not is_ablation_variant(self.variant_truth):
-            raise ValueError("PreparedTask.variant is not a supported execution arm")
         run_path = Path(self.run_dir)
         if run_path.is_absolute() or run_path == Path(".") or ".." in run_path.parts:
             raise ValueError("PreparedTask.run_dir must be a safe non-root relative path")
@@ -778,10 +767,10 @@ class PreparedTask:
         return self._experiment_arm().blind
 
     # --- model-facing surface (blinded) ---
-    def model_facing_variant(self) -> str:
+    def model_facing_variant(self) -> ExecutionVariant:
         """The variant the model may see: with_skill for a blind (materialized) arm,
         otherwise the true variant (instruction-simulated tells the model what to do)."""
-        return self._experiment_arm().model_visible_variant()
+        return ExecutionVariant.parse(self._experiment_arm().model_visible_variant())
 
     def upload_token(self) -> str:
         """Opaque, deterministic token for any ablation (path hygiene): a
@@ -834,9 +823,9 @@ class PreparedTask:
         ctx = "PreparedTask row"
         return cls(
             case_id=_require(row, "case_id", str, ctx),
-            split=_require(row, "split", str, ctx),
-            kind=row.get("kind", "behavior"),
-            variant_truth=str(row.get("variant")),
+            split=Split.parse(_require(row, "split", str, ctx)),
+            kind=CaseKind.parse(row.get("kind", "behavior")),
+            variant_truth=ExecutionVariant.parse(row.get("variant")),
             run_number=_require(row, "run_number", int, ctx),
             skill_name=_require(row, "skill_name", str, ctx),
             repo_root=_require(row, "repo_root", str, ctx),

--- a/docs/abstractions.md
+++ b/docs/abstractions.md
@@ -13,8 +13,8 @@ This is the **engineering lens** on the terms in [`vocabulary.md`](vocabulary.md
 |---|---|---|
 | Manifest | `validate_manifest` | The full test definition for one skill. |
 | Case | `iter_cases` | One scenario with a prompt and graders. |
-| Variant | `task_variants` | The arm a case runs under; the lift axis. |
-| Split | `VALID_SPLITS` | Which cases are visible during iteration. |
+| Variant | `manifest_contracts.ExecutionVariant` / `task_variants` | The arm a case runs under; the lift axis. |
+| Split | `manifest_contracts.Split` | Which cases are visible during iteration. |
 | Assertion | `assertion_result` | A single pass/fail check over one run. |
 | Prepared task row | `prepared_task_rows` | A runner-neutral unit of work. |
 | Run-output contract | `discover_run_bases` | The files a runner leaves on disk. |
@@ -51,6 +51,11 @@ case, so the variant axis is where skill effect becomes measurable. `variant_ins
 writes the per-arm instruction; the baseline must run from a workspace that cannot read the
 skill files, or the comparison means nothing.
 
+In process, every arm is an `ExecutionVariant`: a validated `str` subtype that closes the base
+vocabulary and owns the `ablation:<id>` encoding. It retains the existing JSON/path spelling, so
+the type strengthens the boundary without changing persisted artifacts. `task_variants` returns
+these typed values instead of unchecked strings.
+
 ## Split
 
 `tune`, `holdout`, and `holdback` label the intended evaluation phase. Tune cases are for
@@ -58,6 +63,11 @@ iteration; holdout is intended for end-of-round scoring; holdback is intended to
 skill/docs/eval descriptions until after scoring. The harness filters and reports these labels but
 does not provide access control—repositories and CI must keep private material private. `prepare` refuses to emit a hidden case with no
 `prompt_ref` unless you pass `--allow-missing-prompts` for dry-run planning.
+
+`Split` is the corresponding closed `str` subtype. `CaseKind` remains intentionally extensible
+for descriptive labels, but it owns the only structural classification the runners need:
+`answer` versus `trigger`. `PreparedTask.from_row` parses all three identity values at the wire
+boundary, and the executable task carries their precise types thereafter.
 
 ## Assertion
 
@@ -151,10 +161,10 @@ in the codebase.
 ## Runner / adapter
 
 An **answer runner** consumes prepared task rows and produces the run-output contract. The repo
-ships Pi answer smoke (`examples/adewale-workspace/run_pi_smoke.py`), Codex (`run_codex:10504`), Claude (`run_claude:10685`, capturing real
+ships Pi answer smoke (`examples/adewale-workspace/run_pi_smoke.py`), Codex (`run_codex:10525`), Claude (`run_claude:10706`, capturing real
 per-run cost), Gemini CLI and Mistral Vibe (`run-agent --agent gemini|vibe`, using isolated provider homes outside the workdir), the in-process
-subagent runner (`run_subagent:13225`, which hosts record/replay tool I/O via `ToolReplayStore`),
-Jetty (`JettyClient:3978` and the export/run/import commands), and any runner that writes the
+subagent runner (`run_subagent:13246`, which hosts record/replay tool I/O via `ToolReplayStore`),
+Jetty (`JettyClient:3999` and the export/run/import commands), and any runner that writes the
 contract directly. Each answer runner registers a workspace builder so one cross-runner invariant
 proves its `without_skill` arm is skill-free (CF.2). Autonomous trigger runners are separate: they
 read trigger cases from the manifest directly, never consume answer task rows, and emit trigger
@@ -223,7 +233,7 @@ those pairs; missing/ineligible arms remain in `pairing` diagnostics and duplica
 `build_slice_summary` breaks results down
 by domain, difficulty, trigger type, and success goal. Case flags mark saturated, no-lift,
 flaky, and with-skill-failed cases. These flags, the leakage lint
-(`prompt_assertion_leakage_findings:778`), and the split discipline are the part of the tool
+(`prompt_assertion_leakage_findings:789`), and the split discipline are the part of the tool
 no surveyed eval framework copies.
 
 ## What changes when you extend the tool

--- a/docs/eval-framework-roadmap-spec.md
+++ b/docs/eval-framework-roadmap-spec.md
@@ -17,7 +17,7 @@ One invariant governs every item: core grading stays local and deterministic and
 model, and the harness never picks a model for the user. Anything that needs a model lives
 behind an opt-in command or the external `--judge-cmd`. Two abstractions absorb most of the
 work, so the spec returns to them often: the assertion result shape in `assertion_result`
-(`skill_benchmark.py:11193`) and the fan-out in `prepared_task_rows` (`:1540`).
+(`skill_benchmark.py:11214`) and the fan-out in `prepared_task_rows` (`:1561`).
 
 ## Testing baseline
 
@@ -40,7 +40,7 @@ tests are where that claim is checked rather than trusted.
 
 The buckets below extend what the harness can measure. This floor decides whether the number it
 already prints can be believed. The harness reports one thing: lift, `with_skill` minus
-`without_skill` on the same case (`build_paired_summary` (`:15320`)). That number is believable only
+`without_skill` on the same case (`build_paired_summary` (`:15341`)). That number is believable only
 when three preconditions hold, each intended today, none enforced, and each restating a claim from
 `evals-are-not-tests.md`:
 
@@ -60,22 +60,22 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
   hiding the quantity the tool exists to measure.
 - **Abstractions used or changed:** none in the engine. Adds
   `tests/fixtures/detectors/<detector_id>/should-fire.*` and `should-pass.*` that exercise
-  `assertion_result` (`:11193`) directly. That function has no direct unit test today, and its
+  `assertion_result` (`:11214`) directly. That function has no direct unit test today, and its
   `contains_any`, `excludes_any`, and `not_regex` branches go unexercised even though their types
-  are declared in the assertion registries (`TEXT_ASSERTIONS:175`).
+  are declared in the assertion registries (`TEXT_ASSERTIONS:182`).
 - **Design:** one table-driven test loads every pair and asserts the detector fires on `should-fire`
   and stays silent on `should-pass`. A `should-pass` twin is mandatory: it enforces the
   false-positive bar `authoring-evals.md` already sets for skill authors ("check both presence and
   absence"). Each `should-pass` set includes a case where the baseline echoes the prompt, because a
   detector that passes on echoed prompt text is a false oracle; this ties the fixtures to leakage
-  lint (`prompt_assertion_leakage_findings` (`:778`)). Every detector bug then becomes a permanent
+  lint (`prompt_assertion_leakage_findings` (`:789`)). Every detector bug then becomes a permanent
   fixture pair, and `test_command_assertions_match_command_inputs_not_outputs` is the first.
 - **Why it is the keystone:** the fixture pair is also the registration contract. It is what lets a
   harvested or third-party detector be trusted on entry, so it gates the exapted detector library
   (TODO, end of 2026), and it raises the oracle-strength ladder (1.7) so that "strong" means
   fixture-verified, not only deterministic.
 - **Testing:** the fixtures are the test. A meta-test asserts every name in `OBJECTIVE_ASSERTIONS`
-  (`:212`) has a fixture pair, so a new detector cannot land unverified.
+  (`:219`) has a fixture pair, so a new detector cannot land unverified.
 
 ### CF.2 — One cross-runner baseline-isolation invariant
 - **Goal:** prove the baseline is skill-free by construction, so a measured lift is the skill's
@@ -101,7 +101,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 ### CF.4 — A guard that the core grade path calls no model and no network
 - **Goal:** make the governing invariant — "core grading stays local and deterministic and never
   calls a model" — executable rather than aspirational.
-- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:13880`).
+- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:13901`).
 - **Design:** patch `urllib` and `subprocess` to raise, then grade a fixture covering every
   objective family (text, process, efficiency) and assert it completes. The sanctioned exceptions —
   `script` oracles and `judge` plumbing — are excluded from this path by design and keep their own
@@ -111,7 +111,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 
 ### Boundary
 The set stops here deliberately. Report-level correctness — whether the saturation, no-lift, flaky,
-and negative-delta flags (`build_benchmark_report` (`:16730`)) are computed right — sits a layer
+and negative-delta flags (`build_benchmark_report` (`:16751`)) are computed right — sits a layer
 above the raw measurement, where the golden-report tests the buckets already plan (1.2, 2.6) cover
 it. CF.1–CF.4 are the floor underneath that work: once they pass, a printed lift carries a checked
 measurement, and every feature in the buckets builds on a number that has been verified rather than
@@ -125,9 +125,9 @@ assumed.
 - **Goal:** ship graders authors reach for often, so they stop hand-rolling rubrics.
 - **Abstractions used or changed:** `tool_call` and `structured_output` are deterministic, so
   they become new types in `TEXT_ASSERTIONS` / `PROCESS_ASSERTIONS` and gain a branch in
-  `assertion_result`. `tool_call` reuses `command_events` (`:6373`) and the `command_order`
+  `assertion_result`. `tool_call` reuses `command_events` (`:6394`) and the `command_order`
   logic; `structured_output` extends `json_field_equals` with JSON-Schema validation.
-  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:11776`) renders
+  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:11797`) renders
   and still runs through `--judge-cmd`.
 - **Design:** a preset expands to either a deterministic objective assertion or a `judge`
   assertion with a canned rubric and threshold. No new execution path.
@@ -146,7 +146,7 @@ assumed.
 ### 1.3 Judge config slot and the "judge is not the model under test" guard
 - **Goal:** make an existing convention enforceable.
 - **Abstractions used or changed:** read an optional `judge` block in the manifest; add a check
-  in `audit_manifest_report` (`:19547`) comparing the declared judge model against `jetty.model`
+  in `audit_manifest_report` (`:19568`) comparing the declared judge model against `jetty.model`
   or the run metadata `model`.
 - **Design:** warn by default, error under `--strict-judge`.
 - **Testing:** unit tests for matching and differing model ids.
@@ -163,7 +163,7 @@ assumed.
 - **Status:** `docs/authoring-evals.md` shipped, alongside `architecture.md` and
   `abstractions.md`.
 - **Follow-on:** surface the guide's rules where they are checkable. Extend the messaging in
-  `prompt_assertion_leakage_findings` (`:778`) and `fixture_recommendations` (`:19240`) to point
+  `prompt_assertion_leakage_findings` (`:789`) and `fixture_recommendations` (`:19261`) to point
   at the relevant section.
 - **Testing:** assert the new hint strings appear for crafted manifests.
 
@@ -172,8 +172,8 @@ assumed.
   In `adewale/pythonbyexample` and `adewale/xampler` an example *is* an eval case: an input, an
   expected output, and a check that the output still matches. The harness has no equivalent of
   "this output equals this reference."
-- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:175`), implemented in
-  `assertion_result` (`:11193`). It reads `output.md` (or a named artifact), applies an optional
+- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:182`), implemented in
+  `assertion_result` (`:11214`). It reads `output.md` (or a named artifact), applies an optional
   normalization (trim, collapse whitespace, or a named normalizer), and compares to a reference
   file under the manifest dir. Evidence is a unified diff on mismatch.
 - **Design:** normalization is the whole game, so it is explicit and per-assertion, never
@@ -188,9 +188,9 @@ assumed.
   not name it.
 - **Abstractions used or changed:** an optional `oracle` tier on an assertion
   (`strong` / `demo` / `live`), defaulting by type (deterministic text/process are `strong`,
-  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:16730`)
+  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:16751`)
   reports, per case, the share of its pass rate carried by `strong` oracles;
-  `audit_manifest_report` (`:19547`) warns when a case passes only on weak ones. This extends
+  `audit_manifest_report` (`:19568`) warns when a case passes only on weak ones. This extends
   leakage lint (`:164`) from prompts to oracles.
 - **Strongest tier — the rendered-artifact oracle:** the top of the ladder is an oracle that
   builds or renders the artifact and inspects the result, not the source text.
@@ -205,8 +205,8 @@ assumed.
   splits "good poster" into seven `script` oracles, but each is forced all-or-nothing by the
   exit-code-only contract: a poster with six of seven drama carriers fails `drama_oracle` exactly
   like one with zero. That is the binary-saturation problem inside a single oracle.
-- **Abstractions used or changed:** extend `run_script_assertion` (`:11061`) and
-  `assertion_result` (`:11193`) to optionally parse a score from the oracle's stdout — a JSON line
+- **Abstractions used or changed:** extend `run_script_assertion` (`:11082`) and
+  `assertion_result` (`:11214`) to optionally parse a score from the oracle's stdout — a JSON line
   such as `{"score": 6, "max_score": 7}` (normalized to 0-1) — beside the existing
   `pass_exit_code`. The parsed score flows into the `score`/`severity` channel from 2.2, so a
   script oracle becomes a graded dimension while staying fully deterministic and model-free.
@@ -223,9 +223,9 @@ assumed.
   past it — either way, question it. This is the inverse of the saturation flag: saturation marks
   a case as too easy *now*; staleness marks a case that has never discriminated *over time*.
 - **Abstractions used or changed:** reads the cross-run history from 2.6. A `prune` report (or a
-  flag in `build_benchmark_report` (`:16730`)) marks a case a removal candidate when, across the
+  flag in `build_benchmark_report` (`:16751`)) marks a case a removal candidate when, across the
   last N runs, it never failed and never showed lift (`with_skill` == `without_skill` every time).
-  `audit_manifest_report` (`:19547`) lists the candidates; removal stays a human decision.
+  `audit_manifest_report` (`:19568`) lists the candidates; removal stays a human decision.
 - **Design:** the harness suggests, never deletes. A case may be kept deliberately as a
   regression guard even when stale; the report says so rather than acting.
 - **Depends on:** 2.6 (needs run history to judge "never failed over time").
@@ -239,12 +239,12 @@ assumed.
 ### 2.1 Multi-model fan-out (priority)
 - **Goal:** run the same cases across several models and compare lift per model. No surveyed
   framework does this; vitest-evals, eve, and viteval all push it onto the test runner.
-- **Abstractions used or changed:** `prepared_task_rows` (`:1540`) gains a `model` dimension
+- **Abstractions used or changed:** `prepared_task_rows` (`:1561`) gains a `model` dimension
   beside `variant` and `run_number`. Each row carries its target `model`, and `run_dir` gains a
   model segment (`<case>/<model>/<variant>/run-<n>`), kept backward-compatible when one model
   runs. Runners pass the row `model` through; per-run `model` already lands in `metadata.json`,
-  so grading needs no change. `build_benchmark_report` (`:16730`) groups `by_variant` within
-  `by_model`, and `build_paired_summary` (`:15320`) computes lift per (case, model).
+  so grading needs no change. `build_benchmark_report` (`:16751`) groups `by_variant` within
+  `by_model`, and `build_paired_summary` (`:15341`) computes lift per (case, model).
 - **Design:** model is a third axis, not a new variant. Variants stay orthogonal, giving a
   model-by-variant grid. CLI: `--models a,b,c` on `prepare`.
 - **Testing:** a fan-out test asserting row count equals cases × variants × runs × models with
@@ -261,7 +261,7 @@ assumed.
   no-regression floor. This spec ports those shapes into the harness rather than inventing new
   ones.
 - **Abstractions used or changed:**
-  - `assertion_result` (`:11193`) gains an optional `score` (0-1 or a normalized 1-5) and
+  - `assertion_result` (`:11214`) gains an optional `score` (0-1 or a normalized 1-5) and
     `severity` (`critical` / `gate` / `soft`), read from `critical`/`gate`/`soft`/`atLeast` on the
     assertion.
   - **`critical` (absorbing-barrier) tier — valley-dodging.** From the Jetty "valley-dodging"
@@ -276,13 +276,13 @@ assumed.
   - **Anchored `graded_dimensions`** as a `judge` assertion shape:
     `{name, scale: "1-5", rubric: "5 = …observable…; 1 = …observable…"}`. Anchors name what each
     score level looks like, so a judge scores against criteria, not a vibe. `judge_prompt`
-    (`:11776`) renders the dimensions; the result carries per-dimension scores in `evidence`.
+    (`:11797`) renders the dimensions; the result carries per-dimension scores in `evidence`.
   - **`dynamic_rubric`** as a second `judge` shape: `{instruction, minimum_criteria}`. The judge
     drafts 3-5 case-specific criteria before grading and must meet at least `minimum_criteria`.
-  - `grade_case_variant` (`:13880`) splits totals into critical, gated, and soft. A `critical`
+  - `grade_case_variant` (`:13901`) splits totals into critical, gated, and soft. A `critical`
     failure vetoes the case; a `gate` failure lowers the pass rate; a `soft` failure lowers
     neither and fills a `scored` bucket. A `--strict` flag promotes soft to gate.
-  - **Statistical lift** in `build_paired_summary` (`:15320`): alongside the raw delta, compute a
+  - **Statistical lift** in `build_paired_summary` (`:15341`): alongside the raw delta, compute a
     significance test over the per-case graded scores (paired bootstrap or sign-flip
     permutation, mirroring `score_delta.py`), so lift is tested, not eyeballed.
   - **Reference-anchor floor:** an optional `reference_score` / `reference_graded_score` on a
@@ -315,7 +315,7 @@ assumed.
 - **Goal:** deterministic re-runs that pay nothing for external dependencies, by recording tool
   inputs and outputs.
 - **Abstractions used or changed:** this lives in the runner, not core grading. Recording sits
-  beside `write_trace_artifacts` (`:8234`): a `tool-replay.json` keyed per tool, with
+  beside `write_trace_artifacts` (`:8255`): a `tool-replay.json` keyed per tool, with
   `sanitize` and `version`. Modes (`auto`, `record`, `off`, `strict`) come from an environment
   variable that `run_codex` and the Pi and subagent runners read.
 - **Design:** orthogonal to the disk re-grade the harness already does. Replay makes the agent
@@ -326,8 +326,8 @@ assumed.
 
 ### 2.4 OpenTelemetry GenAI normalization target
 - **Goal:** make the trace adapter boundary a standard rather than a bespoke schema.
-- **Abstractions used or changed:** `normalize_trace_record` (`:7291`) and
-  `normalize_trace_records` (`:7950`) keep their inputs but emit OTel GenAI semantic-key
+- **Abstractions used or changed:** `normalize_trace_record` (`:7312`) and
+  `normalize_trace_records` (`:7971`) keep their inputs but emit OTel GenAI semantic-key
   attributes; the `events.json` schema version bumps. Process and efficiency assertions read the
   new keys with backward-compatible fallbacks.
 - **Design:** additive schema. An old `events.json` still grades.
@@ -337,7 +337,7 @@ assumed.
 ### 2.5 Dataset abstraction
 - **Goal:** fan one case template over many rows instead of hand-authoring each case.
 - **Abstractions used or changed:** a new optional manifest construct (`datasets`, plus a case
-  `template` referencing a dataset id). `iter_cases` (`:589`) materializes template by row into
+  `template` referencing a dataset id). `iter_cases` (`:596`) materializes template by row into
   concrete cases before fan-out; `validate_manifest` validates rows and runs leakage lint per
   materialized case.
 - **Design:** materialization happens early, so prepare, grade, and report stay unchanged.
@@ -351,7 +351,7 @@ assumed.
 - **Goal:** watch lift, saturation, and token drift over time.
 - **Abstractions used or changed:** a consumer of `build_benchmark_report`. Add an append-only
   history store and a `trend` subcommand that diffs successive `benchmark.json` files, reusing
-  the `compare_results` (`:17912`) logic.
+  the `compare_results` (`:17933`) logic.
 - **Severity-weighted ranking (from the macro-evals notebook):** when surfacing recurring
   failures across runs, rank them by `prevalence × severity`, not raw count, so a rare but severe
   failure outranks a common trivial one. This is the floor-raising principle made quantitative;
@@ -377,8 +377,8 @@ assumed.
   it dispatches a subagent with a rubric whose "criteria [are] deliberately absent from
   generation rules."
 - **Abstractions used or changed:** mostly a discipline made first-class, not new machinery.
-  `prepared_task_rows` (`:1540`) already omits `review_rubric` from generation payloads unless
-  `--include-answer-key`; extend `validate_manifest` (`:1153`) to require that a `holdout`/
+  `prepared_task_rows` (`:1561`) already omits `review_rubric` from generation payloads unless
+  `--include-answer-key`; extend `validate_manifest` (`:1164`) to require that a `holdout`/
   `holdback` case's rubric stays out of the skill and public eval text, and pair it with the
   subagent judge from 2.7 and the graded scoring from 2.2. Track which rubrics were held out so
   the report can separate held-out scores from tune-visible ones.
@@ -390,7 +390,7 @@ assumed.
 ### 2.8 Interactive served report and richer artifacts
 - **Goal:** capture feedback in the browser and render image, PDF, and xlsx artifacts, beyond the
   static `render_viewer`.
-- **Abstractions used or changed:** extend `render_viewer` (`:18709`) with a `serve` mode and
+- **Abstractions used or changed:** extend `render_viewer` (`:18730`) with a `serve` mode and
   artifact encoders. Anthropic's `eval-viewer/generate_review.py` is the blueprint, including
   `feedback.json` persistence and a `--previous-workspace` diff.
 - **Testing:** unit-test the artifact embedding and categorization and the feedback round trip;
@@ -422,7 +422,7 @@ assumed.
 - **Goal:** evaluate conversational skills across a send/respond sequence.
 - **Abstractions changed (core contract):** a case gains an optional `turns` list. The
   run-output contract grows from one `output.md` to a turn-indexed transcript, so
-  `read_output_base` (`:6226`) and `discover_run_bases` learn the turn layout; runners drive the
+  `read_output_base` (`:6247`) and `discover_run_bases` learn the turn layout; runners drive the
   sequence; `grade_case_variant` grades per turn and aggregates.
 - **Design:** single-shot stays the default, so existing manifests are untouched.
 - **Testing:** a fixture multi-turn run asserting per-turn grading and aggregate, plus a
@@ -435,7 +435,7 @@ assumed.
   the model axis, plus a viewer panel.
 - **Slice-lift concentration (from the macro-evals notebook):** compute, per slice, where lift (or
   a failure) concentrates — `slice share ÷ overall share`, the macro-eval `lift` metric one level
-  up from per-case lift. `build_slice_summary` (`:15491`) already groups by domain/difficulty/
+  up from per-case lift. `build_slice_summary` (`:15512`) already groups by domain/difficulty/
   trigger/goal, so this is a ratio over groups it already forms, not new plumbing.
 - **Testing:** a report test over a two-model by two-variant fixture grid, plus a concentration
   test asserting a failure confined to one slice scores a high ratio there.
@@ -548,7 +548,7 @@ and upgrading to the new features should be something an agent can drive.
 
 ### Abstractions used or changed
 
-- `version` on the manifest (`validate_manifest:1153`) becomes meaningful: `validate` accepts both
+- `version` on the manifest (`validate_manifest:1164`) becomes meaningful: `validate` accepts both
   1 and 2, and warns (not errors) on a `version: 1` manifest once 2.2 has landed, pointing at
   `migrate`.
 - No grading abstraction changes for migration itself; it is a source-rewrite plus a guide.

--- a/docs/skill-ablation-spec.md
+++ b/docs/skill-ablation-spec.md
@@ -363,7 +363,7 @@ Opt in with `"invalid_skill": true` on the ablation: the run is tagged
 
 ## Validation additions
 
-`validate_manifest` (`skill_benchmark.py:1153`), per ablation:
+`validate_manifest` (`skill_benchmark.py:1164`), per ablation:
 
 - `id` unique and slug-formatted; keep `removed_component`.
 - If a removal is declared: exactly one of `mechanism`+`target` or `components`;

--- a/manifest_contracts.py
+++ b/manifest_contracts.py
@@ -1,0 +1,123 @@
+"""Typed identity values shared by manifest planning and prepared tasks.
+
+The manifest remains an ordinary JSON/YAML mapping at the wire boundary. These
+``str`` subclasses are the validated in-process values: they serialize exactly
+like the legacy strings while preventing an unchecked string from masquerading
+as a split, case kind, or execution arm in typed code.
+"""
+from __future__ import annotations
+
+from enum import Enum
+
+ABLATION_VARIANT_PREFIX = "ablation:"
+
+
+class Split(str):
+    """One of the three closed evaluation phases."""
+
+    _VALUES = ("tune", "holdout", "holdback")
+
+    def __new__(cls, value: str) -> Split:
+        if not isinstance(value, str):
+            raise TypeError("split must be a string")
+        if value not in cls._VALUES:
+            raise ValueError(f"split must be one of {list(cls._VALUES)!r}")
+        return str.__new__(cls, value)
+
+    @classmethod
+    def parse(cls, value: object) -> Split:
+        if not isinstance(value, str):
+            raise ValueError("split must be a string")
+        return cls(value)
+
+    @classmethod
+    def values(cls) -> tuple[str, ...]:
+        return cls._VALUES
+
+
+class CasePopulation(str, Enum):
+    ANSWER = "answer"
+    TRIGGER = "trigger"
+
+
+class CaseKind(str):
+    """A non-empty descriptive case kind with one structural population."""
+
+    def __new__(cls, value: str) -> CaseKind:
+        if not isinstance(value, str):
+            raise TypeError("case kind must be a string")
+        if not value.strip():
+            raise ValueError("case kind must be a non-empty string")
+        return str.__new__(cls, value)
+
+    @classmethod
+    def parse(cls, value: object) -> CaseKind:
+        if not isinstance(value, str):
+            raise ValueError("case kind must be a string")
+        return cls(value)
+
+    @property
+    def population(self) -> CasePopulation:
+        return CasePopulation.TRIGGER if self == "trigger" else CasePopulation.ANSWER
+
+
+class ExecutionVariant(str):
+    """A base, historical, or declared-ablation execution arm."""
+
+    _BASE_VALUES = ("with_skill", "without_skill", "old_skill")
+
+    def __new__(cls, value: str) -> ExecutionVariant:
+        if not isinstance(value, str):
+            raise TypeError("execution variant must be a string")
+        if value not in cls._BASE_VALUES:
+            if not value.startswith(ABLATION_VARIANT_PREFIX):
+                raise ValueError("execution variant is not a supported arm")
+            ablation_id = value.removeprefix(ABLATION_VARIANT_PREFIX)
+            if not ablation_id:
+                raise ValueError("ablation execution variant must include an id")
+        return str.__new__(cls, value)
+
+    @classmethod
+    def parse(cls, value: object) -> ExecutionVariant:
+        if not isinstance(value, str):
+            raise ValueError("execution variant must be a string")
+        return cls(value)
+
+    @classmethod
+    def base_values(cls) -> tuple[str, ...]:
+        return cls._BASE_VALUES
+
+    @classmethod
+    def ablation(cls, ablation_id: object) -> ExecutionVariant:
+        if not isinstance(ablation_id, str) or not ablation_id:
+            raise ValueError("ablation execution variant must include a string id")
+        return cls(f"{ABLATION_VARIANT_PREFIX}{ablation_id}")
+
+    @property
+    def is_ablation(self) -> bool:
+        return self.startswith(ABLATION_VARIANT_PREFIX)
+
+    @property
+    def ablation_id(self) -> str | None:
+        if not self.is_ablation:
+            return None
+        return self.removeprefix(ABLATION_VARIANT_PREFIX)
+
+
+WITH_SKILL = ExecutionVariant("with_skill")
+WITHOUT_SKILL = ExecutionVariant("without_skill")
+OLD_SKILL = ExecutionVariant("old_skill")
+DEFAULT_EXECUTION_VARIANTS = (WITH_SKILL, WITHOUT_SKILL)
+
+
+def is_ablation_variant(variant: object) -> bool:
+    """Compatibility predicate for untrusted/legacy values at wire boundaries."""
+    return str(variant).startswith(ABLATION_VARIANT_PREFIX)
+
+
+def ablation_id_of(variant: object) -> str | None:
+    """Return the id encoded by ``ablation:<id>``, else ``None``."""
+    value = str(variant)
+    if not value.startswith(ABLATION_VARIANT_PREFIX):
+        return None
+    return value.removeprefix(ABLATION_VARIANT_PREFIX)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ skill-pi-trigger-eval = "run_pi_trigger_eval:main"
 skill-trigger-matrix = "run_trigger_matrix:main"
 
 [tool.setuptools]
-py-modules = ["skill_benchmark", "run_pi_trigger_eval", "run_trigger_matrix", "ablation_model", "agent_capabilities", "telemetry", "trigger_contracts", "trigger_reporting", "trace_contracts", "runner_contracts", "judge_contracts", "judge_verdict", "experimental_pairs", "jetty_contracts", "gemini_contracts", "json_contracts", "text_contracts"]
+py-modules = ["skill_benchmark", "run_pi_trigger_eval", "run_trigger_matrix", "ablation_model", "agent_capabilities", "telemetry", "trigger_contracts", "trigger_reporting", "trace_contracts", "runner_contracts", "judge_contracts", "judge_verdict", "experimental_pairs", "jetty_contracts", "gemini_contracts", "json_contracts", "manifest_contracts", "text_contracts"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
@@ -59,6 +59,7 @@ required-version = "==0.16.0"
 "experimental_pairs.py" = ["TRY004"]
 "gemini_contracts.py" = ["TRY004"]
 "judge_verdict.py" = ["TRY004"]
+"manifest_contracts.py" = ["PYI034", "TRY004"]
 "runner_contracts.py" = ["TRY004"]
 "telemetry.py" = ["TRY004"]
 # Runner boundaries must report arbitrary provider/CLI failures as evaluation

--- a/skill_benchmark.py
+++ b/skill_benchmark.py
@@ -137,6 +137,13 @@ from judge_verdict import (
     verdict_fields,
     verdict_from_dict,
 )
+from manifest_contracts import (
+    DEFAULT_EXECUTION_VARIANTS,
+    CaseKind,
+    CasePopulation,
+    ExecutionVariant,
+    Split,
+)
 from text_contracts import (
     ComparisonProfile,
     ComparisonText,
@@ -162,16 +169,16 @@ from trigger_contracts import (
 )
 from trigger_reporting import CompleteTriggerCohort, summarize_trigger_cohort
 
-VALID_SPLITS = {"tune", "holdout", "holdback"}
+VALID_SPLITS = frozenset(Split.values())
 HARNESS_SEMANTIC_MODULES = (
     "ablation_model.py", "agent_capabilities.py", "experimental_pairs.py",
     "gemini_contracts.py",
-    "jetty_contracts.py", "judge_contracts.py", "judge_verdict.py", "json_contracts.py", "run_pi_trigger_eval.py",
+    "jetty_contracts.py", "judge_contracts.py", "judge_verdict.py", "json_contracts.py", "manifest_contracts.py", "run_pi_trigger_eval.py",
     "run_trigger_matrix.py", "runner_contracts.py", "skill_benchmark.py",
     "telemetry.py", "trace_contracts.py", "trigger_contracts.py",
     "trigger_reporting.py",
 )
-DEFAULT_VARIANTS = ["with_skill", "without_skill"]
+DEFAULT_VARIANTS = list(DEFAULT_EXECUTION_VARIANTS)
 TEXT_ASSERTIONS = {
     "contains",
     "contains_any",
@@ -598,7 +605,11 @@ def is_trigger_case(case: dict[str, Any]) -> bool:
     output is a raw_autonomous_trigger_measurement — a different population from
     answer runs. Every grading path (benchmark, grade, judge) must exclude them
     through THIS predicate so the boundary cannot drift per-command."""
-    return case.get("kind") == "trigger"
+    try:
+        kind = CaseKind.parse(case.get("kind", "behavior"))
+    except ValueError:
+        return False
+    return kind.population is CasePopulation.TRIGGER
 
 
 def is_judge_only_case(case: dict[str, Any]) -> bool:
@@ -1216,10 +1227,14 @@ def validate_manifest(path: Path, allow_missing_holdback: bool = True) -> dict[s
         if cid in seen:
             die(f"duplicate case id: {cid}")
         seen.add(cid)
+        try:
+            case_kind = CaseKind.parse(case.get("kind", "behavior"))
+        except ValueError:
+            die(f"{cid}: kind must be a non-empty string")
         split = case.get("split")
         if split not in VALID_SPLITS:
             die(f"{cid}: split must be one of {sorted(VALID_SPLITS)}")
-        trigger_case = is_trigger_case(case)
+        trigger_case = case_kind.population is CasePopulation.TRIGGER
         if trigger_case:
             if not isinstance(case.get("should_trigger"), bool):
                 die(f"{cid}: trigger cases require an explicit boolean should_trigger")
@@ -1411,15 +1426,21 @@ def variant_instruction(variant: str, manifest: dict[str, Any], repo_root: Path 
     return f"Run variant {variant}."
 
 
-def task_variants(manifest: dict[str, Any], *, include_old_skill: bool = False, include_ablations: bool = False) -> list[str]:
-    variants = list(manifest.get("variants", DEFAULT_VARIANTS))
+def task_variants(manifest: dict[str, Any], *, include_old_skill: bool = False, include_ablations: bool = False) -> list[ExecutionVariant]:
+    variants = [
+        ExecutionVariant.parse(value)
+        for value in manifest.get("variants", DEFAULT_VARIANTS)
+    ]
     if include_old_skill:
         old_paths = manifest.get("old_skill_paths") or []
         if not old_paths:
             die("--include-old-skill requires manifest.old_skill_paths to be populated")
-        variants.append("old_skill")
+        variants.append(ExecutionVariant("old_skill"))
     if include_ablations:
-        variants.extend(f"ablation:{a['id']}" for a in manifest.get("ablations", []))
+        variants.extend(
+            ExecutionVariant.ablation(ablation["id"])
+            for ablation in manifest.get("ablations", [])
+        )
     return variants
 
 

--- a/tests/test_manifest_contracts.py
+++ b/tests/test_manifest_contracts.py
@@ -1,0 +1,110 @@
+import json
+import unittest
+
+import ablation_model
+import skill_benchmark as sb
+from manifest_contracts import (
+    ABLATION_VARIANT_PREFIX,
+    CaseKind,
+    CasePopulation,
+    ExecutionVariant,
+    Split,
+    ablation_id_of,
+    is_ablation_variant,
+)
+
+
+class ManifestIdentityContractTests(unittest.TestCase):
+    def test_split_is_closed_and_keeps_wire_shape(self):
+        splits = [Split.parse(value) for value in Split.values()]
+        self.assertEqual(splits, ["tune", "holdout", "holdback"])
+        self.assertEqual(json.dumps({"split": splits[0]}), '{"split": "tune"}')
+        with self.assertRaises(ValueError):
+            Split.parse("training")
+        with self.assertRaises(ValueError):
+            Split.parse(None)
+
+    def test_case_kind_owns_answer_vs_trigger_population(self):
+        self.assertIs(CaseKind("trigger").population, CasePopulation.TRIGGER)
+        self.assertIs(CaseKind("pr-review").population, CasePopulation.ANSWER)
+        self.assertIs(CaseKind.parse("behavior").population, CasePopulation.ANSWER)
+        with self.assertRaises(ValueError):
+            CaseKind.parse(3)
+
+    def test_execution_variant_is_closed_and_decodes_ablation_once(self):
+        base = [ExecutionVariant(value) for value in ExecutionVariant.base_values()]
+        self.assertEqual(base, ["with_skill", "without_skill", "old_skill"])
+        ablation = ExecutionVariant.ablation("no-rp")
+        self.assertTrue(ablation.is_ablation)
+        self.assertEqual(ablation.ablation_id, "no-rp")
+        self.assertEqual(ablation_id_of(ablation), "no-rp")
+        self.assertTrue(is_ablation_variant(ablation))
+        with self.assertRaises(ValueError):
+            ExecutionVariant("control")
+        with self.assertRaises(ValueError):
+            ExecutionVariant("ablation:")
+
+    def test_ablation_model_reexports_the_canonical_compatibility_helpers(self):
+        self.assertEqual(ablation_model.ABLATION_VARIANT_PREFIX, ABLATION_VARIANT_PREFIX)
+        self.assertIs(ablation_model.ablation_id_of, ablation_id_of)
+        self.assertIs(ablation_model.is_ablation_variant, is_ablation_variant)
+
+    def test_task_variants_returns_typed_values_without_changing_strings(self):
+        manifest = {
+            "variants": ["with_skill", "without_skill"],
+            "old_skill_paths": ["old/SKILL.md"],
+            "ablations": [{"id": "no-rp"}],
+        }
+        variants = sb.task_variants(
+            manifest, include_old_skill=True, include_ablations=True
+        )
+        self.assertTrue(all(isinstance(value, ExecutionVariant) for value in variants))
+        self.assertEqual(
+            variants,
+            ["with_skill", "without_skill", "old_skill", "ablation:no-rp"],
+        )
+
+    def test_prepared_task_parses_identity_values_at_the_row_boundary(self):
+        row = {
+            "case_id": "case-1",
+            "split": "tune",
+            "kind": "behavior",
+            "variant": "with_skill",
+            "run_number": 1,
+            "skill_name": "example",
+            "repo_root": "/repo",
+            "skill_paths": ["/repo/SKILL.md"],
+            "input_files": [],
+            "run_dir": "case-1/with_skill",
+            "instruction": "use the skill",
+            "prompt": "do the task",
+            "tags": [],
+        }
+        task = ablation_model.PreparedTask.from_row(row)
+        self.assertIsInstance(task.split, Split)
+        self.assertIsInstance(task.kind, CaseKind)
+        self.assertIsInstance(task.variant_truth, ExecutionVariant)
+        self.assertEqual(task.harness_record(), row)
+
+    def test_prepared_task_rejects_untyped_identity_values_at_the_boundary(self):
+        row = {
+            "case_id": "case-1",
+            "split": "training",
+            "kind": "behavior",
+            "variant": "with_skill",
+            "run_number": 1,
+            "skill_name": "example",
+            "repo_root": "/repo",
+            "skill_paths": ["/repo/SKILL.md"],
+            "input_files": [],
+            "run_dir": "case-1/with_skill",
+            "instruction": "",
+            "prompt": "",
+            "tags": [],
+        }
+        with self.assertRaisesRegex(ValueError, "split must be"):
+            ablation_model.PreparedTask.from_row(row)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/type_tests/abstraction_contracts.py
+++ b/type_tests/abstraction_contracts.py
@@ -8,6 +8,7 @@ the intended precise types.
 
 from typing import NoReturn
 
+from ablation_model import PreparedTask
 from judge_verdict import (
     BooleanVerdict,
     ConsensusVerdict,
@@ -16,6 +17,7 @@ from judge_verdict import (
     JudgeVerdict,
     ScoredVerdict,
 )
+from manifest_contracts import CaseKind, ExecutionVariant, Split
 from runner_contracts import (
     AnswerOutcome,
     Completed,
@@ -87,3 +89,10 @@ def judge_verdict_is_exhaustive(verdict: JudgeVerdict) -> None:
         _consensus_passed: bool = verdict.passed
     else:
         _assert_never(verdict)
+
+
+def prepared_task_identity_is_precise(task: PreparedTask) -> None:
+    _split: Split = task.split
+    _kind: CaseKind = task.kind
+    _variant: ExecutionVariant = task.variant_truth
+    _visible_variant: ExecutionVariant = task.model_facing_variant()


### PR DESCRIPTION
## Summary

- introduce validated `Split`, `CaseKind`, and `ExecutionVariant` string subtypes
- parse those values at the prepared-row boundary and carry precise types through `PreparedTask`
- move the single `ablation:<id>` parser into the manifest identity owner while preserving the existing `ablation_model` import surface
- preserve the current JSON and run-directory spelling exactly

This is layer 2 of the `ty` migration stack and depends on #72.

## Why

Split, case population, and execution-arm identity were repeatedly represented as unchecked strings. This layer makes invalid prepared-task states fail at construction and gives `ty` precise fields downstream without a schema or artifact migration.

`CaseKind` remains open for descriptive labels; it owns only the structural answer-versus-trigger classification. `ExecutionVariant` closes the executable arms while retaining the declared `ablation:<id>` extension.

## Risk

The new values subclass `str`, so equality, JSON serialization, paths, and persisted records remain compatible. Validation is stricter for malformed programmatic task rows and malformed case kinds, which is intentional.

## Testing

- `.venv/bin/ty check`
- `.venv/bin/ruff check .`
- `.venv/bin/python -m py_compile *.py examples/adewale-workspace/*.py type_tests/*.py`
- `.venv/bin/python -m unittest discover -s tests -q` — 1,224 tests passed, 7 skipped
- focused manifest contract, manifest, and ablation suites
- `.venv/bin/python scripts/fix_doc_refs.py --check`
- `git diff --check`
