### PR TITLE
Type experimental pair identities

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -71,7 +71,7 @@ Jetty runbooks emit a standardized machine-readable `validation_report.json` per
 (`jettyio/jettyio-skills`, `skills/create-runbook/SKILL.md`). Rubric evaluation scores 3-7
 dimensions on a 1-5 scale; programmatic evaluation returns `PASS` / `PARTIAL` / `FAIL`. The
 items below map that report onto the harness judge-result row `{judge_task_id, passed, score,
-threshold, evidence}` (`load_judge_results:11640`, merged in `grade_case_variant:13901`).
+threshold, evidence}` (`load_judge_results:11643`, merged in `grade_case_variant:13904`).
 
 - [ ] Export qualitative judge tasks to Jetty workflows using `simple_judge` where useful.
       Carry `judge_task_id` (`case::variant::run-n::assertion`) into the Jetty task so the

--- a/ablation_model.py
+++ b/ablation_model.py
@@ -42,8 +42,10 @@ from agent_capabilities import BACKENDS
 from json_contracts import freeze_json_value
 from manifest_contracts import (
     ABLATION_VARIANT_PREFIX,
+    CaseId,
     CaseKind,
     ExecutionVariant,
+    RunNumber,
     Split,
     ablation_id_of,
     is_ablation_variant,
@@ -669,11 +671,11 @@ class PreparedTask:
     from_row() reconstructs the typed task on the far side of that boundary. The row
     dict is the only thing that crosses to disk — the type is the in-process owner."""
 
-    case_id: str
+    case_id: CaseId
     split: Split
     kind: CaseKind
     variant_truth: ExecutionVariant
-    run_number: int
+    run_number: RunNumber
     skill_name: str
     repo_root: str
     skill_paths: tuple[str, ...]
@@ -688,17 +690,16 @@ class PreparedTask:
     skill_root_keys: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "case_id", CaseId.parse(self.case_id))
         object.__setattr__(self, "split", Split.parse(self.split))
         object.__setattr__(self, "kind", CaseKind.parse(self.kind))
         object.__setattr__(self, "variant_truth", ExecutionVariant.parse(self.variant_truth))
-        for label, value in (("case_id", self.case_id), ("kind", self.kind),
+        object.__setattr__(self, "run_number", RunNumber.parse(self.run_number))
+        for label, value in (("kind", self.kind),
                              ("skill_name", self.skill_name), ("repo_root", self.repo_root),
                              ("run_dir", self.run_dir)):
             if not isinstance(value, str) or not value.strip():
                 raise ValueError(f"PreparedTask.{label} must be non-empty")
-        if (isinstance(self.run_number, bool) or not isinstance(self.run_number, int)
-                or self.run_number < 1):
-            raise ValueError("PreparedTask.run_number must be a positive integer")
         if self.kind == "trigger":
             raise ValueError("PreparedTask is answer-population only; trigger cases use autonomous runners")
         run_path = Path(self.run_dir)
@@ -822,11 +823,11 @@ class PreparedTask:
             collections[key] = tuple(raw)
         ctx = "PreparedTask row"
         return cls(
-            case_id=_require(row, "case_id", str, ctx),
+            case_id=CaseId.parse(_require(row, "case_id", str, ctx)),
             split=Split.parse(_require(row, "split", str, ctx)),
             kind=CaseKind.parse(row.get("kind", "behavior")),
             variant_truth=ExecutionVariant.parse(row.get("variant")),
-            run_number=_require(row, "run_number", int, ctx),
+            run_number=RunNumber.parse(_require(row, "run_number", int, ctx)),
             skill_name=_require(row, "skill_name", str, ctx),
             repo_root=_require(row, "repo_root", str, ctx),
             skill_paths=collections["skill_paths"],

--- a/docs/abstractions.md
+++ b/docs/abstractions.md
@@ -130,6 +130,10 @@ executable. `PreparedTaskDraft.validate()` / `PreparedTask.from_row()` construct
 repetition is positive, `run_dir` is safe and relative, and `without_skill` cannot carry skill
 paths. Every native runner and Jetty exporter requires the executable type.
 
+`CaseId`, `ModelId`, and `RunNumber` keep the run identity dimensions distinct from ordinary
+strings and integers. They serialize as the existing scalar values, while construction rejects an
+empty case/model or a boolean, zero, or negative repetition before that identity reaches pairing.
+
 The prepared rows also form a persisted `answer-design.json`: the exact expected
 case/model/repetition identities plus a digest of manifest inputs, referenced oracles, and
 variant instructions. Each produced run repeats the design, task, and instruction digests.
@@ -161,10 +165,10 @@ in the codebase.
 ## Runner / adapter
 
 An **answer runner** consumes prepared task rows and produces the run-output contract. The repo
-ships Pi answer smoke (`examples/adewale-workspace/run_pi_smoke.py`), Codex (`run_codex:10525`), Claude (`run_claude:10706`, capturing real
+ships Pi answer smoke (`examples/adewale-workspace/run_pi_smoke.py`), Codex (`run_codex:10528`), Claude (`run_claude:10709`, capturing real
 per-run cost), Gemini CLI and Mistral Vibe (`run-agent --agent gemini|vibe`, using isolated provider homes outside the workdir), the in-process
-subagent runner (`run_subagent:13246`, which hosts record/replay tool I/O via `ToolReplayStore`),
-Jetty (`JettyClient:3999` and the export/run/import commands), and any runner that writes the
+subagent runner (`run_subagent:13249`, which hosts record/replay tool I/O via `ToolReplayStore`),
+Jetty (`JettyClient:4002` and the export/run/import commands), and any runner that writes the
 contract directly. Each answer runner registers a workspace builder so one cross-runner invariant
 proves its `without_skill` arm is skill-free (CF.2). Autonomous trigger runners are separate: they
 read trigger cases from the manifest directly, never consume answer task rows, and emit trigger
@@ -227,14 +231,26 @@ external-process exceptions.
 turns those in-memory result rows into the artifact you read. It does not consume the output
 of the `grade` command. Before arithmetic,
 `experimental_pairs.py` constructs exact `(case, model, repetition, population)` identities and
-requires one eligible arm of each kind. `build_paired_summary` computes per-case lift
+requires one eligible treatment and control arm from an explicit `ContrastSpec`. The default
+skill-presence contrast maps to the existing `with_skill`/`without_skill` wire rows.
+The stable identity of a comparison result is `(contrast_id, pair_key)`. Blocked rows and pairing
+diagnostics serialize that contrast ID, so two different comparisons over the same execution rows
+cannot collide or lose their causal question at a persistence boundary.
+`build_paired_summary` computes per-case lift
 (`with_skill` minus `without_skill`, normalized gain, and a flag when the skill hurts) only from
 those pairs; missing/ineligible arms remain in `pairing` diagnostics and duplicate arms fail.
 `build_slice_summary` breaks results down
 by domain, difficulty, trigger type, and success goal. Case flags mark saturated, no-lift,
 flaky, and with-skill-failed cases. These flags, the leakage lint
-(`prompt_assertion_leakage_findings:789`), and the split discipline are the part of the tool
+(`prompt_assertion_leakage_findings:792`), and the split discipline are the part of the tool
 no surveyed eval framework copies.
+
+The pairing key carries `CaseId`, `ModelId | None`, `RunNumber`, and the closed
+`ExperimentalPopulation` enum. The pair also carries a contrast whose canonical factor coordinates
+separate activation, skill set, and content revision; those differing treatment coordinates do not
+pollute the shared repetition identity. `ExperimentalPair` is generic in its payload, so pairing run paths
+retains `Path` while pairing result rows retains their mapping interface; the shared constructor no
+longer erases every downstream payload to `Any`.
 
 ## What changes when you extend the tool
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,9 +126,13 @@ dimension in the fan-out (`case × variant × model × run`), not a new kind of 
 report then groups `by_model` and computes lift per (case, model) — see `model_analysis`.
 
 Before any lift, reliability, cost delta, or token-overhead value is computed, result rows become
-`ExperimentalPairKey(case, model, repetition, population)` arms. Only a validated pair with exactly
-one `with_skill` and one `without_skill` arm can contribute. Missing/ineligible arms remain blocked
-diagnostics, and duplicate identities fail instead of overwriting an earlier row. Telemetry then
+`ExperimentalPairKey(case, model, repetition, population)` arms under an explicit binary
+`ContrastSpec`. Only a validated pair with exactly one declared treatment and control arm can
+contribute. The default contrast preserves `with_skill`/`without_skill`; its canonical factor
+coordinates keep activation, skill-set, and content-revision axes distinct for future contrasts.
+Missing/ineligible arms remain blocked
+diagnostics with their `contrast_id`; a comparison result is identified by `(contrast_id, pair_key)`,
+and duplicate identities fail instead of overwriting an earlier row. Telemetry then
 adds its stricter provenance/unit/billing-basis comparison.
 
 ## Typed trust boundaries

--- a/docs/correctness-by-construction-audit.md
+++ b/docs/correctness-by-construction-audit.md
@@ -60,11 +60,18 @@ success, and exhausted retries. Exhaustive finite-state and trigger truth tables
 
 ## Paired experimental identity
 
-`experimental_pairs.py` owns `ExperimentalPairKey(case_id, model, run_number, population)` and the
-only constructor for `ExperimentalPair`.
+`experimental_pairs.py` owns `ExperimentalPairKey(case_id, model, run_number, population)`, one
+explicit `ContrastSpec`, and the only constructor for `ExperimentalPair`.
 
-- A complete pair contains exactly one `with_skill` and one `without_skill` arm with the same key.
-- Missing arms and ineligible arms become explicit `BlockedExperimentalPair` values.
+- A complete pair contains exactly one treatment and one control arm from its declared contrast,
+  with the same key. The default contrast retains the existing `with_skill`/`without_skill` wire
+  shape and compatibility properties.
+- Each contrast binds both arms to canonical activation, skill-set, and content-revision factor
+  coordinates. Native discovery and component-composition work can therefore add declared binary
+  contrasts without pretending those dimensions are ordinary execution variants.
+- Missing arms and ineligible arms become explicit `BlockedExperimentalPair` values that retain the
+  `contrast_id`. Pairing diagnostics serialize the same ID; the durable comparison identity is
+  `(contrast_id, pair_key)`.
 - A duplicate arm for one identity raises before aggregation; it can no longer overwrite an earlier
   row in a dictionary.
 - Lift, graded lift, paired reliability, paired cost, token-overhead run discovery, slice/case

--- a/docs/eval-framework-roadmap-spec.md
+++ b/docs/eval-framework-roadmap-spec.md
@@ -17,7 +17,7 @@ One invariant governs every item: core grading stays local and deterministic and
 model, and the harness never picks a model for the user. Anything that needs a model lives
 behind an opt-in command or the external `--judge-cmd`. Two abstractions absorb most of the
 work, so the spec returns to them often: the assertion result shape in `assertion_result`
-(`skill_benchmark.py:11214`) and the fan-out in `prepared_task_rows` (`:1561`).
+(`skill_benchmark.py:11217`) and the fan-out in `prepared_task_rows` (`:1564`).
 
 ## Testing baseline
 
@@ -40,7 +40,7 @@ tests are where that claim is checked rather than trusted.
 
 The buckets below extend what the harness can measure. This floor decides whether the number it
 already prints can be believed. The harness reports one thing: lift, `with_skill` minus
-`without_skill` on the same case (`build_paired_summary` (`:15341`)). That number is believable only
+`without_skill` on the same case (`build_paired_summary` (`:15348`)). That number is believable only
 when three preconditions hold, each intended today, none enforced, and each restating a claim from
 `evals-are-not-tests.md`:
 
@@ -60,22 +60,22 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
   hiding the quantity the tool exists to measure.
 - **Abstractions used or changed:** none in the engine. Adds
   `tests/fixtures/detectors/<detector_id>/should-fire.*` and `should-pass.*` that exercise
-  `assertion_result` (`:11214`) directly. That function has no direct unit test today, and its
+  `assertion_result` (`:11217`) directly. That function has no direct unit test today, and its
   `contains_any`, `excludes_any`, and `not_regex` branches go unexercised even though their types
-  are declared in the assertion registries (`TEXT_ASSERTIONS:182`).
+  are declared in the assertion registries (`TEXT_ASSERTIONS:185`).
 - **Design:** one table-driven test loads every pair and asserts the detector fires on `should-fire`
   and stays silent on `should-pass`. A `should-pass` twin is mandatory: it enforces the
   false-positive bar `authoring-evals.md` already sets for skill authors ("check both presence and
   absence"). Each `should-pass` set includes a case where the baseline echoes the prompt, because a
   detector that passes on echoed prompt text is a false oracle; this ties the fixtures to leakage
-  lint (`prompt_assertion_leakage_findings` (`:789`)). Every detector bug then becomes a permanent
+  lint (`prompt_assertion_leakage_findings` (`:792`)). Every detector bug then becomes a permanent
   fixture pair, and `test_command_assertions_match_command_inputs_not_outputs` is the first.
 - **Why it is the keystone:** the fixture pair is also the registration contract. It is what lets a
   harvested or third-party detector be trusted on entry, so it gates the exapted detector library
   (TODO, end of 2026), and it raises the oracle-strength ladder (1.7) so that "strong" means
   fixture-verified, not only deterministic.
 - **Testing:** the fixtures are the test. A meta-test asserts every name in `OBJECTIVE_ASSERTIONS`
-  (`:219`) has a fixture pair, so a new detector cannot land unverified.
+  (`:222`) has a fixture pair, so a new detector cannot land unverified.
 
 ### CF.2 — One cross-runner baseline-isolation invariant
 - **Goal:** prove the baseline is skill-free by construction, so a measured lift is the skill's
@@ -101,7 +101,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 ### CF.4 — A guard that the core grade path calls no model and no network
 - **Goal:** make the governing invariant — "core grading stays local and deterministic and never
   calls a model" — executable rather than aspirational.
-- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:13901`).
+- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:13904`).
 - **Design:** patch `urllib` and `subprocess` to raise, then grade a fixture covering every
   objective family (text, process, efficiency) and assert it completes. The sanctioned exceptions —
   `script` oracles and `judge` plumbing — are excluded from this path by design and keep their own
@@ -111,7 +111,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 
 ### Boundary
 The set stops here deliberately. Report-level correctness — whether the saturation, no-lift, flaky,
-and negative-delta flags (`build_benchmark_report` (`:16751`)) are computed right — sits a layer
+and negative-delta flags (`build_benchmark_report` (`:16767`)) are computed right — sits a layer
 above the raw measurement, where the golden-report tests the buckets already plan (1.2, 2.6) cover
 it. CF.1–CF.4 are the floor underneath that work: once they pass, a printed lift carries a checked
 measurement, and every feature in the buckets builds on a number that has been verified rather than
@@ -125,9 +125,9 @@ assumed.
 - **Goal:** ship graders authors reach for often, so they stop hand-rolling rubrics.
 - **Abstractions used or changed:** `tool_call` and `structured_output` are deterministic, so
   they become new types in `TEXT_ASSERTIONS` / `PROCESS_ASSERTIONS` and gain a branch in
-  `assertion_result`. `tool_call` reuses `command_events` (`:6394`) and the `command_order`
+  `assertion_result`. `tool_call` reuses `command_events` (`:6397`) and the `command_order`
   logic; `structured_output` extends `json_field_equals` with JSON-Schema validation.
-  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:11797`) renders
+  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:11800`) renders
   and still runs through `--judge-cmd`.
 - **Design:** a preset expands to either a deterministic objective assertion or a `judge`
   assertion with a canned rubric and threshold. No new execution path.
@@ -146,7 +146,7 @@ assumed.
 ### 1.3 Judge config slot and the "judge is not the model under test" guard
 - **Goal:** make an existing convention enforceable.
 - **Abstractions used or changed:** read an optional `judge` block in the manifest; add a check
-  in `audit_manifest_report` (`:19568`) comparing the declared judge model against `jetty.model`
+  in `audit_manifest_report` (`:19590`) comparing the declared judge model against `jetty.model`
   or the run metadata `model`.
 - **Design:** warn by default, error under `--strict-judge`.
 - **Testing:** unit tests for matching and differing model ids.
@@ -163,7 +163,7 @@ assumed.
 - **Status:** `docs/authoring-evals.md` shipped, alongside `architecture.md` and
   `abstractions.md`.
 - **Follow-on:** surface the guide's rules where they are checkable. Extend the messaging in
-  `prompt_assertion_leakage_findings` (`:789`) and `fixture_recommendations` (`:19261`) to point
+  `prompt_assertion_leakage_findings` (`:792`) and `fixture_recommendations` (`:19283`) to point
   at the relevant section.
 - **Testing:** assert the new hint strings appear for crafted manifests.
 
@@ -172,8 +172,8 @@ assumed.
   In `adewale/pythonbyexample` and `adewale/xampler` an example *is* an eval case: an input, an
   expected output, and a check that the output still matches. The harness has no equivalent of
   "this output equals this reference."
-- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:182`), implemented in
-  `assertion_result` (`:11214`). It reads `output.md` (or a named artifact), applies an optional
+- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:185`), implemented in
+  `assertion_result` (`:11217`). It reads `output.md` (or a named artifact), applies an optional
   normalization (trim, collapse whitespace, or a named normalizer), and compares to a reference
   file under the manifest dir. Evidence is a unified diff on mismatch.
 - **Design:** normalization is the whole game, so it is explicit and per-assertion, never
@@ -188,9 +188,9 @@ assumed.
   not name it.
 - **Abstractions used or changed:** an optional `oracle` tier on an assertion
   (`strong` / `demo` / `live`), defaulting by type (deterministic text/process are `strong`,
-  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:16751`)
+  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:16767`)
   reports, per case, the share of its pass rate carried by `strong` oracles;
-  `audit_manifest_report` (`:19568`) warns when a case passes only on weak ones. This extends
+  `audit_manifest_report` (`:19590`) warns when a case passes only on weak ones. This extends
   leakage lint (`:164`) from prompts to oracles.
 - **Strongest tier — the rendered-artifact oracle:** the top of the ladder is an oracle that
   builds or renders the artifact and inspects the result, not the source text.
@@ -205,8 +205,8 @@ assumed.
   splits "good poster" into seven `script` oracles, but each is forced all-or-nothing by the
   exit-code-only contract: a poster with six of seven drama carriers fails `drama_oracle` exactly
   like one with zero. That is the binary-saturation problem inside a single oracle.
-- **Abstractions used or changed:** extend `run_script_assertion` (`:11082`) and
-  `assertion_result` (`:11214`) to optionally parse a score from the oracle's stdout — a JSON line
+- **Abstractions used or changed:** extend `run_script_assertion` (`:11085`) and
+  `assertion_result` (`:11217`) to optionally parse a score from the oracle's stdout — a JSON line
   such as `{"score": 6, "max_score": 7}` (normalized to 0-1) — beside the existing
   `pass_exit_code`. The parsed score flows into the `score`/`severity` channel from 2.2, so a
   script oracle becomes a graded dimension while staying fully deterministic and model-free.
@@ -223,9 +223,9 @@ assumed.
   past it — either way, question it. This is the inverse of the saturation flag: saturation marks
   a case as too easy *now*; staleness marks a case that has never discriminated *over time*.
 - **Abstractions used or changed:** reads the cross-run history from 2.6. A `prune` report (or a
-  flag in `build_benchmark_report` (`:16751`)) marks a case a removal candidate when, across the
+  flag in `build_benchmark_report` (`:16767`)) marks a case a removal candidate when, across the
   last N runs, it never failed and never showed lift (`with_skill` == `without_skill` every time).
-  `audit_manifest_report` (`:19568`) lists the candidates; removal stays a human decision.
+  `audit_manifest_report` (`:19590`) lists the candidates; removal stays a human decision.
 - **Design:** the harness suggests, never deletes. A case may be kept deliberately as a
   regression guard even when stale; the report says so rather than acting.
 - **Depends on:** 2.6 (needs run history to judge "never failed over time").
@@ -239,12 +239,12 @@ assumed.
 ### 2.1 Multi-model fan-out (priority)
 - **Goal:** run the same cases across several models and compare lift per model. No surveyed
   framework does this; vitest-evals, eve, and viteval all push it onto the test runner.
-- **Abstractions used or changed:** `prepared_task_rows` (`:1561`) gains a `model` dimension
+- **Abstractions used or changed:** `prepared_task_rows` (`:1564`) gains a `model` dimension
   beside `variant` and `run_number`. Each row carries its target `model`, and `run_dir` gains a
   model segment (`<case>/<model>/<variant>/run-<n>`), kept backward-compatible when one model
   runs. Runners pass the row `model` through; per-run `model` already lands in `metadata.json`,
-  so grading needs no change. `build_benchmark_report` (`:16751`) groups `by_variant` within
-  `by_model`, and `build_paired_summary` (`:15341`) computes lift per (case, model).
+  so grading needs no change. `build_benchmark_report` (`:16767`) groups `by_variant` within
+  `by_model`, and `build_paired_summary` (`:15348`) computes lift per (case, model).
 - **Design:** model is a third axis, not a new variant. Variants stay orthogonal, giving a
   model-by-variant grid. CLI: `--models a,b,c` on `prepare`.
 - **Testing:** a fan-out test asserting row count equals cases × variants × runs × models with
@@ -261,7 +261,7 @@ assumed.
   no-regression floor. This spec ports those shapes into the harness rather than inventing new
   ones.
 - **Abstractions used or changed:**
-  - `assertion_result` (`:11214`) gains an optional `score` (0-1 or a normalized 1-5) and
+  - `assertion_result` (`:11217`) gains an optional `score` (0-1 or a normalized 1-5) and
     `severity` (`critical` / `gate` / `soft`), read from `critical`/`gate`/`soft`/`atLeast` on the
     assertion.
   - **`critical` (absorbing-barrier) tier — valley-dodging.** From the Jetty "valley-dodging"
@@ -276,13 +276,13 @@ assumed.
   - **Anchored `graded_dimensions`** as a `judge` assertion shape:
     `{name, scale: "1-5", rubric: "5 = …observable…; 1 = …observable…"}`. Anchors name what each
     score level looks like, so a judge scores against criteria, not a vibe. `judge_prompt`
-    (`:11797`) renders the dimensions; the result carries per-dimension scores in `evidence`.
+    (`:11800`) renders the dimensions; the result carries per-dimension scores in `evidence`.
   - **`dynamic_rubric`** as a second `judge` shape: `{instruction, minimum_criteria}`. The judge
     drafts 3-5 case-specific criteria before grading and must meet at least `minimum_criteria`.
-  - `grade_case_variant` (`:13901`) splits totals into critical, gated, and soft. A `critical`
+  - `grade_case_variant` (`:13904`) splits totals into critical, gated, and soft. A `critical`
     failure vetoes the case; a `gate` failure lowers the pass rate; a `soft` failure lowers
     neither and fills a `scored` bucket. A `--strict` flag promotes soft to gate.
-  - **Statistical lift** in `build_paired_summary` (`:15341`): alongside the raw delta, compute a
+  - **Statistical lift** in `build_paired_summary` (`:15348`): alongside the raw delta, compute a
     significance test over the per-case graded scores (paired bootstrap or sign-flip
     permutation, mirroring `score_delta.py`), so lift is tested, not eyeballed.
   - **Reference-anchor floor:** an optional `reference_score` / `reference_graded_score` on a
@@ -315,7 +315,7 @@ assumed.
 - **Goal:** deterministic re-runs that pay nothing for external dependencies, by recording tool
   inputs and outputs.
 - **Abstractions used or changed:** this lives in the runner, not core grading. Recording sits
-  beside `write_trace_artifacts` (`:8255`): a `tool-replay.json` keyed per tool, with
+  beside `write_trace_artifacts` (`:8258`): a `tool-replay.json` keyed per tool, with
   `sanitize` and `version`. Modes (`auto`, `record`, `off`, `strict`) come from an environment
   variable that `run_codex` and the Pi and subagent runners read.
 - **Design:** orthogonal to the disk re-grade the harness already does. Replay makes the agent
@@ -326,8 +326,8 @@ assumed.
 
 ### 2.4 OpenTelemetry GenAI normalization target
 - **Goal:** make the trace adapter boundary a standard rather than a bespoke schema.
-- **Abstractions used or changed:** `normalize_trace_record` (`:7312`) and
-  `normalize_trace_records` (`:7971`) keep their inputs but emit OTel GenAI semantic-key
+- **Abstractions used or changed:** `normalize_trace_record` (`:7315`) and
+  `normalize_trace_records` (`:7974`) keep their inputs but emit OTel GenAI semantic-key
   attributes; the `events.json` schema version bumps. Process and efficiency assertions read the
   new keys with backward-compatible fallbacks.
 - **Design:** additive schema. An old `events.json` still grades.
@@ -337,7 +337,7 @@ assumed.
 ### 2.5 Dataset abstraction
 - **Goal:** fan one case template over many rows instead of hand-authoring each case.
 - **Abstractions used or changed:** a new optional manifest construct (`datasets`, plus a case
-  `template` referencing a dataset id). `iter_cases` (`:596`) materializes template by row into
+  `template` referencing a dataset id). `iter_cases` (`:599`) materializes template by row into
   concrete cases before fan-out; `validate_manifest` validates rows and runs leakage lint per
   materialized case.
 - **Design:** materialization happens early, so prepare, grade, and report stay unchanged.
@@ -351,7 +351,7 @@ assumed.
 - **Goal:** watch lift, saturation, and token drift over time.
 - **Abstractions used or changed:** a consumer of `build_benchmark_report`. Add an append-only
   history store and a `trend` subcommand that diffs successive `benchmark.json` files, reusing
-  the `compare_results` (`:17933`) logic.
+  the `compare_results` (`:17949`) logic.
 - **Severity-weighted ranking (from the macro-evals notebook):** when surfacing recurring
   failures across runs, rank them by `prevalence × severity`, not raw count, so a rare but severe
   failure outranks a common trivial one. This is the floor-raising principle made quantitative;
@@ -377,8 +377,8 @@ assumed.
   it dispatches a subagent with a rubric whose "criteria [are] deliberately absent from
   generation rules."
 - **Abstractions used or changed:** mostly a discipline made first-class, not new machinery.
-  `prepared_task_rows` (`:1561`) already omits `review_rubric` from generation payloads unless
-  `--include-answer-key`; extend `validate_manifest` (`:1164`) to require that a `holdout`/
+  `prepared_task_rows` (`:1564`) already omits `review_rubric` from generation payloads unless
+  `--include-answer-key`; extend `validate_manifest` (`:1167`) to require that a `holdout`/
   `holdback` case's rubric stays out of the skill and public eval text, and pair it with the
   subagent judge from 2.7 and the graded scoring from 2.2. Track which rubrics were held out so
   the report can separate held-out scores from tune-visible ones.
@@ -390,7 +390,7 @@ assumed.
 ### 2.8 Interactive served report and richer artifacts
 - **Goal:** capture feedback in the browser and render image, PDF, and xlsx artifacts, beyond the
   static `render_viewer`.
-- **Abstractions used or changed:** extend `render_viewer` (`:18730`) with a `serve` mode and
+- **Abstractions used or changed:** extend `render_viewer` (`:18746`) with a `serve` mode and
   artifact encoders. Anthropic's `eval-viewer/generate_review.py` is the blueprint, including
   `feedback.json` persistence and a `--previous-workspace` diff.
 - **Testing:** unit-test the artifact embedding and categorization and the feedback round trip;
@@ -422,7 +422,7 @@ assumed.
 - **Goal:** evaluate conversational skills across a send/respond sequence.
 - **Abstractions changed (core contract):** a case gains an optional `turns` list. The
   run-output contract grows from one `output.md` to a turn-indexed transcript, so
-  `read_output_base` (`:6247`) and `discover_run_bases` learn the turn layout; runners drive the
+  `read_output_base` (`:6250`) and `discover_run_bases` learn the turn layout; runners drive the
   sequence; `grade_case_variant` grades per turn and aggregates.
 - **Design:** single-shot stays the default, so existing manifests are untouched.
 - **Testing:** a fixture multi-turn run asserting per-turn grading and aggregate, plus a
@@ -435,7 +435,7 @@ assumed.
   the model axis, plus a viewer panel.
 - **Slice-lift concentration (from the macro-evals notebook):** compute, per slice, where lift (or
   a failure) concentrates — `slice share ÷ overall share`, the macro-eval `lift` metric one level
-  up from per-case lift. `build_slice_summary` (`:15512`) already groups by domain/difficulty/
+  up from per-case lift. `build_slice_summary` (`:15519`) already groups by domain/difficulty/
   trigger/goal, so this is a ratio over groups it already forms, not new plumbing.
 - **Testing:** a report test over a two-model by two-variant fixture grid, plus a concentration
   test asserting a failure confined to one slice scores a high ratio there.
@@ -548,7 +548,7 @@ and upgrading to the new features should be something an agent can drive.
 
 ### Abstractions used or changed
 
-- `version` on the manifest (`validate_manifest:1164`) becomes meaningful: `validate` accepts both
+- `version` on the manifest (`validate_manifest:1167`) becomes meaningful: `validate` accepts both
   1 and 2, and warns (not errors) on a `version: 1` manifest once 2.2 has landed, pointing at
   `migrate`.
 - No grading abstraction changes for migration itself; it is a source-rewrite plus a guide.

--- a/docs/skill-ablation-spec.md
+++ b/docs/skill-ablation-spec.md
@@ -363,7 +363,7 @@ Opt in with `"invalid_skill": true` on the ablation: the run is tagged
 
 ## Validation additions
 
-`validate_manifest` (`skill_benchmark.py:1164`), per ablation:
+`validate_manifest` (`skill_benchmark.py:1167`), per ablation:
 
 - `id` unique and slug-formatted; keep `removed_component`.
 - If a removal is declared: exactly one of `mechanism`+`target` or `components`;

--- a/experimental_pairs.py
+++ b/experimental_pairs.py
@@ -10,9 +10,100 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Literal
+from typing import Any, Generic, TypeVar
 
-ArmName = Literal["with_skill", "without_skill"]
+from manifest_contracts import CaseId, ModelId, RunNumber
+
+PayloadT = TypeVar("PayloadT")
+
+
+class ExperimentalArmId(str):
+    """One wire arm name selected by an explicit contrast."""
+
+    def __new__(cls, value: str) -> ExperimentalArmId:
+        if not isinstance(value, str):
+            raise TypeError("experimental arm id must be a string")
+        if not value.strip():
+            raise ValueError("experimental arm id must be non-empty")
+        return str.__new__(cls, value)
+
+
+class ExperimentalFactor(str, Enum):
+    ACTIVATION = "activation"
+    SKILL_SET = "skill_set"
+    CONTENT_REVISION = "content_revision"
+
+
+@dataclass(frozen=True, order=True)
+class FactorCoordinate:
+    factor: ExperimentalFactor
+    level: str
+
+    def __post_init__(self) -> None:
+        try:
+            object.__setattr__(self, "factor", ExperimentalFactor(self.factor))
+        except ValueError as exc:
+            raise ValueError(f"unknown experimental factor: {self.factor!r}") from exc
+        if not isinstance(self.level, str) or not self.level.strip():
+            raise ValueError("experimental factor level must be non-empty")
+
+
+@dataclass(frozen=True)
+class TreatmentCoordinate:
+    factors: tuple[FactorCoordinate, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.factors, tuple) or not all(
+            isinstance(item, FactorCoordinate) for item in self.factors
+        ):
+            raise TypeError("treatment factors must be a tuple of FactorCoordinate values")
+        ordered = tuple(sorted(self.factors))
+        if len({item.factor for item in ordered}) != len(ordered):
+            raise ValueError("treatment coordinate cannot repeat a factor")
+        object.__setattr__(self, "factors", ordered)
+
+
+@dataclass(frozen=True)
+class ContrastSpec:
+    """One declared binary comparison and both of its treatment coordinates."""
+
+    contrast_id: str
+    treatment_arm: ExperimentalArmId
+    control_arm: ExperimentalArmId
+    treatment: TreatmentCoordinate
+    control: TreatmentCoordinate
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.contrast_id, str) or not self.contrast_id.strip():
+            raise ValueError("experimental contrast id must be non-empty")
+        object.__setattr__(
+            self, "treatment_arm", ExperimentalArmId(self.treatment_arm))
+        object.__setattr__(self, "control_arm", ExperimentalArmId(self.control_arm))
+        if self.treatment_arm == self.control_arm:
+            raise ValueError("experimental contrast arms must be distinct")
+        if not isinstance(self.treatment, TreatmentCoordinate) or not isinstance(
+            self.control, TreatmentCoordinate
+        ):
+            raise TypeError("experimental contrast coordinates must be TreatmentCoordinate")
+        if self.treatment == self.control:
+            raise ValueError("experimental contrast coordinates must be distinct")
+
+
+SKILL_PRESENCE_CONTRAST = ContrastSpec(
+    contrast_id="skill_presence",
+    treatment_arm=ExperimentalArmId("with_skill"),
+    control_arm=ExperimentalArmId("without_skill"),
+    treatment=TreatmentCoordinate((
+        FactorCoordinate(ExperimentalFactor.ACTIVATION, "forced"),
+        FactorCoordinate(ExperimentalFactor.SKILL_SET, "all"),
+        FactorCoordinate(ExperimentalFactor.CONTENT_REVISION, "current"),
+    )),
+    control=TreatmentCoordinate((
+        FactorCoordinate(ExperimentalFactor.ACTIVATION, "none"),
+        FactorCoordinate(ExperimentalFactor.SKILL_SET, "none"),
+        FactorCoordinate(ExperimentalFactor.CONTENT_REVISION, "current"),
+    )),
+)
 
 
 class ExperimentalPopulation(str, Enum):
@@ -21,28 +112,56 @@ class ExperimentalPopulation(str, Enum):
     JUDGE = "judge"
     STATIC = "static"
 
+    @classmethod
+    def parse(cls, value: object) -> ExperimentalPopulation:
+        if not isinstance(value, str):
+            raise ValueError("experimental population must be a string")
+        try:
+            return cls(value)
+        except ValueError as exc:
+            raise ValueError(f"unknown experimental population: {value!r}") from exc
 
-@dataclass(frozen=True, order=True)
+
+@dataclass(frozen=True)
 class ExperimentalPairKey:
-    case_id: str
-    model: str | None
-    run_number: int
-    population: str
+    case_id: CaseId
+    model: ModelId | None
+    run_number: RunNumber
+    population: ExperimentalPopulation
 
     def __post_init__(self) -> None:
-        if not isinstance(self.case_id, str) or not self.case_id.strip():
-            raise ValueError("pair case_id must be a non-empty string")
-        if self.model is not None and (not isinstance(self.model, str) or not self.model.strip()):
-            raise ValueError("pair model must be null or a non-empty string")
-        if isinstance(self.run_number, bool) or not isinstance(self.run_number, int) or self.run_number < 1:
-            raise ValueError("pair run_number must be a positive integer")
-        try:
-            object.__setattr__(self, "population", ExperimentalPopulation(self.population).value)
-        except ValueError as exc:
-            raise ValueError(f"unknown experimental population: {self.population!r}") from exc
+        object.__setattr__(self, "case_id", CaseId.parse(self.case_id))
+        object.__setattr__(
+            self, "model", None if self.model is None else ModelId.parse(self.model)
+        )
+        object.__setattr__(self, "run_number", RunNumber.parse(self.run_number))
+        object.__setattr__(
+            self, "population", ExperimentalPopulation.parse(self.population)
+        )
 
     @classmethod
-    def from_row(cls, row: Mapping[str, Any], *, population: str) -> ExperimentalPairKey:
+    def parse(
+        cls,
+        case_id: object,
+        model: object,
+        run_number: object,
+        population: object,
+    ) -> ExperimentalPairKey:
+        return cls(
+            CaseId.parse(case_id),
+            None if model is None else ModelId.parse(model),
+            RunNumber.parse(run_number),
+            ExperimentalPopulation.parse(population),
+        )
+
+    @classmethod
+    def from_row(
+        cls,
+        row: Mapping[str, Any],
+        *,
+        population: ExperimentalPopulation,
+    ) -> ExperimentalPairKey:
+        parsed_population = ExperimentalPopulation.parse(population)
         if "case_id" not in row:
             raise ValueError("experimental row is missing case_id")
         if not isinstance(row["case_id"], str):
@@ -50,35 +169,35 @@ class ExperimentalPairKey:
         if "run_number" not in row:
             raise ValueError("experimental row is missing run_number")
         row_population = row.get("population")
-        if row_population is not None and row_population != population:
+        if row_population is not None and row_population != parsed_population.value:
             raise ValueError(
-                f"experimental row population {row_population!r} conflicts with {population!r}"
+                "experimental row population "
+                f"{row_population!r} conflicts with {parsed_population.value!r}"
             )
         model = row.get("model")
-        return cls(row["case_id"], model, row["run_number"], population)
+        return cls.parse(row["case_id"], model, row["run_number"], parsed_population)
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "case_id": self.case_id,
             "model": self.model,
             "run_number": self.run_number,
-            "population": self.population,
+            "population": self.population.value,
         }
 
 
 @dataclass(frozen=True)
-class ExperimentalArm:
+class ExperimentalArm(Generic[PayloadT]):
     key: ExperimentalPairKey
-    arm: ArmName
-    payload: Any
+    arm: ExperimentalArmId
+    payload: PayloadT
     eligible: bool = True
     blocked_reason: str | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.key, ExperimentalPairKey):
             raise TypeError("experimental arm key must be ExperimentalPairKey")
-        if self.arm not in ("with_skill", "without_skill"):
-            raise ValueError(f"unknown experimental arm: {self.arm!r}")
+        object.__setattr__(self, "arm", ExperimentalArmId(self.arm))
         if not isinstance(self.eligible, bool):
             raise TypeError("experimental arm eligible must be boolean")
         if self.eligible and self.blocked_reason is not None:
@@ -88,55 +207,119 @@ class ExperimentalArm:
 
 
 @dataclass(frozen=True)
-class ExperimentalPair:
+class ExperimentalPair(Generic[PayloadT]):
     key: ExperimentalPairKey
-    with_skill: ExperimentalArm
-    without_skill: ExperimentalArm
+    contrast: ContrastSpec
+    treatment: ExperimentalArm[PayloadT]
+    control: ExperimentalArm[PayloadT]
 
     def __post_init__(self) -> None:
-        if self.with_skill.key != self.key or self.without_skill.key != self.key:
+        if not isinstance(self.key, ExperimentalPairKey):
+            raise TypeError("experimental pair key must be ExperimentalPairKey")
+        if not isinstance(self.contrast, ContrastSpec):
+            raise TypeError("experimental pair contrast must be ContrastSpec")
+        if self.treatment.key != self.key or self.control.key != self.key:
             raise ValueError("experimental pair arms must have exactly matching identities")
-        if self.with_skill.arm != "with_skill" or self.without_skill.arm != "without_skill":
-            raise ValueError("experimental pair must contain one arm of each kind")
-        if not self.with_skill.eligible or not self.without_skill.eligible:
+        if (self.treatment.arm != self.contrast.treatment_arm
+                or self.control.arm != self.contrast.control_arm):
+            raise ValueError("experimental pair arms do not match its contrast")
+        if not self.treatment.eligible or not self.control.eligible:
             raise ValueError("experimental pair cannot contain an ineligible arm")
+
+    @property
+    def with_skill(self) -> ExperimentalArm[PayloadT]:
+        """Compatibility projection for the default skill-presence contrast."""
+        if self.contrast != SKILL_PRESENCE_CONTRAST:
+            raise AttributeError("with_skill is only defined for the skill-presence contrast")
+        return self.treatment
+
+    @property
+    def without_skill(self) -> ExperimentalArm[PayloadT]:
+        """Compatibility projection for the default skill-presence contrast."""
+        if self.contrast != SKILL_PRESENCE_CONTRAST:
+            raise AttributeError("without_skill is only defined for the skill-presence contrast")
+        return self.control
 
 
 @dataclass(frozen=True)
 class BlockedExperimentalPair:
     key: ExperimentalPairKey
     reason: str
+    contrast_id: str
 
     def __post_init__(self) -> None:
         if not isinstance(self.key, ExperimentalPairKey):
             raise TypeError("blocked pair key must be ExperimentalPairKey")
         if not isinstance(self.reason, str) or not self.reason:
             raise ValueError("blocked experimental pair requires a reason")
+        if not isinstance(self.contrast_id, str) or not self.contrast_id.strip():
+            raise ValueError("blocked experimental pair requires a contrast id")
 
     def to_dict(self) -> dict[str, Any]:
-        return {**self.key.to_dict(), "reason": self.reason}
+        return {
+            "contrast_id": self.contrast_id,
+            **self.key.to_dict(),
+            "reason": self.reason,
+        }
 
 
 @dataclass(frozen=True)
-class PairConstruction:
-    pairs: tuple[ExperimentalPair, ...]
+class PairConstruction(Generic[PayloadT]):
+    contrast: ContrastSpec
+    pairs: tuple[ExperimentalPair[PayloadT], ...]
     blocked: tuple[BlockedExperimentalPair, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.contrast, ContrastSpec):
+            raise TypeError("pair construction contrast must be ContrastSpec")
+        if not isinstance(self.pairs, tuple) or not all(
+            isinstance(item, ExperimentalPair) for item in self.pairs
+        ):
+            raise TypeError("constructed pairs must be a tuple of ExperimentalPair values")
+        if not isinstance(self.blocked, tuple) or not all(
+            isinstance(item, BlockedExperimentalPair) for item in self.blocked
+        ):
+            raise TypeError("blocked pairs must be a tuple of BlockedExperimentalPair values")
+        pair_keys = [item.key for item in self.pairs]
+        blocked_keys = [item.key for item in self.blocked]
+        if any(item.contrast != self.contrast for item in self.pairs):
+            raise ValueError("constructed pairs must use the construction contrast")
+        if any(item.contrast_id != self.contrast.contrast_id for item in self.blocked):
+            raise ValueError("blocked pairs must use the construction contrast")
+        if len(set(pair_keys)) != len(pair_keys) or len(set(blocked_keys)) != len(blocked_keys):
+            raise ValueError("pair construction cannot repeat an experimental identity")
+        if set(pair_keys) & set(blocked_keys):
+            raise ValueError("an experimental identity cannot be paired and blocked")
 
     def diagnostics(self) -> dict[str, Any]:
         reason_counts: dict[str, int] = {}
         for item in self.blocked:
             reason_counts[item.reason] = reason_counts.get(item.reason, 0) + 1
         return {
+            "contrast_id": self.contrast.contrast_id,
             "eligible_pairs": len(self.pairs),
             "blocked_pairs": len(self.blocked),
             "blocked_reason_counts": dict(sorted(reason_counts.items())),
         }
 
 
-def construct_pairs(arms: Iterable[ExperimentalArm]) -> PairConstruction:
+def construct_pairs(
+    arms: Iterable[ExperimentalArm[PayloadT]],
+    *,
+    contrast: ContrastSpec = SKILL_PRESENCE_CONTRAST,
+) -> PairConstruction[PayloadT]:
     """Build matched pairs and reject duplicate observations for either arm."""
-    indexed: dict[ExperimentalPairKey, dict[ArmName, ExperimentalArm]] = {}
+    indexed: dict[
+        ExperimentalPairKey, dict[ExperimentalArmId, ExperimentalArm[PayloadT]]
+    ] = {}
     for observation in arms:
+        if not isinstance(observation, ExperimentalArm):
+            raise TypeError("pair construction requires ExperimentalArm values")
+        if observation.arm not in {contrast.treatment_arm, contrast.control_arm}:
+            raise ValueError(
+                f"experimental arm {observation.arm!r} is not part of "
+                f"contrast {contrast.contrast_id!r}"
+            )
         slots = indexed.setdefault(observation.key, {})
         if observation.arm in slots:
             raise ValueError(
@@ -145,39 +328,46 @@ def construct_pairs(arms: Iterable[ExperimentalArm]) -> PairConstruction:
             )
         slots[observation.arm] = observation
 
-    pairs: list[ExperimentalPair] = []
+    pairs: list[ExperimentalPair[PayloadT]] = []
     blocked: list[BlockedExperimentalPair] = []
     for key in sorted(indexed, key=lambda item: (
-            item.case_id, item.model or "", item.run_number, item.population)):
+            item.case_id, item.model or "", item.run_number, item.population.value)):
         slots = indexed[key]
-        left = slots.get("with_skill")
-        right = slots.get("without_skill")
+        left = slots.get(contrast.treatment_arm)
+        right = slots.get(contrast.control_arm)
         if left is None:
-            blocked.append(BlockedExperimentalPair(key, "missing_with_skill"))
+            blocked.append(BlockedExperimentalPair(
+                key, f"missing_{contrast.treatment_arm}", contrast.contrast_id))
         elif right is None:
-            blocked.append(BlockedExperimentalPair(key, "missing_without_skill"))
+            blocked.append(BlockedExperimentalPair(
+                key, f"missing_{contrast.control_arm}", contrast.contrast_id))
         elif not left.eligible:
-            blocked.append(BlockedExperimentalPair(key, str(left.blocked_reason)))
+            blocked.append(BlockedExperimentalPair(
+                key, str(left.blocked_reason), contrast.contrast_id))
         elif not right.eligible:
-            blocked.append(BlockedExperimentalPair(key, str(right.blocked_reason)))
+            blocked.append(BlockedExperimentalPair(
+                key, str(right.blocked_reason), contrast.contrast_id))
         else:
-            pairs.append(ExperimentalPair(key, left, right))
-    return PairConstruction(tuple(pairs), tuple(blocked))
+            pairs.append(ExperimentalPair(key, contrast, left, right))
+    return PairConstruction(contrast, tuple(pairs), tuple(blocked))
 
 
 def pairs_from_rows(
     rows: Iterable[Mapping[str, Any]],
     *,
-    population: str,
+    population: ExperimentalPopulation,
     eligibility: Callable[[Mapping[str, Any]], tuple[bool, str | None]] | None = None,
-) -> PairConstruction:
+    contrast: ContrastSpec = SKILL_PRESENCE_CONTRAST,
+) -> PairConstruction[Mapping[str, Any]]:
     """Parse untrusted result rows into arms, then construct validated pairs."""
-    arms: list[ExperimentalArm] = []
+    arms: list[ExperimentalArm[Mapping[str, Any]]] = []
     for row in rows:
         arm = row.get("variant")
-        if arm not in ("with_skill", "without_skill"):
+        if arm not in (contrast.treatment_arm, contrast.control_arm):
             continue
         key = ExperimentalPairKey.from_row(row, population=population)
         eligible, reason = eligibility(row) if eligibility is not None else (True, None)
-        arms.append(ExperimentalArm(key, arm, row, eligible, reason))
-    return construct_pairs(arms)
+        assert isinstance(arm, str)
+        arms.append(ExperimentalArm(
+            key, ExperimentalArmId(arm), row, eligible, reason))
+    return construct_pairs(arms, contrast=contrast)

--- a/manifest_contracts.py
+++ b/manifest_contracts.py
@@ -12,6 +12,57 @@ from enum import Enum
 ABLATION_VARIANT_PREFIX = "ablation:"
 
 
+class CaseId(str):
+    """A validated case identity used across planning, runs, and reports."""
+
+    def __new__(cls, value: str) -> CaseId:
+        if not isinstance(value, str):
+            raise TypeError("case id must be a string")
+        if not value.strip():
+            raise ValueError("case id must be a non-empty string")
+        return str.__new__(cls, value)
+
+    @classmethod
+    def parse(cls, value: object) -> CaseId:
+        if not isinstance(value, str):
+            raise ValueError("case id must be a string")
+        return cls(value)
+
+
+class ModelId(str):
+    """A non-empty model identity; absence remains represented by ``None``."""
+
+    def __new__(cls, value: str) -> ModelId:
+        if not isinstance(value, str):
+            raise TypeError("model id must be a string")
+        if not value.strip():
+            raise ValueError("model id must be a non-empty string")
+        return str.__new__(cls, value)
+
+    @classmethod
+    def parse(cls, value: object) -> ModelId:
+        if not isinstance(value, str):
+            raise ValueError("model id must be a string")
+        return cls(value)
+
+
+class RunNumber(int):
+    """A positive repetition identity (booleans are not integers here)."""
+
+    def __new__(cls, value: int) -> RunNumber:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError("run number must be an integer")
+        if value < 1:
+            raise ValueError("run number must be positive")
+        return int.__new__(cls, value)
+
+    @classmethod
+    def parse(cls, value: object) -> RunNumber:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError("run number must be an integer")
+        return cls(value)
+
+
 class Split(str):
     """One of the three closed evaluation phases."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ required-version = "==0.16.0"
 # These parsers intentionally normalize every malformed wire/schema value to
 # ValueError as part of their public validation contract.
 "ablation_model.py" = ["F401", "TRY004"]
-"experimental_pairs.py" = ["TRY004"]
+"experimental_pairs.py" = ["PYI034", "TRY004"]
 "gemini_contracts.py" = ["TRY004"]
 "judge_verdict.py" = ["TRY004"]
 "manifest_contracts.py" = ["PYI034", "TRY004"]

--- a/skill_benchmark.py
+++ b/skill_benchmark.py
@@ -142,6 +142,7 @@ from manifest_contracts import (
     CaseKind,
     CasePopulation,
     ExecutionVariant,
+    RunNumber,
     Split,
 )
 from text_contracts import (
@@ -179,6 +180,8 @@ HARNESS_SEMANTIC_MODULES = (
     "trigger_reporting.py",
 )
 DEFAULT_VARIANTS = list(DEFAULT_EXECUTION_VARIANTS)
+_ResultPair = pair_domain.ExperimentalPair[Mapping[str, Any]]
+_ResultPairConstruction = pair_domain.PairConstruction[Mapping[str, Any]]
 TEXT_ASSERTIONS = {
     "contains",
     "contains_any",
@@ -1690,7 +1693,7 @@ def prepared_task_rows(
                         split=case["split"],
                         kind=case.get("kind", "behavior"),
                         variant_truth=variant,
-                        run_number=run_number,
+                        run_number=RunNumber(run_number),
                         skill_name=manifest["skill_name"],
                         repo_root=str(repo_root),
                         skill_paths=tuple(skill_paths),
@@ -15226,7 +15229,7 @@ def build_reliability(results: list[dict[str, Any]]) -> dict[str, Any]:
     return {"by_case_variant": by_case_variant, "by_variant": by_variant_summary}
 
 
-def _metric_pair_construction(results: list[dict[str, Any]], key: str) -> pair_domain.PairConstruction:
+def _metric_pair_construction(results: list[dict[str, Any]], key: str) -> _ResultPairConstruction:
     def eligibility(row: Mapping[str, Any]) -> tuple[bool, str | None]:
         if not scorable_run(row):
             return False, "unscorable_arm"
@@ -15236,13 +15239,17 @@ def _metric_pair_construction(results: list[dict[str, Any]], key: str) -> pair_d
         if key in {"objective_pass_rate", "combined_pass_rate", "graded_score"} and not 0 <= float(value) <= 1:
             return False, f"invalid_{key}"
         return True, None
-    return pair_domain.pairs_from_rows(results, population="answer", eligibility=eligibility)
+    return pair_domain.pairs_from_rows(
+        results,
+        population=pair_domain.ExperimentalPopulation.ANSWER,
+        eligibility=eligibility,
+    )
 
 
 def paired_case_rates(results: list[dict[str, Any]], *, key: str = "objective_pass_rate") -> tuple[list[float], list[float], list[dict[str, Any]]]:
     """Per-case rates computed only from validated repetition-level pairs."""
     construction = _metric_pair_construction(results, key)
-    grouped: dict[str, list[pair_domain.ExperimentalPair]] = collections.defaultdict(list)
+    grouped: dict[str, list[_ResultPair]] = collections.defaultdict(list)
     for pair in construction.pairs:
         grouped[pair.key.case_id].append(pair)
     paired_with_rates: list[float] = []
@@ -15278,7 +15285,7 @@ def _reliability_counts(rows: list[dict[str, Any]]) -> tuple[int, int]:
 def paired_case_counts(results: list[dict[str, Any]]) -> list[tuple[str, tuple[int, int], tuple[int, int]]]:
     """Per-case success counts over the same validated repetition-level pairs."""
     construction = _metric_pair_construction(results, "objective_pass_rate")
-    grouped: dict[str, list[pair_domain.ExperimentalPair]] = collections.defaultdict(list)
+    grouped: dict[str, list[_ResultPair]] = collections.defaultdict(list)
     for pair in construction.pairs:
         grouped[pair.key.case_id].append(pair)
     pairs: list[tuple[str, tuple[int, int], tuple[int, int]]] = []
@@ -15319,7 +15326,7 @@ PAIR_HEADLINE_FIELDS = (
 
 
 def pairing_aware_block(block: dict[str, Any],
-                        construction: pair_domain.PairConstruction) -> dict[str, Any]:
+                        construction: _ResultPairConstruction) -> dict[str, Any]:
     """Make subset-only lift explicitly diagnostic when any identity is blocked."""
     out = dict(block)
     out["pairing"] = construction.diagnostics()
@@ -15446,7 +15453,7 @@ def paired_reliability_block(pairs: list[tuple[str, tuple[int, int], tuple[int, 
 
 
 def pairing_aware_reliability(block: dict[str, Any],
-                              construction: pair_domain.PairConstruction) -> dict[str, Any]:
+                              construction: _ResultPairConstruction) -> dict[str, Any]:
     out = dict(block)
     out["pairing"] = construction.diagnostics()
     if not construction.blocked:
@@ -15731,18 +15738,21 @@ def build_ablation_regression_report(manifest: dict[str, Any], results: list[dic
             return True, None
 
         ablation_pairing = pair_domain.pairs_from_rows(
-            ablation_pair_rows, population="answer", eligibility=ablation_eligibility)
-        pairs_by_case_model: dict[tuple[str, str | None], list[pair_domain.ExperimentalPair]] = collections.defaultdict(list)
+            ablation_pair_rows,
+            population=pair_domain.ExperimentalPopulation.ANSWER,
+            eligibility=ablation_eligibility,
+        )
+        pairs_by_case_model: dict[tuple[str, str | None], list[_ResultPair]] = collections.defaultdict(list)
         for pair in ablation_pairing.pairs:
             pairs_by_case_model[(pair.key.case_id, pair.key.model)].append(pair)
         entry["pairing"] = ablation_pairing.diagnostics()
 
-        def assertion_value(row: dict[str, Any], name: str) -> bool | None:
+        def assertion_value(row: Mapping[str, Any], name: str) -> bool | None:
             matches = [a.get("passed") for a in list(row.get("assertions", [])) + list(row.get("qualitative_assertions", []))
                        if a.get("name") == name]
             return matches[0] if len(matches) == 1 and isinstance(matches[0], bool) else None
 
-        def paired_assertion_rates(pairs: list[pair_domain.ExperimentalPair], name: str) -> tuple[float | None, float | None, int]:
+        def paired_assertion_rates(pairs: list[_ResultPair], name: str) -> tuple[float | None, float | None, int]:
             observations = []
             for pair in pairs:
                 left = assertion_value(pair.with_skill.payload, name)
@@ -15755,7 +15765,7 @@ def build_ablation_regression_report(manifest: dict[str, Any], results: list[dic
                     sum(right for _, right in observations) / len(observations),
                     len(observations))
 
-        def paired_combined_deltas(pairs: list[pair_domain.ExperimentalPair]) -> list[float]:
+        def paired_combined_deltas(pairs: list[_ResultPair]) -> list[float]:
             deltas = []
             for pair in pairs:
                 left = pair.with_skill.payload.get("combined_pass_rate", pair.with_skill.payload.get("objective_pass_rate"))
@@ -15915,7 +15925,7 @@ def cost_stats(values: list[float]) -> dict[str, Any]:
     }
 
 
-def _row_measurement(row: dict[str, Any], key: str):
+def _row_measurement(row: Mapping[str, Any], key: str):
     measurement = row.get(f"{key}_measurement")
     if isinstance(measurement, telemetry_domain.Measurement):
         return measurement
@@ -15925,7 +15935,7 @@ def _row_measurement(row: dict[str, Any], key: str):
     )
 
 
-def _cost_measurement(row: dict[str, Any]):
+def _cost_measurement(row: Mapping[str, Any]):
     measurement = row.get("cost_measurement")
     if isinstance(measurement, telemetry_domain.Measurement):
         return measurement
@@ -16155,8 +16165,10 @@ def build_cost_summary(results: list[dict[str, Any]], *, judge_results: dict[str
     paired_cost_delta: dict[str, Any] = {}
     deltas_by_currency: dict[str, list[float]] = collections.defaultdict(list)
     all_cost_pairs_comparable = True
-    cost_pairing = pair_domain.pairs_from_rows(rows, population="answer")
-    complete_by_case: dict[str, list[pair_domain.ExperimentalPair]] = collections.defaultdict(list)
+    cost_pairing = pair_domain.pairs_from_rows(
+        rows, population=pair_domain.ExperimentalPopulation.ANSWER
+    )
+    complete_by_case: dict[str, list[_ResultPair]] = collections.defaultdict(list)
     blocked_by_case: dict[str, list[str]] = collections.defaultdict(list)
     for pair in cost_pairing.pairs:
         complete_by_case[pair.key.case_id].append(pair)
@@ -16698,7 +16710,11 @@ def build_trajectory_diff(results: list[dict[str, Any]]) -> dict[str, Any]:
         profiles[base] = _trajectory_profile(events)
         return True, None
 
-    construction = pair_domain.pairs_from_rows(results, population="answer", eligibility=eligibility)
+    construction = pair_domain.pairs_from_rows(
+        results,
+        population=pair_domain.ExperimentalPopulation.ANSWER,
+        eligibility=eligibility,
+    )
     delta_keys = ("steps", "commands", "tool_calls", "file_reads", "file_writes")
     by_case: dict[str, dict[str, Any]] = {}
     for pair in construction.pairs:
@@ -18861,9 +18877,15 @@ def paired_run_bases(runs: Path, case_id: str, with_variant: str, without_varian
         bases: dict[tuple[int, str], Path] = {}
         for arm, discovered in (("with_skill", with_runs), ("without_skill", without_runs)):
             for run_number, base in discovered:
-                key = pair_domain.ExperimentalPairKey(case_id, model, run_number, "answer")
+                key = pair_domain.ExperimentalPairKey.parse(
+                    case_id,
+                    model,
+                    run_number,
+                    pair_domain.ExperimentalPopulation.ANSWER,
+                )
                 bases[(run_number, arm)] = base
-                arms.append(pair_domain.ExperimentalArm(key, arm, base))
+                arms.append(pair_domain.ExperimentalArm(
+                    key, pair_domain.ExperimentalArmId(arm), base))
         construction = pair_domain.construct_pairs(arms)
         for pair in construction.pairs:
             yield model, pair.key.run_number, pair.with_skill.payload, pair.without_skill.payload
@@ -19305,11 +19327,11 @@ def readiness_run_signals(benchmark_report: dict[str, Any], *, eps: float = 1e-9
     for row in rows:
         intent.setdefault(row.get("case_id"), row.get("eval_intent", "capability"))
     pairing = pair_domain.pairs_from_rows(
-        rows, population="answer",
+        rows, population=pair_domain.ExperimentalPopulation.ANSWER,
         eligibility=lambda row: ((True, None) if scorable_run(row) else (False, "unscorable_arm")),
     )
 
-    def combined_value(row: dict[str, Any]) -> float | None:
+    def combined_value(row: Mapping[str, Any]) -> float | None:
         value = row.get("combined_pass_rate")
         # Soft judges live in graded_score, not combined; the qualitative signal
         # this function looks for rides whichever channel the judge fed.
@@ -19320,7 +19342,7 @@ def readiness_run_signals(benchmark_report: dict[str, Any], *, eps: float = 1e-9
         return (float(value) if isinstance(value, (int, float)) and not isinstance(value, bool)
                 and math.isfinite(float(value)) and 0 <= float(value) <= 1 else None)
 
-    by_case: dict[str, list[pair_domain.ExperimentalPair]] = collections.defaultdict(list)
+    by_case: dict[str, list[_ResultPair]] = collections.defaultdict(list)
     for pair in pairing.pairs:
         by_case[pair.key.case_id].append(pair)
     base_saturated, base_saturated_expected, qualitative_only = [], [], []

--- a/tests/test_experimental_pairs.py
+++ b/tests/test_experimental_pairs.py
@@ -6,6 +6,10 @@ import experimental_pairs as ep
 class ExperimentalPairKeyTests(unittest.TestCase):
     def test_identity_dimensions_are_required_and_validated(self):
         key = ep.ExperimentalPairKey("case", "model", 2, "answer")
+        self.assertIsInstance(key.case_id, ep.CaseId)
+        self.assertIsInstance(key.model, ep.ModelId)
+        self.assertIsInstance(key.run_number, ep.RunNumber)
+        self.assertIs(key.population, ep.ExperimentalPopulation.ANSWER)
         self.assertEqual(key.to_dict(), {
             "case_id": "case", "model": "model", "run_number": 2, "population": "answer",
         })
@@ -24,6 +28,14 @@ class ExperimentalPairKeyTests(unittest.TestCase):
     def test_row_boundary_does_not_invent_repetition_identity(self):
         with self.assertRaisesRegex(ValueError, "run_number"):
             ep.ExperimentalPairKey.from_row({"case_id": "c"}, population="answer")
+
+    def test_parse_constructs_one_precise_identity_from_wire_values(self):
+        key = ep.ExperimentalPairKey.parse("case", None, 3, "judge")
+        self.assertEqual(
+            key.to_dict(),
+            {"case_id": "case", "model": None, "run_number": 3, "population": "judge"},
+        )
+        self.assertIs(key.population, ep.ExperimentalPopulation.JUDGE)
 
 
 class PairConstructionTests(unittest.TestCase):
@@ -65,6 +77,7 @@ class PairConstructionTests(unittest.TestCase):
         ])
         self.assertEqual(ineligible.blocked[0].reason, "unscorable_arm")
         self.assertEqual(ineligible.diagnostics(), {
+            "contrast_id": "skill_presence",
             "eligible_pairs": 0,
             "blocked_pairs": 1,
             "blocked_reason_counts": {"unscorable_arm": 1},
@@ -77,7 +90,7 @@ class PairConstructionTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             ep.ExperimentalArm(key, "without_skill", {}, False, None)
         with self.assertRaises(ValueError):
-            ep.ExperimentalArm(key, "ablation", {})
+            ep.construct_pairs([ep.ExperimentalArm(key, "ablation", {})])
         with self.assertRaises(TypeError):
             ep.ExperimentalArm(None, "with_skill", {})  # type: ignore[arg-type]
         with self.assertRaises(TypeError):
@@ -93,6 +106,67 @@ class PairConstructionTests(unittest.TestCase):
             ep.pairs_from_rows([{**row, "case_id": 1}], population="answer")
         with self.assertRaisesRegex(ValueError, "population.*conflicts"):
             ep.pairs_from_rows([{**row, "population": "trigger"}], population="answer")
+
+    def test_declared_contrast_supports_non_presence_coordinates(self):
+        contrast = ep.ContrastSpec(
+            contrast_id="native-vs-forced",
+            treatment_arm=ep.ExperimentalArmId("native"),
+            control_arm=ep.ExperimentalArmId("forced"),
+            treatment=ep.TreatmentCoordinate((
+                ep.FactorCoordinate(ep.ExperimentalFactor.ACTIVATION, "native"),
+                ep.FactorCoordinate(ep.ExperimentalFactor.SKILL_SET, "all"),
+            )),
+            control=ep.TreatmentCoordinate((
+                ep.FactorCoordinate(ep.ExperimentalFactor.ACTIVATION, "forced"),
+                ep.FactorCoordinate(ep.ExperimentalFactor.SKILL_SET, "all"),
+            )),
+        )
+        key = ep.ExperimentalPairKey("c", "m", 1, "answer")
+        construction = ep.construct_pairs([
+            ep.ExperimentalArm(key, "native", {"answer": "n"}),
+            ep.ExperimentalArm(key, "forced", {"answer": "f"}),
+        ], contrast=contrast)
+
+        self.assertEqual(construction.contrast, contrast)
+        self.assertEqual(construction.pairs[0].treatment.payload["answer"], "n")
+        self.assertEqual(construction.pairs[0].control.payload["answer"], "f")
+        with self.assertRaises(AttributeError):
+            _ = construction.pairs[0].with_skill
+
+    def test_equivalent_default_contrast_retains_stable_compatibility_identity(self):
+        reconstructed = ep.ContrastSpec(
+            contrast_id=ep.SKILL_PRESENCE_CONTRAST.contrast_id,
+            treatment_arm=ep.SKILL_PRESENCE_CONTRAST.treatment_arm,
+            control_arm=ep.SKILL_PRESENCE_CONTRAST.control_arm,
+            treatment=ep.SKILL_PRESENCE_CONTRAST.treatment,
+            control=ep.SKILL_PRESENCE_CONTRAST.control,
+        )
+        pair = ep.construct_pairs([
+            self.arm(), self.arm(arm="without_skill"),
+        ], contrast=reconstructed).pairs[0]
+
+        self.assertEqual(pair.with_skill.arm, "with_skill")
+        self.assertEqual(pair.without_skill.arm, "without_skill")
+
+    def test_contrast_identity_survives_blocked_diagnostics(self):
+        construction = ep.construct_pairs([self.arm()])
+
+        self.assertEqual(construction.blocked[0].contrast_id, "skill_presence")
+        self.assertEqual(construction.blocked[0].to_dict()["contrast_id"], "skill_presence")
+        self.assertEqual(construction.diagnostics()["contrast_id"], "skill_presence")
+
+    def test_pair_construction_rejects_directly_assembled_contradictions(self):
+        key = ep.ExperimentalPairKey("c", None, 1, "answer")
+        pair = ep.construct_pairs([
+            ep.ExperimentalArm(key, "with_skill", {}),
+            ep.ExperimentalArm(key, "without_skill", {}),
+        ]).pairs[0]
+        with self.assertRaises(ValueError):
+            ep.PairConstruction(
+                ep.SKILL_PRESENCE_CONTRAST,
+                (pair,),
+                (ep.BlockedExperimentalPair(key, "also_blocked", "skill_presence"),),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_manifest_contracts.py
+++ b/tests/test_manifest_contracts.py
@@ -5,9 +5,12 @@ import ablation_model
 import skill_benchmark as sb
 from manifest_contracts import (
     ABLATION_VARIANT_PREFIX,
+    CaseId,
     CaseKind,
     CasePopulation,
     ExecutionVariant,
+    ModelId,
+    RunNumber,
     Split,
     ablation_id_of,
     is_ablation_variant,
@@ -15,6 +18,20 @@ from manifest_contracts import (
 
 
 class ManifestIdentityContractTests(unittest.TestCase):
+    def test_run_identity_scalars_are_validated_and_keep_wire_shape(self):
+        identity = {
+            "case_id": CaseId.parse("case-1"),
+            "model": ModelId.parse("model-a"),
+            "run_number": RunNumber.parse(2),
+        }
+        self.assertEqual(
+            json.dumps(identity),
+            '{"case_id": "case-1", "model": "model-a", "run_number": 2}',
+        )
+        for value in (0, -1, True, "1", None):
+            with self.subTest(run_number=value), self.assertRaises(ValueError):
+                RunNumber.parse(value)
+
     def test_split_is_closed_and_keeps_wire_shape(self):
         splits = [Split.parse(value) for value in Split.values()]
         self.assertEqual(splits, ["tune", "holdout", "holdback"])

--- a/type_tests/abstraction_contracts.py
+++ b/type_tests/abstraction_contracts.py
@@ -6,9 +6,17 @@ current union can be narrowed exhaustively and that its public fields retain
 the intended precise types.
 """
 
+from pathlib import Path
 from typing import NoReturn
 
+from typing_extensions import assert_type
+
 from ablation_model import PreparedTask
+from experimental_pairs import (
+    ExperimentalPair,
+    ExperimentalPairKey,
+    ExperimentalPopulation,
+)
 from judge_verdict import (
     BooleanVerdict,
     ConsensusVerdict,
@@ -17,7 +25,14 @@ from judge_verdict import (
     JudgeVerdict,
     ScoredVerdict,
 )
-from manifest_contracts import CaseKind, ExecutionVariant, Split
+from manifest_contracts import (
+    CaseId,
+    CaseKind,
+    ExecutionVariant,
+    ModelId,
+    RunNumber,
+    Split,
+)
 from runner_contracts import (
     AnswerOutcome,
     Completed,
@@ -92,7 +107,23 @@ def judge_verdict_is_exhaustive(verdict: JudgeVerdict) -> None:
 
 
 def prepared_task_identity_is_precise(task: PreparedTask) -> None:
+    _case_id: CaseId = task.case_id
     _split: Split = task.split
     _kind: CaseKind = task.kind
     _variant: ExecutionVariant = task.variant_truth
+    _run_number: RunNumber = task.run_number
     _visible_variant: ExecutionVariant = task.model_facing_variant()
+
+
+def experimental_pair_identity_is_precise(key: ExperimentalPairKey) -> None:
+    _case_id: CaseId = key.case_id
+    _model: ModelId | None = key.model
+    _run_number: RunNumber = key.run_number
+    _population: ExperimentalPopulation = key.population
+
+
+def experimental_pair_payload_type_is_preserved(
+    pair: ExperimentalPair[Path],
+) -> None:
+    assert_type(pair.with_skill.payload, Path)
+    assert_type(pair.without_skill.payload, Path)


### PR DESCRIPTION
## Summary

- add validated `CaseId`, `ModelId`, positive `RunNumber`, and closed population identities
- replace hard-coded arm pairing internals with an explicit `ContrastSpec`, arm IDs, and canonical activation / skill-set / content-revision coordinates
- define durable comparison identity as `(contrast_id, pair_key)` and retain it in blocked rows and pairing diagnostics
- preserve payload types through generic `ExperimentalArm`, `ExperimentalPair`, and `PairConstruction` values

This is layer 3 of the `ty` migration stack and depends on #74.

## Why

Comparative results are valid only when both arms share the exact case, model, repetition, and population identity and answer one declared causal question. The previous representation made the default `with_skill` / `without_skill` comparison implicit and erased payloads to `Any`, which would not support native-discovery or composition contrasts safely.

## Compatibility and risk

The default contrast retains the existing `with_skill` / `without_skill` row names and compatibility projections. Reconstructed equal contrast values work by stable value identity rather than Python object identity. Pairing diagnostics gain an additive `contrast_id`; malformed, duplicate, or cross-contrast inputs now fail before aggregation.

## Validation

- focused identity, pairing, reporting, statistics, and telemetry tests
- static payload-precision proof with `assert_type`
- top-of-stack integration: 1,335 passed, 7 skipped, 858 subtests
- warning-fatal `ty`, Ruff, byte compilation, doc-reference check, and `git diff --check`
