### PR TITLE
Type provider invocation plans

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -71,7 +71,7 @@ Jetty runbooks emit a standardized machine-readable `validation_report.json` per
 (`jettyio/jettyio-skills`, `skills/create-runbook/SKILL.md`). Rubric evaluation scores 3-7
 dimensions on a 1-5 scale; programmatic evaluation returns `PASS` / `PARTIAL` / `FAIL`. The
 items below map that report onto the harness judge-result row `{judge_task_id, passed, score,
-threshold, evidence}` (`load_judge_results:11643`, merged in `grade_case_variant:13904`).
+threshold, evidence}` (`load_judge_results:11611`, merged in `grade_case_variant:13872`).
 
 - [ ] Export qualitative judge tasks to Jetty workflows using `simple_judge` where useful.
       Carry `judge_task_id` (`case::variant::run-n::assertion`) into the Jetty task so the

--- a/docs/abstractions.md
+++ b/docs/abstractions.md
@@ -165,10 +165,10 @@ in the codebase.
 ## Runner / adapter
 
 An **answer runner** consumes prepared task rows and produces the run-output contract. The repo
-ships Pi answer smoke (`examples/adewale-workspace/run_pi_smoke.py`), Codex (`run_codex:10528`), Claude (`run_claude:10709`, capturing real
+ships Pi answer smoke (`examples/adewale-workspace/run_pi_smoke.py`), Codex (`run_codex:10485`), Claude (`run_claude:10671`, capturing real
 per-run cost), Gemini CLI and Mistral Vibe (`run-agent --agent gemini|vibe`, using isolated provider homes outside the workdir), the in-process
-subagent runner (`run_subagent:13249`, which hosts record/replay tool I/O via `ToolReplayStore`),
-Jetty (`JettyClient:4002` and the export/run/import commands), and any runner that writes the
+subagent runner (`run_subagent:13217`, which hosts record/replay tool I/O via `ToolReplayStore`),
+Jetty (`JettyClient:4006` and the export/run/import commands), and any runner that writes the
 contract directly. Each answer runner registers a workspace builder so one cross-runner invariant
 proves its `without_skill` arm is skill-free (CF.2). Autonomous trigger runners are separate: they
 read trigger cases from the manifest directly, never consume answer task rows, and emit trigger
@@ -180,6 +180,16 @@ fields; `write_runner_outcome` exhaustively writes the disk contract. A backend 
 independently set timeout, return code, answer, and failure into a contradictory bag. The harness
 calls no model during default grading; it reads what the runner left behind. The explicit
 `--allow-scripts` and `--embed-cmd` modes may invoke caller-supplied external oracle subprocesses.
+
+Before a native provider subprocess starts, `invocation_contracts.py` constructs one
+`ProcessInvocationPlan`: immutable argv, stdin, working directory, environment, and a positive
+`TimeoutSeconds`. `run_argv_capture` accepts only that plan and returns the closed
+`InvocationResult` lifecycle. The answer backend receives the smaller `InvocationRequest`, whose
+model and timeout are also precise values. Provider adapters can choose wire formats, but they
+cannot omit or disagree about process inputs after the plan boundary. The same module owns the
+shared `InvocationState` vocabulary: `InvocationResult` admits only process-boundary states, while
+provider or harness failures remain semantic classifications and never rewrite the observed return
+code.
 
 ## Trace normalization
 
@@ -242,7 +252,7 @@ those pairs; missing/ineligible arms remain in `pairing` diagnostics and duplica
 `build_slice_summary` breaks results down
 by domain, difficulty, trigger type, and success goal. Case flags mark saturated, no-lift,
 flaky, and with-skill-failed cases. These flags, the leakage lint
-(`prompt_assertion_leakage_findings:792`), and the split discipline are the part of the tool
+(`prompt_assertion_leakage_findings:796`), and the split discipline are the part of the tool
 no surveyed eval framework copies.
 
 The pairing key carries `CaseId`, `ModelId | None`, `RunNumber`, and the closed

--- a/docs/correctness-by-construction-audit.md
+++ b/docs/correctness-by-construction-audit.md
@@ -122,6 +122,7 @@ a provider-specific wire contract at the point where Gemini's JSON or JSONL leav
 
 ```text
 InvocationRequest
+  -> ProcessInvocationPlan
   -> InvocationResult
   -> GeminiStream | GeminiJsonResponse
   -> Completed | ProviderFailed        (answer)
@@ -129,10 +130,10 @@ InvocationRequest
 ```
 
 - `InvocationRequest` is a validated minimal answer request: prompt, optional model, positive timeout,
-  and working directory. It does **not** freeze argv, environment, auth, or provider policy; those are
-  still adapter-owned plans assembled after request construction and remain the clearest abstraction
-  gap for a future typed `InvocationPlan`. The Gemini adapter accepts one caller-trusted executable
-  token and owns output-format,
+  and working directory. Provider adapters refine it into a frozen `ProcessInvocationPlan` containing
+  argv, stdin, cwd, timeout, and environment; the sole internal subprocess owner accepts that plan,
+  including version probes. Provider-specific auth and policy remain adapter-owned inputs to plan
+  construction. The Gemini adapter accepts one caller-trusted executable token and owns output-format,
   policy, trust, conditional sandbox, workspace expansion, session, extension, and prompt/model
   flags. Prefix launchers are rejected because they can reinterpret appended arguments; the chosen
   executable itself remains an explicit operator authority recorded in artifacts.

--- a/docs/eval-framework-roadmap-spec.md
+++ b/docs/eval-framework-roadmap-spec.md
@@ -17,7 +17,7 @@ One invariant governs every item: core grading stays local and deterministic and
 model, and the harness never picks a model for the user. Anything that needs a model lives
 behind an opt-in command or the external `--judge-cmd`. Two abstractions absorb most of the
 work, so the spec returns to them often: the assertion result shape in `assertion_result`
-(`skill_benchmark.py:11217`) and the fan-out in `prepared_task_rows` (`:1564`).
+(`skill_benchmark.py:11185`) and the fan-out in `prepared_task_rows` (`:1568`).
 
 ## Testing baseline
 
@@ -40,7 +40,7 @@ tests are where that claim is checked rather than trusted.
 
 The buckets below extend what the harness can measure. This floor decides whether the number it
 already prints can be believed. The harness reports one thing: lift, `with_skill` minus
-`without_skill` on the same case (`build_paired_summary` (`:15348`)). That number is believable only
+`without_skill` on the same case (`build_paired_summary` (`:15316`)). That number is believable only
 when three preconditions hold, each intended today, none enforced, and each restating a claim from
 `evals-are-not-tests.md`:
 
@@ -60,22 +60,22 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
   hiding the quantity the tool exists to measure.
 - **Abstractions used or changed:** none in the engine. Adds
   `tests/fixtures/detectors/<detector_id>/should-fire.*` and `should-pass.*` that exercise
-  `assertion_result` (`:11217`) directly. That function has no direct unit test today, and its
+  `assertion_result` (`:11185`) directly. That function has no direct unit test today, and its
   `contains_any`, `excludes_any`, and `not_regex` branches go unexercised even though their types
-  are declared in the assertion registries (`TEXT_ASSERTIONS:185`).
+  are declared in the assertion registries (`TEXT_ASSERTIONS:189`).
 - **Design:** one table-driven test loads every pair and asserts the detector fires on `should-fire`
   and stays silent on `should-pass`. A `should-pass` twin is mandatory: it enforces the
   false-positive bar `authoring-evals.md` already sets for skill authors ("check both presence and
   absence"). Each `should-pass` set includes a case where the baseline echoes the prompt, because a
   detector that passes on echoed prompt text is a false oracle; this ties the fixtures to leakage
-  lint (`prompt_assertion_leakage_findings` (`:792`)). Every detector bug then becomes a permanent
+  lint (`prompt_assertion_leakage_findings` (`:796`)). Every detector bug then becomes a permanent
   fixture pair, and `test_command_assertions_match_command_inputs_not_outputs` is the first.
 - **Why it is the keystone:** the fixture pair is also the registration contract. It is what lets a
   harvested or third-party detector be trusted on entry, so it gates the exapted detector library
   (TODO, end of 2026), and it raises the oracle-strength ladder (1.7) so that "strong" means
   fixture-verified, not only deterministic.
 - **Testing:** the fixtures are the test. A meta-test asserts every name in `OBJECTIVE_ASSERTIONS`
-  (`:222`) has a fixture pair, so a new detector cannot land unverified.
+  (`:226`) has a fixture pair, so a new detector cannot land unverified.
 
 ### CF.2 — One cross-runner baseline-isolation invariant
 - **Goal:** prove the baseline is skill-free by construction, so a measured lift is the skill's
@@ -101,7 +101,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 ### CF.4 — A guard that the core grade path calls no model and no network
 - **Goal:** make the governing invariant — "core grading stays local and deterministic and never
   calls a model" — executable rather than aspirational.
-- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:13904`).
+- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:13872`).
 - **Design:** patch `urllib` and `subprocess` to raise, then grade a fixture covering every
   objective family (text, process, efficiency) and assert it completes. The sanctioned exceptions —
   `script` oracles and `judge` plumbing — are excluded from this path by design and keep their own
@@ -111,7 +111,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 
 ### Boundary
 The set stops here deliberately. Report-level correctness — whether the saturation, no-lift, flaky,
-and negative-delta flags (`build_benchmark_report` (`:16767`)) are computed right — sits a layer
+and negative-delta flags (`build_benchmark_report` (`:16735`)) are computed right — sits a layer
 above the raw measurement, where the golden-report tests the buckets already plan (1.2, 2.6) cover
 it. CF.1–CF.4 are the floor underneath that work: once they pass, a printed lift carries a checked
 measurement, and every feature in the buckets builds on a number that has been verified rather than
@@ -125,9 +125,9 @@ assumed.
 - **Goal:** ship graders authors reach for often, so they stop hand-rolling rubrics.
 - **Abstractions used or changed:** `tool_call` and `structured_output` are deterministic, so
   they become new types in `TEXT_ASSERTIONS` / `PROCESS_ASSERTIONS` and gain a branch in
-  `assertion_result`. `tool_call` reuses `command_events` (`:6397`) and the `command_order`
+  `assertion_result`. `tool_call` reuses `command_events` (`:6401`) and the `command_order`
   logic; `structured_output` extends `json_field_equals` with JSON-Schema validation.
-  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:11800`) renders
+  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:11768`) renders
   and still runs through `--judge-cmd`.
 - **Design:** a preset expands to either a deterministic objective assertion or a `judge`
   assertion with a canned rubric and threshold. No new execution path.
@@ -146,7 +146,7 @@ assumed.
 ### 1.3 Judge config slot and the "judge is not the model under test" guard
 - **Goal:** make an existing convention enforceable.
 - **Abstractions used or changed:** read an optional `judge` block in the manifest; add a check
-  in `audit_manifest_report` (`:19590`) comparing the declared judge model against `jetty.model`
+  in `audit_manifest_report` (`:19558`) comparing the declared judge model against `jetty.model`
   or the run metadata `model`.
 - **Design:** warn by default, error under `--strict-judge`.
 - **Testing:** unit tests for matching and differing model ids.
@@ -163,7 +163,7 @@ assumed.
 - **Status:** `docs/authoring-evals.md` shipped, alongside `architecture.md` and
   `abstractions.md`.
 - **Follow-on:** surface the guide's rules where they are checkable. Extend the messaging in
-  `prompt_assertion_leakage_findings` (`:792`) and `fixture_recommendations` (`:19283`) to point
+  `prompt_assertion_leakage_findings` (`:796`) and `fixture_recommendations` (`:19251`) to point
   at the relevant section.
 - **Testing:** assert the new hint strings appear for crafted manifests.
 
@@ -172,8 +172,8 @@ assumed.
   In `adewale/pythonbyexample` and `adewale/xampler` an example *is* an eval case: an input, an
   expected output, and a check that the output still matches. The harness has no equivalent of
   "this output equals this reference."
-- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:185`), implemented in
-  `assertion_result` (`:11217`). It reads `output.md` (or a named artifact), applies an optional
+- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:189`), implemented in
+  `assertion_result` (`:11185`). It reads `output.md` (or a named artifact), applies an optional
   normalization (trim, collapse whitespace, or a named normalizer), and compares to a reference
   file under the manifest dir. Evidence is a unified diff on mismatch.
 - **Design:** normalization is the whole game, so it is explicit and per-assertion, never
@@ -188,9 +188,9 @@ assumed.
   not name it.
 - **Abstractions used or changed:** an optional `oracle` tier on an assertion
   (`strong` / `demo` / `live`), defaulting by type (deterministic text/process are `strong`,
-  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:16767`)
+  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:16735`)
   reports, per case, the share of its pass rate carried by `strong` oracles;
-  `audit_manifest_report` (`:19590`) warns when a case passes only on weak ones. This extends
+  `audit_manifest_report` (`:19558`) warns when a case passes only on weak ones. This extends
   leakage lint (`:164`) from prompts to oracles.
 - **Strongest tier — the rendered-artifact oracle:** the top of the ladder is an oracle that
   builds or renders the artifact and inspects the result, not the source text.
@@ -205,8 +205,8 @@ assumed.
   splits "good poster" into seven `script` oracles, but each is forced all-or-nothing by the
   exit-code-only contract: a poster with six of seven drama carriers fails `drama_oracle` exactly
   like one with zero. That is the binary-saturation problem inside a single oracle.
-- **Abstractions used or changed:** extend `run_script_assertion` (`:11085`) and
-  `assertion_result` (`:11217`) to optionally parse a score from the oracle's stdout — a JSON line
+- **Abstractions used or changed:** extend `run_script_assertion` (`:11053`) and
+  `assertion_result` (`:11185`) to optionally parse a score from the oracle's stdout — a JSON line
   such as `{"score": 6, "max_score": 7}` (normalized to 0-1) — beside the existing
   `pass_exit_code`. The parsed score flows into the `score`/`severity` channel from 2.2, so a
   script oracle becomes a graded dimension while staying fully deterministic and model-free.
@@ -223,9 +223,9 @@ assumed.
   past it — either way, question it. This is the inverse of the saturation flag: saturation marks
   a case as too easy *now*; staleness marks a case that has never discriminated *over time*.
 - **Abstractions used or changed:** reads the cross-run history from 2.6. A `prune` report (or a
-  flag in `build_benchmark_report` (`:16767`)) marks a case a removal candidate when, across the
+  flag in `build_benchmark_report` (`:16735`)) marks a case a removal candidate when, across the
   last N runs, it never failed and never showed lift (`with_skill` == `without_skill` every time).
-  `audit_manifest_report` (`:19590`) lists the candidates; removal stays a human decision.
+  `audit_manifest_report` (`:19558`) lists the candidates; removal stays a human decision.
 - **Design:** the harness suggests, never deletes. A case may be kept deliberately as a
   regression guard even when stale; the report says so rather than acting.
 - **Depends on:** 2.6 (needs run history to judge "never failed over time").
@@ -239,12 +239,12 @@ assumed.
 ### 2.1 Multi-model fan-out (priority)
 - **Goal:** run the same cases across several models and compare lift per model. No surveyed
   framework does this; vitest-evals, eve, and viteval all push it onto the test runner.
-- **Abstractions used or changed:** `prepared_task_rows` (`:1564`) gains a `model` dimension
+- **Abstractions used or changed:** `prepared_task_rows` (`:1568`) gains a `model` dimension
   beside `variant` and `run_number`. Each row carries its target `model`, and `run_dir` gains a
   model segment (`<case>/<model>/<variant>/run-<n>`), kept backward-compatible when one model
   runs. Runners pass the row `model` through; per-run `model` already lands in `metadata.json`,
-  so grading needs no change. `build_benchmark_report` (`:16767`) groups `by_variant` within
-  `by_model`, and `build_paired_summary` (`:15348`) computes lift per (case, model).
+  so grading needs no change. `build_benchmark_report` (`:16735`) groups `by_variant` within
+  `by_model`, and `build_paired_summary` (`:15316`) computes lift per (case, model).
 - **Design:** model is a third axis, not a new variant. Variants stay orthogonal, giving a
   model-by-variant grid. CLI: `--models a,b,c` on `prepare`.
 - **Testing:** a fan-out test asserting row count equals cases × variants × runs × models with
@@ -261,7 +261,7 @@ assumed.
   no-regression floor. This spec ports those shapes into the harness rather than inventing new
   ones.
 - **Abstractions used or changed:**
-  - `assertion_result` (`:11217`) gains an optional `score` (0-1 or a normalized 1-5) and
+  - `assertion_result` (`:11185`) gains an optional `score` (0-1 or a normalized 1-5) and
     `severity` (`critical` / `gate` / `soft`), read from `critical`/`gate`/`soft`/`atLeast` on the
     assertion.
   - **`critical` (absorbing-barrier) tier — valley-dodging.** From the Jetty "valley-dodging"
@@ -276,13 +276,13 @@ assumed.
   - **Anchored `graded_dimensions`** as a `judge` assertion shape:
     `{name, scale: "1-5", rubric: "5 = …observable…; 1 = …observable…"}`. Anchors name what each
     score level looks like, so a judge scores against criteria, not a vibe. `judge_prompt`
-    (`:11800`) renders the dimensions; the result carries per-dimension scores in `evidence`.
+    (`:11768`) renders the dimensions; the result carries per-dimension scores in `evidence`.
   - **`dynamic_rubric`** as a second `judge` shape: `{instruction, minimum_criteria}`. The judge
     drafts 3-5 case-specific criteria before grading and must meet at least `minimum_criteria`.
-  - `grade_case_variant` (`:13904`) splits totals into critical, gated, and soft. A `critical`
+  - `grade_case_variant` (`:13872`) splits totals into critical, gated, and soft. A `critical`
     failure vetoes the case; a `gate` failure lowers the pass rate; a `soft` failure lowers
     neither and fills a `scored` bucket. A `--strict` flag promotes soft to gate.
-  - **Statistical lift** in `build_paired_summary` (`:15348`): alongside the raw delta, compute a
+  - **Statistical lift** in `build_paired_summary` (`:15316`): alongside the raw delta, compute a
     significance test over the per-case graded scores (paired bootstrap or sign-flip
     permutation, mirroring `score_delta.py`), so lift is tested, not eyeballed.
   - **Reference-anchor floor:** an optional `reference_score` / `reference_graded_score` on a
@@ -315,7 +315,7 @@ assumed.
 - **Goal:** deterministic re-runs that pay nothing for external dependencies, by recording tool
   inputs and outputs.
 - **Abstractions used or changed:** this lives in the runner, not core grading. Recording sits
-  beside `write_trace_artifacts` (`:8258`): a `tool-replay.json` keyed per tool, with
+  beside `write_trace_artifacts` (`:8274`): a `tool-replay.json` keyed per tool, with
   `sanitize` and `version`. Modes (`auto`, `record`, `off`, `strict`) come from an environment
   variable that `run_codex` and the Pi and subagent runners read.
 - **Design:** orthogonal to the disk re-grade the harness already does. Replay makes the agent
@@ -326,8 +326,8 @@ assumed.
 
 ### 2.4 OpenTelemetry GenAI normalization target
 - **Goal:** make the trace adapter boundary a standard rather than a bespoke schema.
-- **Abstractions used or changed:** `normalize_trace_record` (`:7315`) and
-  `normalize_trace_records` (`:7974`) keep their inputs but emit OTel GenAI semantic-key
+- **Abstractions used or changed:** `normalize_trace_record` (`:7331`) and
+  `normalize_trace_records` (`:7990`) keep their inputs but emit OTel GenAI semantic-key
   attributes; the `events.json` schema version bumps. Process and efficiency assertions read the
   new keys with backward-compatible fallbacks.
 - **Design:** additive schema. An old `events.json` still grades.
@@ -337,7 +337,7 @@ assumed.
 ### 2.5 Dataset abstraction
 - **Goal:** fan one case template over many rows instead of hand-authoring each case.
 - **Abstractions used or changed:** a new optional manifest construct (`datasets`, plus a case
-  `template` referencing a dataset id). `iter_cases` (`:599`) materializes template by row into
+  `template` referencing a dataset id). `iter_cases` (`:603`) materializes template by row into
   concrete cases before fan-out; `validate_manifest` validates rows and runs leakage lint per
   materialized case.
 - **Design:** materialization happens early, so prepare, grade, and report stay unchanged.
@@ -351,7 +351,7 @@ assumed.
 - **Goal:** watch lift, saturation, and token drift over time.
 - **Abstractions used or changed:** a consumer of `build_benchmark_report`. Add an append-only
   history store and a `trend` subcommand that diffs successive `benchmark.json` files, reusing
-  the `compare_results` (`:17949`) logic.
+  the `compare_results` (`:17917`) logic.
 - **Severity-weighted ranking (from the macro-evals notebook):** when surfacing recurring
   failures across runs, rank them by `prevalence × severity`, not raw count, so a rare but severe
   failure outranks a common trivial one. This is the floor-raising principle made quantitative;
@@ -377,8 +377,8 @@ assumed.
   it dispatches a subagent with a rubric whose "criteria [are] deliberately absent from
   generation rules."
 - **Abstractions used or changed:** mostly a discipline made first-class, not new machinery.
-  `prepared_task_rows` (`:1564`) already omits `review_rubric` from generation payloads unless
-  `--include-answer-key`; extend `validate_manifest` (`:1167`) to require that a `holdout`/
+  `prepared_task_rows` (`:1568`) already omits `review_rubric` from generation payloads unless
+  `--include-answer-key`; extend `validate_manifest` (`:1171`) to require that a `holdout`/
   `holdback` case's rubric stays out of the skill and public eval text, and pair it with the
   subagent judge from 2.7 and the graded scoring from 2.2. Track which rubrics were held out so
   the report can separate held-out scores from tune-visible ones.
@@ -390,7 +390,7 @@ assumed.
 ### 2.8 Interactive served report and richer artifacts
 - **Goal:** capture feedback in the browser and render image, PDF, and xlsx artifacts, beyond the
   static `render_viewer`.
-- **Abstractions used or changed:** extend `render_viewer` (`:18746`) with a `serve` mode and
+- **Abstractions used or changed:** extend `render_viewer` (`:18714`) with a `serve` mode and
   artifact encoders. Anthropic's `eval-viewer/generate_review.py` is the blueprint, including
   `feedback.json` persistence and a `--previous-workspace` diff.
 - **Testing:** unit-test the artifact embedding and categorization and the feedback round trip;
@@ -422,7 +422,7 @@ assumed.
 - **Goal:** evaluate conversational skills across a send/respond sequence.
 - **Abstractions changed (core contract):** a case gains an optional `turns` list. The
   run-output contract grows from one `output.md` to a turn-indexed transcript, so
-  `read_output_base` (`:6250`) and `discover_run_bases` learn the turn layout; runners drive the
+  `read_output_base` (`:6254`) and `discover_run_bases` learn the turn layout; runners drive the
   sequence; `grade_case_variant` grades per turn and aggregates.
 - **Design:** single-shot stays the default, so existing manifests are untouched.
 - **Testing:** a fixture multi-turn run asserting per-turn grading and aggregate, plus a
@@ -435,7 +435,7 @@ assumed.
   the model axis, plus a viewer panel.
 - **Slice-lift concentration (from the macro-evals notebook):** compute, per slice, where lift (or
   a failure) concentrates — `slice share ÷ overall share`, the macro-eval `lift` metric one level
-  up from per-case lift. `build_slice_summary` (`:15519`) already groups by domain/difficulty/
+  up from per-case lift. `build_slice_summary` (`:15487`) already groups by domain/difficulty/
   trigger/goal, so this is a ratio over groups it already forms, not new plumbing.
 - **Testing:** a report test over a two-model by two-variant fixture grid, plus a concentration
   test asserting a failure confined to one slice scores a high ratio there.
@@ -548,7 +548,7 @@ and upgrading to the new features should be something an agent can drive.
 
 ### Abstractions used or changed
 
-- `version` on the manifest (`validate_manifest:1167`) becomes meaningful: `validate` accepts both
+- `version` on the manifest (`validate_manifest:1171`) becomes meaningful: `validate` accepts both
   1 and 2, and warns (not errors) on a `version: 1` manifest once 2.2 has landed, pointing at
   `migrate`.
 - No grading abstraction changes for migration itself; it is a source-rewrite plus a guide.

--- a/docs/skill-ablation-spec.md
+++ b/docs/skill-ablation-spec.md
@@ -363,7 +363,7 @@ Opt in with `"invalid_skill": true` on the ablation: the run is tagged
 
 ## Validation additions
 
-`validate_manifest` (`skill_benchmark.py:1167`), per ablation:
+`validate_manifest` (`skill_benchmark.py:1171`), per ablation:
 
 - `id` unique and slug-formatted; keep `removed_component`.
 - If a removal is declared: exactly one of `mechanism`+`target` or `components`;

--- a/invocation_contracts.py
+++ b/invocation_contracts.py
@@ -1,0 +1,212 @@
+"""Provider-neutral request, process-plan, and process-result contracts."""
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+from json_contracts import freeze_json_mapping, validate_json_text
+from manifest_contracts import ModelId
+
+
+class InvocationState(str, Enum):
+    """Closed lifecycle vocabulary shared by process and semantic adapters.
+
+    ``InvocationResult`` admits only the four process-boundary states. Provider
+    and harness adapters may use the two semantic failure states without
+    rewriting the subprocess return code that produced their evidence.
+    """
+
+    COMPLETE = "complete"
+    TIMED_OUT = "timed_out"
+    SPAWN_FAILED = "spawn_failed"
+    PROCESS_FAILED = "process_failed"
+    PROVIDER_FAILED = "provider_failed"
+    HARNESS_FAILED = "harness_failed"
+
+
+class TimeoutSeconds(int):
+    """A positive provider invocation timeout."""
+
+    def __new__(cls, value: int) -> TimeoutSeconds:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError("invocation timeout must be an integer")
+        if value < 1:
+            raise ValueError("invocation timeout must be positive")
+        return int.__new__(cls, value)
+
+    @classmethod
+    def parse(cls, value: object) -> TimeoutSeconds:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError("invocation timeout must be an integer")
+        return cls(value)
+
+
+@dataclass(frozen=True)
+class InvocationRequest:
+    """Provider-neutral request handed to an answer backend."""
+
+    prompt: str
+    workspace: Path
+    model: ModelId | None
+    timeout_s: TimeoutSeconds
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.prompt, str):
+            raise TypeError("invocation prompt must be text")
+        validate_json_text(self.prompt, "invocation prompt")
+        if not isinstance(self.workspace, Path):
+            raise TypeError("invocation workspace must be a Path")
+        object.__setattr__(
+            self,
+            "model",
+            None if self.model is None else ModelId.parse(self.model),
+        )
+        if self.model is not None:
+            validate_json_text(self.model, "invocation model")
+        object.__setattr__(
+            self, "timeout_s", TimeoutSeconds.parse(self.timeout_s)
+        )
+
+    @classmethod
+    def parse(
+        cls,
+        *,
+        prompt: object,
+        workspace: object,
+        model: object,
+        timeout_s: object,
+    ) -> InvocationRequest:
+        if not isinstance(prompt, str):
+            raise ValueError("invocation prompt must be text")
+        if not isinstance(workspace, Path):
+            raise ValueError("invocation workspace must be a Path")
+        return cls(
+            prompt=prompt,
+            workspace=workspace,
+            model=None if model is None else ModelId.parse(model),
+            timeout_s=TimeoutSeconds.parse(timeout_s),
+        )
+
+
+@dataclass(frozen=True)
+class ProcessInvocationPlan:
+    """Everything the subprocess owner needs, validated before spawn."""
+
+    argv: tuple[str, ...]
+    input_text: str | None
+    cwd: Path
+    timeout_s: TimeoutSeconds
+    environment: Mapping[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.argv, tuple):
+            raise TypeError("process argv must be a tuple")
+        if not self.argv or not self.argv[0]:
+            raise ValueError("process argv needs a non-empty executable")
+        if any(not isinstance(value, str) for value in self.argv):
+            raise TypeError("process argv values must be strings")
+        for position, value in enumerate(self.argv):
+            validate_json_text(value, f"process argv[{position}]")
+            if "\x00" in value:
+                raise ValueError("process argv values cannot contain NUL")
+        if self.input_text is not None:
+            if not isinstance(self.input_text, str):
+                raise TypeError("process stdin must be text or None")
+            validate_json_text(self.input_text, "process stdin")
+        if not isinstance(self.cwd, Path):
+            raise TypeError("process cwd must be a Path")
+        object.__setattr__(
+            self, "timeout_s", TimeoutSeconds.parse(self.timeout_s)
+        )
+        if self.environment is not None:
+            if not isinstance(self.environment, Mapping):
+                raise TypeError("process environment must be a mapping or None")
+            copied: dict[str, str] = {}
+            for key, value in self.environment.items():
+                if not isinstance(key, str) or not isinstance(value, str):
+                    raise TypeError("process environment keys and values must be strings")
+                if not key or "=" in key or "\x00" in key or "\x00" in value:
+                    raise ValueError("process environment contains an invalid key or value")
+                copied[key] = value
+            object.__setattr__(self, "environment", MappingProxyType(copied))
+
+    @classmethod
+    def from_values(
+        cls,
+        argv: Sequence[str],
+        *,
+        input_text: str | None,
+        cwd: Path | str,
+        timeout_s: int,
+        environment: Mapping[str, str] | None = None,
+    ) -> ProcessInvocationPlan:
+        if isinstance(argv, (str, bytes)):
+            raise TypeError("process argv must be a sequence of argument strings")
+        return cls(
+            argv=tuple(argv),
+            input_text=input_text,
+            cwd=Path(cwd),
+            timeout_s=TimeoutSeconds(timeout_s),
+            environment=environment,
+        )
+
+
+@dataclass(frozen=True)
+class InvocationResult:
+    stdout: str
+    stderr: str
+    returncode: int
+    elapsed_ms: int
+    invocation_state: InvocationState
+    stdout_utf8_valid: bool
+    stderr_utf8_valid: bool
+    timed_out: bool = False
+    adapter_metadata: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.stdout, str) or not isinstance(self.stderr, str):
+            raise TypeError("invocation stdout and stderr must be text")
+        validate_json_text(self.stdout, "invocation stdout")
+        validate_json_text(self.stderr, "invocation stderr")
+        if type(self.returncode) is not int:
+            raise TypeError("invocation returncode must be an integer")
+        if (isinstance(self.elapsed_ms, bool) or not isinstance(self.elapsed_ms, int)
+                or self.elapsed_ms < 0 or self.elapsed_ms > 2**63 - 1):
+            raise ValueError("invocation elapsed_ms must be a non-negative integer")
+        if not isinstance(self.invocation_state, InvocationState):
+            raise TypeError("invocation_state must be InvocationState")
+        if not isinstance(self.stdout_utf8_valid, bool) or not isinstance(
+                self.stderr_utf8_valid, bool):
+            raise TypeError("invocation UTF-8 validity fields must be boolean")
+        if not isinstance(self.timed_out, bool):
+            raise TypeError("invocation timed_out must be boolean")
+        expected = {
+            InvocationState.COMPLETE: (0, False),
+            InvocationState.TIMED_OUT: (124, True),
+            InvocationState.SPAWN_FAILED: (127, False),
+        }
+        if self.invocation_state in expected:
+            code, timed_out = expected[self.invocation_state]
+            if self.returncode != code or self.timed_out is not timed_out:
+                raise ValueError("invocation state contradicts returncode/timed_out")
+        elif self.invocation_state is InvocationState.PROCESS_FAILED:
+            if self.returncode == 0 or self.timed_out:
+                raise ValueError("process failure requires nonzero exit without timeout")
+        else:
+            raise ValueError("InvocationResult requires a process-boundary state")
+        if self.adapter_metadata is not None:
+            frozen_metadata = freeze_json_mapping(
+                self.adapter_metadata, "invocation adapter metadata")
+            expected_flags = {
+                "stdout_utf8_valid": self.stdout_utf8_valid,
+                "stderr_utf8_valid": self.stderr_utf8_valid,
+            }
+            for key, expected_value in expected_flags.items():
+                if key in frozen_metadata and frozen_metadata[key] is not expected_value:
+                    raise ValueError(
+                        f"invocation adapter metadata contradicts {key}")
+            object.__setattr__(self, "adapter_metadata", frozen_metadata)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ skill-pi-trigger-eval = "run_pi_trigger_eval:main"
 skill-trigger-matrix = "run_trigger_matrix:main"
 
 [tool.setuptools]
-py-modules = ["skill_benchmark", "run_pi_trigger_eval", "run_trigger_matrix", "ablation_model", "agent_capabilities", "telemetry", "trigger_contracts", "trigger_reporting", "trace_contracts", "runner_contracts", "judge_contracts", "judge_verdict", "experimental_pairs", "jetty_contracts", "gemini_contracts", "json_contracts", "manifest_contracts", "text_contracts"]
+py-modules = ["skill_benchmark", "run_pi_trigger_eval", "run_trigger_matrix", "ablation_model", "agent_capabilities", "telemetry", "trigger_contracts", "trigger_reporting", "trace_contracts", "runner_contracts", "judge_contracts", "judge_verdict", "experimental_pairs", "jetty_contracts", "gemini_contracts", "invocation_contracts", "json_contracts", "manifest_contracts", "text_contracts"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
@@ -59,6 +59,7 @@ required-version = "==0.16.0"
 "experimental_pairs.py" = ["PYI034", "TRY004"]
 "gemini_contracts.py" = ["TRY004"]
 "judge_verdict.py" = ["TRY004"]
+"invocation_contracts.py" = ["PYI034", "TRY004"]
 "manifest_contracts.py" = ["PYI034", "TRY004"]
 "runner_contracts.py" = ["TRY004"]
 "telemetry.py" = ["TRY004"]

--- a/run_pi_trigger_eval.py
+++ b/run_pi_trigger_eval.py
@@ -27,6 +27,7 @@ from skill_benchmark import (
     VALID_SPLITS,
     AblationError,
     PiStream,
+    ProcessInvocationPlan,
     build_canonical_skill_tree,
     canonical_json_sha256,
     canonical_trigger_query,
@@ -223,7 +224,13 @@ def observe_query(manifest_path: Path, query: str, should_trigger: bool, timeout
         env = os.environ.copy()
         env["PI_CODING_AGENT_DIR"] = str(config_dir)
         invocation = pi_invocation_outcome(
-            invoke_argv_with_timeout(pi_argv(query, model), cwd=config_dir, env=env, timeout=timeout)
+            invoke_argv_with_timeout(ProcessInvocationPlan.from_values(
+                pi_argv(query, model),
+                input_text="",
+                cwd=config_dir,
+                timeout_s=timeout,
+                environment=env,
+            ))
         )
         stream = invocation.provider_payload
         if not isinstance(stream, PiStream):

--- a/run_trigger_matrix.py
+++ b/run_trigger_matrix.py
@@ -94,6 +94,7 @@ from skill_benchmark import (
     VIBE_READ_ONLY_TOOLS,
     AblationError,
     PiStream,
+    ProcessInvocationPlan,
     build_canonical_skill_tree,
     build_vibe_cli_argv,
     canonical_json_sha256,
@@ -429,7 +430,9 @@ class ClaudeAdapter(AgentAdapter):
             env["CLAUDE_CONFIG_DIR"] = str(config_dir)
             config_isolated = True
         result = validate_invoke_result(
-            self.name, self._run_argv(argv, cwd=workspace, env=env, timeout=timeout)
+            self.name, self._run_argv(ProcessInvocationPlan.from_values(
+                argv, input_text="", cwd=workspace, timeout_s=timeout,
+                environment=env))
         )
         metadata: dict[str, Any] = {"config_isolated": config_isolated}
         if not config_isolated:
@@ -528,7 +531,9 @@ class CodexAdapter(AgentAdapter):
         env, meta = codex_env_for_home(codex_home)
         try:
             result = validate_invoke_result(
-                self.name, self._run_argv(argv, cwd=workspace, env=env, timeout=timeout)
+                self.name, self._run_argv(ProcessInvocationPlan.from_values(
+                    argv, input_text="", cwd=workspace, timeout_s=timeout,
+                    environment=env))
             )
         finally:
             shutil.rmtree(codex_home, ignore_errors=True)
@@ -569,7 +574,9 @@ class PiAdapter(AgentAdapter):
         env["PI_CODING_AGENT_DIR"] = str(workspace / ".pi-config")
         return pi_invocation_outcome(validate_invoke_result(
             self.name,
-            self._run_argv(pi_argv(query, model), cwd=workspace, env=env, timeout=timeout),
+            self._run_argv(ProcessInvocationPlan.from_values(
+                pi_argv(query, model), input_text="", cwd=workspace,
+                timeout_s=timeout, environment=env)),
         )).with_metadata(config_isolated=True)
 
 
@@ -617,7 +624,9 @@ class VibeAdapter(AgentAdapter):
                 )
             result = validate_invoke_result(
                 self.name,
-                self._run_argv(argv, input_text="", cwd=workspace, env=env, timeout=timeout),
+                self._run_argv(ProcessInvocationPlan.from_values(
+                    argv, input_text="", cwd=workspace, timeout_s=timeout,
+                    environment=env)),
             )
             if result.observation_complete:
                 result = result.with_provider_error(

--- a/runner_contracts.py
+++ b/runner_contracts.py
@@ -11,8 +11,8 @@ from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import Any, TypeAlias
 
+from invocation_contracts import InvocationState
 from json_contracts import freeze_json_mapping, validate_json_text
-from trigger_contracts import InvocationState
 
 
 class Provider(str, Enum):

--- a/scripts/smoke_supported_clis.py
+++ b/scripts/smoke_supported_clis.py
@@ -25,7 +25,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from agent_capabilities import SMOKE_TARGETS
-from skill_benchmark import invoke_argv_with_timeout
+from skill_benchmark import ProcessInvocationPlan, invoke_argv_with_timeout
 from telemetry import ObservationEvidence
 from trigger_contracts import CompleteTriggerResult, TriggerObservation
 
@@ -84,7 +84,8 @@ def make_smoke_repo(root: Path) -> Path:
 
 
 def run(command: list[str], *, cwd: Path, report: dict[str, Any], label: str) -> bool:
-    outcome = invoke_argv_with_timeout(command, cwd=cwd, timeout=300)
+    outcome = invoke_argv_with_timeout(ProcessInvocationPlan.from_values(
+        command, input_text="", cwd=cwd, timeout_s=300))
     entry: dict[str, Any] = {
         "label": label,
         "command": command,

--- a/skill_benchmark.py
+++ b/skill_benchmark.py
@@ -118,6 +118,12 @@ from agent_capabilities import (
     workspace_builder_implementations,
 )
 from gemini_contracts import GeminiJsonResponse, GeminiStream
+from invocation_contracts import (
+    InvocationRequest,
+    InvocationResult,
+    InvocationState,
+    ProcessInvocationPlan,
+)
 from jetty_contracts import (
     JettyObservation,
     ProtocolInvalid,
@@ -125,7 +131,6 @@ from jetty_contracts import (
     lifecycle_from_status,
 )
 from json_contracts import (
-    freeze_json_mapping,
     validate_json_text,
     validate_json_value,
 )
@@ -161,7 +166,6 @@ from text_contracts import (
 from trace_contracts import EventState, event_is_completed, parse_event_state
 from trigger_contracts import (
     InvocationOutcome,
-    InvocationState,
     TraceEventKind,
     TriggerDetection,
     TriggerEvidenceKind,
@@ -174,7 +178,7 @@ VALID_SPLITS = frozenset(Split.values())
 HARNESS_SEMANTIC_MODULES = (
     "ablation_model.py", "agent_capabilities.py", "experimental_pairs.py",
     "gemini_contracts.py",
-    "jetty_contracts.py", "judge_contracts.py", "judge_verdict.py", "json_contracts.py", "manifest_contracts.py", "run_pi_trigger_eval.py",
+    "invocation_contracts.py", "jetty_contracts.py", "judge_contracts.py", "judge_verdict.py", "json_contracts.py", "manifest_contracts.py", "run_pi_trigger_eval.py",
     "run_trigger_matrix.py", "runner_contracts.py", "skill_benchmark.py",
     "telemetry.py", "trace_contracts.py", "trigger_contracts.py",
     "trigger_reporting.py",
@@ -6530,13 +6534,20 @@ def mount_skill_tree(tree_dir: Path, skills_dir: Path) -> list[Path]:
     return copied
 
 
-def invoke_argv_with_timeout(argv: list[str], *, cwd: Path | str | None = None,
-                             env: dict[str, str] | None = None, timeout: int,
-                             input_text: str | None = None) -> InvocationOutcome:
+def invoke_argv_with_timeout(plan: ProcessInvocationPlan) -> InvocationOutcome:
     """Typed subprocess owner for every spawned runner/adapter process.
 
-    Completion state is classified once here. Consumers cannot independently
-    assemble contradictory returncode/timeout/completeness booleans."""
+    The owner accepts one fully validated plan, so internal callers cannot
+    bypass cwd, timeout, argv, environment, or stdin construction. Completion
+    state is classified once here; consumers cannot independently assemble
+    contradictory returncode/timeout/completeness booleans."""
+    if not isinstance(plan, ProcessInvocationPlan):
+        raise TypeError("invoke_argv_with_timeout requires a ProcessInvocationPlan")
+    argv = list(plan.argv)
+    cwd = plan.cwd
+    env = None if plan.environment is None else dict(plan.environment)
+    timeout = int(plan.timeout_s)
+    input_text = plan.input_text
     def _wire_text(value: Any) -> tuple[str, bool]:
         if value is None:
             return "", True
@@ -6725,9 +6736,14 @@ def run_argv_with_timeout(argv: list[str], *, cwd: Path | str | None = None,
                           env: dict[str, str] | None = None, timeout: int,
                           input_text: str | None = None) -> dict[str, Any]:
     """Legacy dictionary boundary for external callers; internal code uses the typed owner."""
-    return invoke_argv_with_timeout(
-        argv, cwd=cwd, env=env, timeout=timeout, input_text=input_text,
-    ).as_legacy_dict()
+    plan = ProcessInvocationPlan.from_values(
+        argv,
+        input_text=input_text,
+        cwd=Path.cwd() if cwd is None else cwd,
+        timeout_s=timeout,
+        environment=env,
+    )
+    return invoke_argv_with_timeout(plan).as_legacy_dict()
 
 
 def regex_hit(pattern: str, text: str, ci: bool = True) -> bool:
@@ -8870,84 +8886,6 @@ def build_task_prompt(pt: PreparedTask, skill_paths: list[str] | None = None, in
     )
 
 
-@_dataclass(frozen=True)
-class InvocationRequest:
-    """Provider-neutral request handed to an agent backend.
-
-    The harness owns workspace construction and output writing. A backend owns
-    only the invocation wire format: argv/env/stdout parsing. Keeping that seam
-    small makes Claude/Codex parity testable without live model calls."""
-
-    prompt: str
-    workspace: Path
-    model: str | None
-    timeout_s: int
-
-    def __post_init__(self) -> None:
-        if not isinstance(self.prompt, str):
-            raise TypeError("invocation prompt must be text")
-        validate_json_text(self.prompt, "invocation prompt")
-        if not isinstance(self.workspace, Path):
-            raise TypeError("invocation workspace must be a Path")
-        if self.model is not None and (
-                not isinstance(self.model, str) or not self.model.strip()):
-            raise ValueError("invocation model must be non-empty text or None")
-        if self.model is not None:
-            validate_json_text(self.model, "invocation model")
-        if (isinstance(self.timeout_s, bool)
-                or not isinstance(self.timeout_s, int)
-                or self.timeout_s <= 0):
-            raise ValueError("invocation timeout_s must be a positive integer")
-
-
-@_dataclass(frozen=True)
-class InvocationResult:
-    stdout: str
-    stderr: str
-    returncode: int
-    elapsed_ms: int
-    invocation_state: InvocationState
-    stdout_utf8_valid: bool
-    stderr_utf8_valid: bool
-    timed_out: bool = False
-    adapter_metadata: Mapping[str, Any] | None = None
-
-    def __post_init__(self) -> None:
-        if not isinstance(self.stdout, str) or not isinstance(self.stderr, str):
-            raise TypeError("invocation stdout and stderr must be text")
-        validate_json_text(self.stdout, "invocation stdout")
-        validate_json_text(self.stderr, "invocation stderr")
-        if type(self.returncode) is not int:
-            raise TypeError("invocation returncode must be an integer")
-        if (isinstance(self.elapsed_ms, bool) or not isinstance(self.elapsed_ms, int)
-                or self.elapsed_ms < 0 or self.elapsed_ms > 2**63 - 1):
-            raise ValueError("invocation elapsed_ms must be a non-negative integer")
-        if not isinstance(self.invocation_state, InvocationState):
-            raise TypeError("invocation_state must be InvocationState")
-        if not isinstance(self.stdout_utf8_valid, bool) or not isinstance(
-                self.stderr_utf8_valid, bool):
-            raise TypeError("invocation UTF-8 validity fields must be boolean")
-        if not isinstance(self.timed_out, bool):
-            raise TypeError("invocation timed_out must be boolean")
-        expected = {
-            InvocationState.COMPLETE: (0, False),
-            InvocationState.TIMED_OUT: (124, True),
-            InvocationState.SPAWN_FAILED: (127, False),
-        }
-        if self.invocation_state in expected:
-            code, timed_out = expected[self.invocation_state]
-            if self.returncode != code or self.timed_out is not timed_out:
-                raise ValueError("invocation state contradicts returncode/timed_out")
-        elif self.invocation_state is InvocationState.PROCESS_FAILED:
-            if self.returncode == 0 or self.timed_out:
-                raise ValueError("process failure requires nonzero exit without timeout")
-        else:
-            raise ValueError("InvocationResult requires a process-boundary state")
-        if self.adapter_metadata is not None:
-            object.__setattr__(self, "adapter_metadata", freeze_json_mapping(
-                self.adapter_metadata, "invocation adapter metadata"))
-
-
 def coerce_text(value: Any) -> str:
     if value is None:
         return ""
@@ -8956,7 +8894,7 @@ def coerce_text(value: Any) -> str:
     return str(value)
 
 
-def run_argv_capture(argv: list[str], *, input_text: str, cwd: Path | str, timeout: int, env: dict[str, str] | None = None) -> InvocationResult:
+def run_argv_capture(plan: ProcessInvocationPlan) -> InvocationResult:
     """Native agent adapter wrapper over the one subprocess owner.
 
     Correctness-by-construction boundary: callers must choose an explicit cwd,
@@ -8964,7 +8902,9 @@ def run_argv_capture(argv: list[str], *, input_text: str, cwd: Path | str, timeo
     `run_argv_with_timeout` owns spawn failure, process-group timeout cleanup,
     stderr capping, elapsed time, and returncode shape; this function only adapts
     that dict contract into `InvocationResult`."""
-    outcome = invoke_argv_with_timeout(argv, input_text=input_text, cwd=cwd, env=env, timeout=timeout)
+    if not isinstance(plan, ProcessInvocationPlan):
+        raise TypeError("run_argv_capture requires a ProcessInvocationPlan")
+    outcome = invoke_argv_with_timeout(plan)
     if outcome.returncode is None or outcome.elapsed_ms is None:
         raise RuntimeError("subprocess owner returned a non-process invocation outcome")
     return InvocationResult(stdout=outcome.stdout,
@@ -9714,12 +9654,15 @@ def probe_gemini_cli_version(
         return {"gemini_cli_version_status": "unavailable",
                 "gemini_cli_version_error": "command prefix unavailable"}
     command_prefix = argv[:prompt_index]
-    outcome = invoke_argv_with_timeout(
-        [*command_prefix, "--version"], cwd=cwd, env=env,
-        timeout=max(1, min(timeout, 10)), input_text="",
-    )
-    stdout_utf8_valid = outcome.metadata.get("stdout_utf8_valid") is not False
-    stderr_utf8_valid = outcome.metadata.get("stderr_utf8_valid") is not False
+    outcome = run_argv_capture(ProcessInvocationPlan.from_values(
+        [*command_prefix, "--version"],
+        cwd=cwd,
+        environment=env,
+        timeout_s=max(1, min(timeout, 10)),
+        input_text="",
+    ))
+    stdout_utf8_valid = outcome.stdout_utf8_valid
+    stderr_utf8_valid = outcome.stderr_utf8_valid
     validity = {
         "gemini_cli_version_stdout_utf8_valid": stdout_utf8_valid,
         "gemini_cli_version_stderr_utf8_valid": stderr_utf8_valid,
@@ -9909,10 +9852,13 @@ def gemini_cli_invoke(
                 setup_phase = "provider invocation"
                 version_meta = probe_gemini_cli_version(
                     argv, cwd=workspace, env=env, timeout=timeout)
-                result = run_argv_capture(
-                    argv, input_text="", cwd=workspace, env=env,
-                    timeout=timeout,
-                )
+                result = run_argv_capture(ProcessInvocationPlan.from_values(
+                    argv,
+                    input_text="",
+                    cwd=workspace,
+                    environment=env,
+                    timeout_s=timeout,
+                ))
     except (OSError, RuntimeError) as exc:
         # Setup failures are closed no-process observations. Do not leak the
         # exception's credential/policy path text into durable artifacts.
@@ -10243,7 +10189,13 @@ def vibe_cli_invoke(prompt: str, *, model: str | None = None, vibe_cmd: str | No
                     "model": model, "trace_text": "",
                     "invocation_state": InvocationState.SPAWN_FAILED.value,
                     "environment": env_meta}
-        result = run_argv_capture(argv, input_text="", cwd=workspace, env=env, timeout=timeout)
+        result = run_argv_capture(ProcessInvocationPlan.from_values(
+            argv,
+            input_text="",
+            cwd=workspace,
+            environment=env,
+            timeout_s=timeout,
+        ))
     messages, parse_errors = (
         parse_vibe_messages_with_errors(result.stdout)
         if result.stdout_utf8_valid
@@ -10491,7 +10443,12 @@ def run_agent_tasks(tasks: list[dict[str, Any]], runs: Path, backend: AgentBacke
                 prov_extra["skill_tree_hash"] = attestation.mounted_skill_tree_hash
             prov_extra["fixture_tree_hash"] = attestation.fixture_tree_hash
             prompt = build_task_prompt(pt, skill_paths=skill_rel, input_files=input_rel)
-            outcome = backend.invoke_answer(InvocationRequest(prompt=prompt, workspace=ws, model=row_model, timeout_s=timeout), **options)
+            outcome = backend.invoke_answer(InvocationRequest.parse(
+                prompt=prompt,
+                workspace=ws,
+                model=row_model,
+                timeout_s=timeout,
+            ), **options)
         context = outcome_context(outcome)
         env = dict(context.environment or {})
         env.setdefault("runner", backend.name)
@@ -10647,7 +10604,12 @@ def claude_cli_invoke(prompt: str, *, model: str | None = None, claude_bin: str 
         argv += list(extra_args)
 
     def invoke(cwd_path: Path | str) -> InvocationResult:
-        return run_argv_capture(argv, input_text=prompt, cwd=cwd_path, timeout=timeout)
+        return run_argv_capture(ProcessInvocationPlan.from_values(
+            argv,
+            input_text=prompt,
+            cwd=cwd_path,
+            timeout_s=timeout,
+        ))
 
     if cwd is None:
         with tempfile.TemporaryDirectory(prefix="claude-invoke-cwd-") as td:
@@ -10978,7 +10940,13 @@ def codex_cli_invoke(prompt: str, *, model: str | None = None, codex_cmd: str = 
                 argv += ["--output-schema", str(schema_path)]
         if "-" not in argv:
             argv.append("-")
-        result = run_argv_capture(argv, input_text=prompt, cwd=invoke_cwd, env=env, timeout=timeout)
+        result = run_argv_capture(ProcessInvocationPlan.from_values(
+            argv,
+            input_text=prompt,
+            cwd=invoke_cwd,
+            environment=env,
+            timeout_s=timeout,
+        ))
         last_message_found = last_message.exists()
         last_message_utf8_valid = True
         if last_message_found:

--- a/tests/test_invocation_contracts.py
+++ b/tests/test_invocation_contracts.py
@@ -1,0 +1,127 @@
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import skill_benchmark as sb
+from invocation_contracts import (
+    InvocationRequest,
+    InvocationResult,
+    InvocationState,
+    ProcessInvocationPlan,
+    TimeoutSeconds,
+)
+from manifest_contracts import ModelId
+from trigger_contracts import InvocationOutcome
+
+
+class InvocationPlanContractTests(unittest.TestCase):
+    def test_answer_request_parses_precise_model_and_timeout_values(self):
+        request = InvocationRequest.parse(
+            prompt="do the task",
+            workspace=Path("workspace"),
+            model="model-a",
+            timeout_s=30,
+        )
+        self.assertIsInstance(request.model, ModelId)
+        self.assertIsInstance(request.timeout_s, TimeoutSeconds)
+        self.assertEqual(request.model, "model-a")
+        self.assertEqual(request.timeout_s, 30)
+
+    def test_process_plan_freezes_every_spawn_input(self):
+        environment = {"TOKEN": "secret"}
+        plan = ProcessInvocationPlan.from_values(
+            ["provider", "--json"],
+            input_text="prompt",
+            cwd="workspace",
+            timeout_s=20,
+            environment=environment,
+        )
+        environment["TOKEN"] = "changed"
+        self.assertEqual(plan.argv, ("provider", "--json"))
+        self.assertEqual(plan.cwd, Path("workspace"))
+        self.assertEqual(plan.environment, {"TOKEN": "secret"})
+        with self.assertRaises(TypeError):
+            plan.environment["NEW"] = "value"  # type: ignore[index]
+
+    def test_legacy_wrapper_preserves_inherited_stdin(self):
+        observed: list[ProcessInvocationPlan] = []
+
+        def invoke(plan: ProcessInvocationPlan) -> InvocationOutcome:
+            observed.append(plan)
+            return InvocationOutcome.from_process(
+                stdout="", stderr="", returncode=0, elapsed_ms=0)
+
+        with mock.patch.object(sb, "invoke_argv_with_timeout", side_effect=invoke):
+            sb.run_argv_with_timeout(["provider"], timeout=1, input_text=None)
+
+        self.assertIsNone(observed[0].input_text)
+
+    def test_process_plan_rejects_values_that_cannot_be_spawned(self):
+        invalid = [
+            ([], {}, 1),
+            ("provider", {}, 1),
+            ([""], {}, 1),
+            (["provider\x00bad"], {}, 1),
+            (["provider"], {"BAD=KEY": "value"}, 1),
+            (["provider"], {"KEY": "bad\x00value"}, 1),
+            (["provider"], {}, 0),
+            (["provider"], {}, True),
+        ]
+        for argv, environment, timeout in invalid:
+            with self.subTest(argv=argv, environment=environment, timeout=timeout), \
+                    self.assertRaises((TypeError, ValueError)):
+                ProcessInvocationPlan.from_values(
+                    argv,
+                    input_text="",
+                    cwd=Path("workspace"),
+                    timeout_s=timeout,
+                    environment=environment,
+                )
+
+    def test_process_result_closes_lifecycle_state(self):
+        completed = InvocationResult(
+            stdout="answer",
+            stderr="",
+            returncode=0,
+            elapsed_ms=12,
+            invocation_state=InvocationState.COMPLETE,
+            stdout_utf8_valid=True,
+            stderr_utf8_valid=True,
+        )
+        self.assertFalse(completed.timed_out)
+        with self.assertRaisesRegex(ValueError, "contradicts"):
+            InvocationResult(
+                stdout="",
+                stderr="",
+                returncode=0,
+                elapsed_ms=12,
+                invocation_state=InvocationState.TIMED_OUT,
+                stdout_utf8_valid=True,
+                stderr_utf8_valid=True,
+                timed_out=False,
+            )
+
+        with self.assertRaisesRegex(ValueError, "contradicts stdout_utf8_valid"):
+            InvocationResult(
+                stdout="",
+                stderr="",
+                returncode=0,
+                elapsed_ms=12,
+                invocation_state=InvocationState.COMPLETE,
+                stdout_utf8_valid=True,
+                stderr_utf8_valid=True,
+                adapter_metadata={"stdout_utf8_valid": False},
+            )
+
+    def test_subprocess_owner_accepts_only_a_validated_plan(self):
+        with self.assertRaisesRegex(TypeError, "ProcessInvocationPlan"):
+            sb.invoke_argv_with_timeout(["provider"])  # type: ignore[arg-type]
+
+    def test_harness_reexports_the_contract_types(self):
+        self.assertIs(sb.InvocationRequest, InvocationRequest)
+        self.assertIs(sb.InvocationResult, InvocationResult)
+        self.assertIs(sb.ProcessInvocationPlan, ProcessInvocationPlan)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -343,8 +343,9 @@ class ClosedRunnerOutcomeTests(unittest.TestCase):
         outcome = sb.InvocationOutcome.harness_failed("fixture setup failed")
         with mock.patch.object(sb, "invoke_argv_with_timeout", return_value=outcome), \
              self.assertRaisesRegex(RuntimeError, "non-process invocation"):
-            sb.run_argv_capture(
-                ["unused"], input_text="", cwd=Path.cwd(), timeout=1)
+            sb.run_argv_capture(sb.ProcessInvocationPlan.from_values(
+                ["unused"], input_text="", cwd=Path.cwd(), timeout_s=1
+            ))
 
     def test_spawned_reserved_exit_codes_remain_process_failures(self):
         with tempfile.TemporaryDirectory() as td:
@@ -355,7 +356,9 @@ class ClosedRunnerOutcomeTests(unittest.TestCase):
                     f"raise SystemExit({returncode})\n", encoding="utf-8")
                 with self.subTest(returncode=returncode):
                     outcome = sb.invoke_argv_with_timeout(
-                        [sys.executable, str(script)], cwd=root, timeout=5)
+                        sb.ProcessInvocationPlan.from_values(
+                            [sys.executable, str(script)], input_text="",
+                            cwd=root, timeout_s=5))
                     self.assertIs(outcome.state, sb.InvocationState.PROCESS_FAILED)
                     self.assertFalse(outcome.timed_out)
 
@@ -1076,7 +1079,10 @@ class RunnerOutcomeContractTests(unittest.TestCase):
                 "time.sleep(30)\n",
                 encoding="utf-8")
             started = time.monotonic()
-            outcome = sb.invoke_argv_with_timeout([sys.executable, str(parent)], cwd=root, timeout=1)
+            outcome = sb.invoke_argv_with_timeout(
+                sb.ProcessInvocationPlan.from_values(
+                    [sys.executable, str(parent)], input_text="",
+                    cwd=root, timeout_s=1))
             elapsed = time.monotonic() - started
             child_pid = int(pid_file.read_text(encoding="utf-8"))
             try:

--- a/tests/test_trigger_matrix.py
+++ b/tests/test_trigger_matrix.py
@@ -156,7 +156,9 @@ class TriggerRowBoundaryTests(unittest.TestCase):
     def test_pi_trigger_runner_invokes_pi_from_isolated_workspace(self):
         seen = {}
 
-        def fake_run(argv, *, cwd, env, timeout):
+        def fake_run(plan):
+            argv, cwd = list(plan.argv), plan.cwd
+            env, timeout = dict(plan.environment or {}), int(plan.timeout_s)
             seen.update({"argv": argv, "cwd": str(cwd), "config_dir": env["PI_CODING_AGENT_DIR"], "timeout": timeout})
             return InvocationOutcome.from_process(
                 stdout=json.dumps({"type": "agent_end", "messages": [{"stopReason": "stop"}]}) + "\n",
@@ -305,7 +307,8 @@ class TriggerRowBoundaryTests(unittest.TestCase):
         self.assertEqual(result.provider_error, "provider rejected model")
 
     def test_pi_matrix_detection_and_telemetry_share_one_parsed_stream(self):
-        def successful_pi(*args, cwd, **kwargs):
+        def successful_pi(plan):
+            cwd = plan.cwd
             skill = Path(cwd) / ".pi-config" / "skills" / "demo" / "SKILL.md"
             assistant = {"role": "assistant", "stopReason": "stop",
                          "usage": {"input": 4, "output": 1, "totalTokens": 5}}
@@ -663,7 +666,8 @@ class ClaudeDetectionTests(unittest.TestCase):
     def test_claude_invoke_seeds_portable_auth_into_isolated_config(self):
         seen = {}
 
-        def fake_run(argv, *, cwd, env, timeout):
+        def fake_run(plan):
+            env = dict(plan.environment or {})
             config_dir = Path(env["CLAUDE_CONFIG_DIR"])
             seen["config_dir"] = config_dir
             seen["credentials"] = (config_dir / ".credentials.json").read_text(encoding="utf-8")
@@ -686,7 +690,8 @@ class ClaudeDetectionTests(unittest.TestCase):
     def test_claude_invoke_preserves_nonportable_oauth_config(self):
         seen = {}
 
-        def fake_run(argv, *, cwd, env, timeout):
+        def fake_run(plan):
+            env = dict(plan.environment or {})
             seen["config_dir"] = env.get("CLAUDE_CONFIG_DIR")
             return {"stdout": json.dumps({"type": "result", "subtype": "success"}) + "\n",
                     "stderr": "", "returncode": 0, "timed_out": False,
@@ -773,7 +778,9 @@ class CodexAdapterTests(unittest.TestCase):
     def test_codex_invoke_appends_raw_query_model_and_external_skill_dir(self):
         seen = {}
 
-        def fake_run(argv, *, cwd, env, timeout):
+        def fake_run(plan):
+            argv, cwd = list(plan.argv), plan.cwd
+            env, timeout = dict(plan.environment or {}), int(plan.timeout_s)
             seen.update({"argv": argv, "cwd": cwd, "env": env, "timeout": timeout})
             return {"stdout": '{"type":"turn.completed"}\n', "stderr": "", "returncode": 0, "timed_out": False,
                     "elapsed_ms": 1, "observation_complete": True}
@@ -796,7 +803,9 @@ class CodexAdapterTests(unittest.TestCase):
     def test_codex_invoke_seeds_auth_without_copying_user_skills(self):
         seen = {}
 
-        def fake_run(argv, *, cwd, env, timeout):
+        def fake_run(plan):
+            cwd = plan.cwd
+            env = dict(plan.environment or {})
             codex_home = Path(env["CODEX_HOME"])
             seen["auth"] = (codex_home / "auth.json").read_text(encoding="utf-8")
             seen["config"] = (codex_home / "config.toml").read_text(encoding="utf-8")
@@ -1013,7 +1022,10 @@ class VibeAdapterTests(unittest.TestCase):
     def test_vibe_invoke_uses_isolated_home_model_env_and_prompt_arg(self):
         seen = {}
 
-        def fake_run(argv, *, cwd, env, timeout, input_text=None):
+        def fake_run(plan):
+            argv, cwd = list(plan.argv), plan.cwd
+            env, timeout = dict(plan.environment or {}), int(plan.timeout_s)
+            input_text = plan.input_text
             seen.update({"argv": argv, "cwd": cwd, "env": env, "timeout": timeout, "input_text": input_text})
             seen["vibe_home_inside_workdir"] = Path(env["VIBE_HOME"]).is_relative_to(Path(cwd))
             seen["workspace_vibe_env_present"] = (Path(cwd) / ".vibe-home" / ".env").exists()

--- a/trigger_contracts.py
+++ b/trigger_contracts.py
@@ -15,20 +15,12 @@ from types import MappingProxyType
 from typing import Any, TypeAlias
 
 import telemetry as telemetry_domain
+from invocation_contracts import InvocationState
 from json_contracts import (
     freeze_json_mapping,
     strict_json_equal,
     validate_json_text,
 )
-
-
-class InvocationState(str, Enum):
-    COMPLETE = "complete"
-    TIMED_OUT = "timed_out"
-    SPAWN_FAILED = "spawn_failed"
-    PROCESS_FAILED = "process_failed"
-    PROVIDER_FAILED = "provider_failed"
-    HARNESS_FAILED = "harness_failed"
 
 
 class CompletionEvidence(str, Enum):

--- a/type_tests/abstraction_contracts.py
+++ b/type_tests/abstraction_contracts.py
@@ -6,6 +6,7 @@ current union can be narrowed exhaustively and that its public fields retain
 the intended precise types.
 """
 
+from collections.abc import Mapping
 from pathlib import Path
 from typing import NoReturn
 
@@ -16,6 +17,12 @@ from experimental_pairs import (
     ExperimentalPair,
     ExperimentalPairKey,
     ExperimentalPopulation,
+)
+from invocation_contracts import (
+    InvocationRequest,
+    InvocationResult,
+    ProcessInvocationPlan,
+    TimeoutSeconds,
 )
 from judge_verdict import (
     BooleanVerdict,
@@ -43,6 +50,7 @@ from runner_contracts import (
 from trigger_contracts import (
     CompleteTriggerResult,
     IncompleteTriggerResult,
+    InvocationState,
     TriggerResult,
 )
 from trigger_reporting import (
@@ -127,3 +135,15 @@ def experimental_pair_payload_type_is_preserved(
 ) -> None:
     assert_type(pair.with_skill.payload, Path)
     assert_type(pair.without_skill.payload, Path)
+
+
+def provider_invocation_types_are_precise(
+    request: InvocationRequest,
+    plan: ProcessInvocationPlan,
+    result: InvocationResult,
+) -> None:
+    _request_model: ModelId | None = request.model
+    _request_timeout: TimeoutSeconds = request.timeout_s
+    _argv: tuple[str, ...] = plan.argv
+    _environment: Mapping[str, str] | None = plan.environment
+    _state: InvocationState = result.invocation_state


### PR DESCRIPTION
## Summary

- make `invocation_contracts.py` the provider-neutral owner of request, process-plan, process-result, timeout, and lifecycle vocabulary
- require every internal Codex, Claude, Gemini, Vibe, trigger, matrix, and live-smoke subprocess call to supply one immutable `ProcessInvocationPlan`
- freeze argv, cwd, environment, timeout, and optional stdin before spawn
- retain the legacy dictionary wrapper while preserving `input_text=None` as inherited stdin

This is layer 4 of the `ty` migration stack and depends on #75.

## Why

Parallel argv / stdin / cwd / environment / timeout parameters let new call sites omit or misalign process inputs. A single validated plan makes the entire spawn request required and keeps process results distinct from later provider and harness classifications.

## Compatibility and risk

Provider wire formats and the public compatibility wrapper remain unchanged. Invalid Unicode, malformed environments, NUL-containing argv, and invalid timeouts now fail before spawn. The existing harness import surface reexports the moved contracts, while internal consumers import the canonical owner directly.

## Validation

- focused invocation-contract, runner, trigger, Gemini, and consolidation tests
- regression coverage for inherited stdin and contradictory UTF-8 metadata
- top-of-stack integration: 1,335 passed, 7 skipped, 858 subtests
- warning-fatal `ty`, Ruff, byte compilation, doc-reference check, and `git diff --check`
