### PR TITLE
Type persisted artifact observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,11 +581,12 @@ skill-eval-harness/
 ├── run_trigger_matrix.py       # activation matrix across agents × models (claude/codex/pi/vibe/stub adapters)
 ├── ablation_model.py           # typed ablation/provenance/task value objects
 ├── agent_capabilities.py       # unified backend surfaces, capabilities, CLI options, smoke, and failure policy
+├── artifact_contracts.py       # closed persisted-artifact observations and integrity verification
 ├── experimental_pairs.py       # exact pair identities and blocked-pair construction
 ├── runner_contracts.py         # closed answer-runner outcome union
 ├── judge_verdict.py            # strict imported/stored judge verdict variants
 ├── jetty_contracts.py          # closed Jetty lifecycle and observation contract
-├── trace_contracts.py          # normalized event lifecycle contract
+├── trace_contracts.py          # normalized event-log and event lifecycle contracts
 ├── trigger_contracts.py        # autonomous-trigger invocation/detection/observation contract
 ├── telemetry.py                # schema-v3 availability/provenance/comparison domain
 ├── docs/                       # architecture, abstractions, vocabulary, specs, guides (see the map above)

--- a/TODO.md
+++ b/TODO.md
@@ -71,7 +71,7 @@ Jetty runbooks emit a standardized machine-readable `validation_report.json` per
 (`jettyio/jettyio-skills`, `skills/create-runbook/SKILL.md`). Rubric evaluation scores 3-7
 dimensions on a 1-5 scale; programmatic evaluation returns `PASS` / `PARTIAL` / `FAIL`. The
 items below map that report onto the harness judge-result row `{judge_task_id, passed, score,
-threshold, evidence}` (`load_judge_results:11611`, merged in `grade_case_variant:13872`).
+threshold, evidence}` (`load_judge_results:11565`, merged in `grade_case_variant:13826`).
 
 - [ ] Export qualitative judge tasks to Jetty workflows using `simple_judge` where useful.
       Carry `judge_task_id` (`case::variant::run-n::assertion`) into the Jetty task so the

--- a/artifact_contracts.py
+++ b/artifact_contracts.py
@@ -1,0 +1,202 @@
+"""Typed observations of one persisted run-artifact set."""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Literal, TypeAlias
+
+from json_contracts import strict_json_loads
+
+ARTIFACT_COMMIT_NAME = "artifact-commit.json"
+ARTIFACT_CONTRACT_VERSION = 1
+ARTIFACT_REQUIRED_FILES = ("output.md", "events.json", "metrics.json", "metadata.json")
+
+
+class ArtifactSetState(str, Enum):
+    LEGACY_UNDECLARED = "legacy_undeclared"
+    MISSING_COMMIT = "missing_commit"
+    INVALID_COMMIT = "invalid_commit"
+    INCOMPLETE = "incomplete"
+    COMPLETE = "complete"
+
+
+@dataclass(frozen=True)
+class LegacyArtifactSet:
+    state: Literal[ArtifactSetState.LEGACY_UNDECLARED] = field(
+        default=ArtifactSetState.LEGACY_UNDECLARED, init=False)
+
+
+@dataclass(frozen=True)
+class MissingArtifactCommit:
+    reason: str
+    state: Literal[ArtifactSetState.MISSING_COMMIT] = field(
+        default=ArtifactSetState.MISSING_COMMIT, init=False)
+
+    def __post_init__(self) -> None:
+        _validate_reason(self.reason, "missing artifact commit")
+
+
+@dataclass(frozen=True)
+class InvalidArtifactCommit:
+    reason: str
+    state: Literal[ArtifactSetState.INVALID_COMMIT] = field(
+        default=ArtifactSetState.INVALID_COMMIT, init=False)
+
+    def __post_init__(self) -> None:
+        _validate_reason(self.reason, "invalid artifact commit")
+
+
+@dataclass(frozen=True)
+class IncompleteArtifactSet:
+    reason: str
+    state: Literal[ArtifactSetState.INCOMPLETE] = field(
+        default=ArtifactSetState.INCOMPLETE, init=False)
+
+    def __post_init__(self) -> None:
+        _validate_reason(self.reason, "incomplete artifact set")
+
+
+@dataclass(frozen=True)
+class CompleteArtifactSet:
+    inventory_sha256: Mapping[str, str]
+    state: Literal[ArtifactSetState.COMPLETE] = field(
+        default=ArtifactSetState.COMPLETE, init=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.inventory_sha256, Mapping):
+            raise TypeError("complete artifact inventory must be a mapping")
+        invalid = _invalid_inventory_entries(self.inventory_sha256)
+        if invalid:
+            raise ValueError("complete artifact inventory contains an invalid path or digest")
+        if any(name not in self.inventory_sha256 for name in ARTIFACT_REQUIRED_FILES):
+            raise ValueError("complete artifact inventory omits a required file")
+        object.__setattr__(
+            self, "inventory_sha256", MappingProxyType(dict(self.inventory_sha256)))
+
+
+ArtifactSetObservation: TypeAlias = (
+    LegacyArtifactSet
+    | MissingArtifactCommit
+    | InvalidArtifactCommit
+    | IncompleteArtifactSet
+    | CompleteArtifactSet
+)
+
+
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
+
+
+def _validate_reason(value: Any, label: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} reason must be non-empty")
+
+
+def _invalid_inventory_entries(inventory: Mapping[Any, Any]) -> bool:
+    return any(
+        not isinstance(name, str)
+        or not name
+        or not isinstance(digest, str)
+        or _SHA256_RE.fullmatch(digest) is None
+        or Path(name).is_absolute()
+        or Path(name) == Path(".")
+        or ".." in Path(name).parts
+        for name, digest in inventory.items()
+    )
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _invalid(reason: str) -> InvalidArtifactCommit:
+    return InvalidArtifactCommit(reason)
+
+
+def observe_artifact_set(
+    run_dir: Path,
+    *,
+    declared_contract_version: Any = None,
+) -> ArtifactSetObservation:
+    """Classify the commit marker and every file it claims without guessing.
+
+    A directory with no marker and no declared contract is a supported legacy
+    artifact set. Once either side declares the contract, missing, malformed,
+    partial, stale, and complete sets remain distinct values.
+    """
+    marker = run_dir / ARTIFACT_COMMIT_NAME
+    contract_declared = declared_contract_version is not None
+    if contract_declared and (
+        type(declared_contract_version) is not int
+        or declared_contract_version != ARTIFACT_CONTRACT_VERSION
+    ):
+        return _invalid("declared artifact set has an unsupported contract version")
+    if marker.is_symlink():
+        return _invalid("artifact commit marker must be a regular file")
+    marker_exists = marker.exists()
+    if not marker_exists:
+        if not contract_declared:
+            return LegacyArtifactSet()
+        return MissingArtifactCommit("declared artifact set has no commit marker")
+    if not marker.is_file():
+        return _invalid("artifact commit marker must be a regular file")
+    if declared_contract_version != ARTIFACT_CONTRACT_VERSION:
+        return _invalid(
+            "artifact commit marker requires the matching declared contract version")
+    try:
+        raw = strict_json_loads(marker.read_text(encoding="utf-8"))
+    except OSError as exc:
+        return _invalid(f"artifact commit marker is unreadable: {exc}")
+    except json.JSONDecodeError as exc:
+        return _invalid(f"artifact commit marker contains invalid JSON: {exc}")
+    if not isinstance(raw, dict):
+        return _invalid("artifact commit marker must contain a JSON object")
+    if (type(raw.get("schema_version")) is not int
+            or raw.get("schema_version") != ARTIFACT_CONTRACT_VERSION):
+        return _invalid("artifact commit marker has an unsupported schema version")
+    required = raw.get("required_files")
+    inventory = raw.get("inventory_sha256")
+    if required != list(ARTIFACT_REQUIRED_FILES):
+        return _invalid("artifact commit marker has the wrong required-file contract")
+    if not isinstance(inventory, dict):
+        return _invalid("artifact commit inventory must be a JSON object")
+    if _invalid_inventory_entries(inventory):
+        return _invalid("artifact commit inventory contains an invalid path or digest")
+    if any(name not in inventory for name in ARTIFACT_REQUIRED_FILES):
+        return IncompleteArtifactSet("artifact commit inventory omits a required file")
+    try:
+        candidates = list(run_dir.rglob("*"))
+        if any(candidate.is_symlink() for candidate in candidates):
+            return IncompleteArtifactSet("artifact set contains a symbolic link")
+        actual_files = {
+            candidate.relative_to(run_dir).as_posix()
+            for candidate in candidates
+            if candidate.name != ARTIFACT_COMMIT_NAME and candidate.is_file()
+        }
+        if actual_files != set(inventory):
+            return IncompleteArtifactSet(
+                "artifact inventory does not match the files on disk")
+        for name, digest in inventory.items():
+            path = run_dir / name
+            if not path.is_file() or _file_sha256(path) != digest:
+                return IncompleteArtifactSet(
+                    f"artifact content does not match the committed digest: {name}")
+    except OSError as exc:
+        return IncompleteArtifactSet(f"artifact set could not be verified: {exc}")
+    return CompleteArtifactSet(inventory)
+
+
+def artifact_commit_valid(run_dir: Path) -> bool:
+    """Compatibility projection for callers that need only the final boolean."""
+    observation = observe_artifact_set(
+        run_dir, declared_contract_version=ARTIFACT_CONTRACT_VERSION)
+    return isinstance(observation, CompleteArtifactSet)

--- a/docs/abstractions.md
+++ b/docs/abstractions.md
@@ -162,13 +162,22 @@ set incomplete. Legacy or externally written runs that do not declare that contr
 remain readable through the compatibility boundary. This boundary is the main extension seam
 in the codebase.
 
+`artifact_contracts.observe_artifact_set` reads that seam into exactly one frozen value:
+`LegacyArtifactSet | MissingArtifactCommit | InvalidArtifactCommit | IncompleteArtifactSet |
+CompleteArtifactSet`. A malformed marker and a valid marker whose files were interrupted or
+tampered with are therefore different states. Existing dictionary readers retain
+`artifact_set_complete` as a compatibility projection and expose the reasoned state alongside it.
+Likewise, `read_event_log_base` produces `MissingEventLog | InvalidEventLog | LoadedEventLog`;
+`read_events_base` is only the legacy tuple adapter. Strict JSON parsing lives in
+`json_contracts.py`, so every disk reader shares duplicate-key and non-finite-number rejection.
+
 ## Runner / adapter
 
 An **answer runner** consumes prepared task rows and produces the run-output contract. The repo
-ships Pi answer smoke (`examples/adewale-workspace/run_pi_smoke.py`), Codex (`run_codex:10485`), Claude (`run_claude:10671`, capturing real
+ships Pi answer smoke (`examples/adewale-workspace/run_pi_smoke.py`), Codex (`run_codex:10439`), Claude (`run_claude:10625`, capturing real
 per-run cost), Gemini CLI and Mistral Vibe (`run-agent --agent gemini|vibe`, using isolated provider homes outside the workdir), the in-process
-subagent runner (`run_subagent:13217`, which hosts record/replay tool I/O via `ToolReplayStore`),
-Jetty (`JettyClient:4006` and the export/run/import commands), and any runner that writes the
+subagent runner (`run_subagent:13171`, which hosts record/replay tool I/O via `ToolReplayStore`),
+Jetty (`JettyClient:3995` and the export/run/import commands), and any runner that writes the
 contract directly. Each answer runner registers a workspace builder so one cross-runner invariant
 proves its `without_skill` arm is skill-free (CF.2). Autonomous trigger runners are separate: they
 read trigger cases from the manifest directly, never consume answer task rows, and emit trigger
@@ -196,7 +205,8 @@ code.
 Runners disagree on event shape. Codex emits `command_execution` and `turn.completed`; Pi
 emits `message_end` usage aliases; Jetty emits trajectory records. `normalize_trace_record`
 and `normalize_trace_records` collapse these into one schema-versioned `events.json` plus
-`metrics.json`, tagged with the source. `trace_contracts.EventState` first classifies each event as
+`metrics.json`, tagged with the source. Loading `events.json` first constructs the closed event-log
+observation above. `trace_contracts.EventState` then classifies each event as
 completed, in-progress, failed, or unknown; only completed operations contribute command/tool/file
 counts. Process and efficiency assertions read the normalized form, never the raw prose, because
 inferring tool use from answer text is how false evidence gets in.
@@ -252,7 +262,7 @@ those pairs; missing/ineligible arms remain in `pairing` diagnostics and duplica
 `build_slice_summary` breaks results down
 by domain, difficulty, trigger type, and success goal. Case flags mark saturated, no-lift,
 flaky, and with-skill-failed cases. These flags, the leakage lint
-(`prompt_assertion_leakage_findings:796`), and the split discipline are the part of the tool
+(`prompt_assertion_leakage_findings:785`), and the split discipline are the part of the tool
 no surveyed eval framework copies.
 
 The pairing key carries `CaseId`, `ModelId | None`, `RunNumber`, and the closed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,6 +144,8 @@ the interior. Each external boundary has one parser and a closed value:
 prepared row -> PreparedTaskDraft -> PreparedTask
 provider result -> Completed | TimedOut | SpawnFailed | ProviderFailed
 run evidence -> process × provider-response × trace × artifact-set state
+artifact set -> Legacy | MissingCommit | InvalidCommit | Incomplete | Complete
+event log -> Missing | Invalid | Loaded
 judge process -> JudgeInvocation
 judge row -> Boolean | Scored | Dimension | Dynamic | Consensus verdict
 trace status -> Completed | InProgress | Failed | Unknown

--- a/docs/correctness-by-construction-audit.md
+++ b/docs/correctness-by-construction-audit.md
@@ -257,6 +257,24 @@ a protocol error and cannot receive return code zero.
 Dry-run payload generation is planning, not a Jetty execution lifecycle. Non-executable submitted
 payloads are protocol-invalid rather than ordinary provider failures.
 
+## Persisted run artifacts
+
+Persisted run evidence crosses a typed disk boundary before event semantics are inspected:
+
+```text
+artifact-commit.json -> Legacy | MissingCommit | InvalidCommit | Incomplete | Complete
+events.json -> Missing | Invalid | Loaded
+```
+
+- `artifact_contracts.py` verifies the declared schema, required-file inventory, paths, symbolic
+  links, and SHA-256 digests. It preserves malformed marker data separately from a well-formed but
+  partial or stale artifact set.
+- `trace_contracts.parse_event_log` validates the event-log envelope and performs the explicit v1
+  compatibility adaptation. A JSON `null` document is invalid rather than being mistaken for a
+  missing file.
+- `artifact_commit_valid` and `read_events_base` remain compatibility projections; integrity and
+  grading code can consume the closed observations without interpreting booleans or error tuples.
+
 ## Normalized trace-event lifecycle
 
 `trace_contracts.py` owns `EventState`:

--- a/docs/eval-framework-roadmap-spec.md
+++ b/docs/eval-framework-roadmap-spec.md
@@ -17,7 +17,7 @@ One invariant governs every item: core grading stays local and deterministic and
 model, and the harness never picks a model for the user. Anything that needs a model lives
 behind an opt-in command or the external `--judge-cmd`. Two abstractions absorb most of the
 work, so the spec returns to them often: the assertion result shape in `assertion_result`
-(`skill_benchmark.py:11185`) and the fan-out in `prepared_task_rows` (`:1568`).
+(`skill_benchmark.py:11139`) and the fan-out in `prepared_task_rows` (`:1557`).
 
 ## Testing baseline
 
@@ -40,7 +40,7 @@ tests are where that claim is checked rather than trusted.
 
 The buckets below extend what the harness can measure. This floor decides whether the number it
 already prints can be believed. The harness reports one thing: lift, `with_skill` minus
-`without_skill` on the same case (`build_paired_summary` (`:15316`)). That number is believable only
+`without_skill` on the same case (`build_paired_summary` (`:15270`)). That number is believable only
 when three preconditions hold, each intended today, none enforced, and each restating a claim from
 `evals-are-not-tests.md`:
 
@@ -60,22 +60,22 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
   hiding the quantity the tool exists to measure.
 - **Abstractions used or changed:** none in the engine. Adds
   `tests/fixtures/detectors/<detector_id>/should-fire.*` and `should-pass.*` that exercise
-  `assertion_result` (`:11185`) directly. That function has no direct unit test today, and its
+  `assertion_result` (`:11139`) directly. That function has no direct unit test today, and its
   `contains_any`, `excludes_any`, and `not_regex` branches go unexercised even though their types
-  are declared in the assertion registries (`TEXT_ASSERTIONS:189`).
+  are declared in the assertion registries (`TEXT_ASSERTIONS:209`).
 - **Design:** one table-driven test loads every pair and asserts the detector fires on `should-fire`
   and stays silent on `should-pass`. A `should-pass` twin is mandatory: it enforces the
   false-positive bar `authoring-evals.md` already sets for skill authors ("check both presence and
   absence"). Each `should-pass` set includes a case where the baseline echoes the prompt, because a
   detector that passes on echoed prompt text is a false oracle; this ties the fixtures to leakage
-  lint (`prompt_assertion_leakage_findings` (`:796`)). Every detector bug then becomes a permanent
+  lint (`prompt_assertion_leakage_findings` (`:785`)). Every detector bug then becomes a permanent
   fixture pair, and `test_command_assertions_match_command_inputs_not_outputs` is the first.
 - **Why it is the keystone:** the fixture pair is also the registration contract. It is what lets a
   harvested or third-party detector be trusted on entry, so it gates the exapted detector library
   (TODO, end of 2026), and it raises the oracle-strength ladder (1.7) so that "strong" means
   fixture-verified, not only deterministic.
 - **Testing:** the fixtures are the test. A meta-test asserts every name in `OBJECTIVE_ASSERTIONS`
-  (`:226`) has a fixture pair, so a new detector cannot land unverified.
+  (`:246`) has a fixture pair, so a new detector cannot land unverified.
 
 ### CF.2 — One cross-runner baseline-isolation invariant
 - **Goal:** prove the baseline is skill-free by construction, so a measured lift is the skill's
@@ -101,7 +101,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 ### CF.4 — A guard that the core grade path calls no model and no network
 - **Goal:** make the governing invariant — "core grading stays local and deterministic and never
   calls a model" — executable rather than aspirational.
-- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:13872`).
+- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:13826`).
 - **Design:** patch `urllib` and `subprocess` to raise, then grade a fixture covering every
   objective family (text, process, efficiency) and assert it completes. The sanctioned exceptions —
   `script` oracles and `judge` plumbing — are excluded from this path by design and keep their own
@@ -111,7 +111,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 
 ### Boundary
 The set stops here deliberately. Report-level correctness — whether the saturation, no-lift, flaky,
-and negative-delta flags (`build_benchmark_report` (`:16735`)) are computed right — sits a layer
+and negative-delta flags (`build_benchmark_report` (`:16689`)) are computed right — sits a layer
 above the raw measurement, where the golden-report tests the buckets already plan (1.2, 2.6) cover
 it. CF.1–CF.4 are the floor underneath that work: once they pass, a printed lift carries a checked
 measurement, and every feature in the buckets builds on a number that has been verified rather than
@@ -125,9 +125,9 @@ assumed.
 - **Goal:** ship graders authors reach for often, so they stop hand-rolling rubrics.
 - **Abstractions used or changed:** `tool_call` and `structured_output` are deterministic, so
   they become new types in `TEXT_ASSERTIONS` / `PROCESS_ASSERTIONS` and gain a branch in
-  `assertion_result`. `tool_call` reuses `command_events` (`:6401`) and the `command_order`
+  `assertion_result`. `tool_call` reuses `command_events` (`:6396`) and the `command_order`
   logic; `structured_output` extends `json_field_equals` with JSON-Schema validation.
-  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:11768`) renders
+  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:11722`) renders
   and still runs through `--judge-cmd`.
 - **Design:** a preset expands to either a deterministic objective assertion or a `judge`
   assertion with a canned rubric and threshold. No new execution path.
@@ -146,7 +146,7 @@ assumed.
 ### 1.3 Judge config slot and the "judge is not the model under test" guard
 - **Goal:** make an existing convention enforceable.
 - **Abstractions used or changed:** read an optional `judge` block in the manifest; add a check
-  in `audit_manifest_report` (`:19558`) comparing the declared judge model against `jetty.model`
+  in `audit_manifest_report` (`:19512`) comparing the declared judge model against `jetty.model`
   or the run metadata `model`.
 - **Design:** warn by default, error under `--strict-judge`.
 - **Testing:** unit tests for matching and differing model ids.
@@ -163,7 +163,7 @@ assumed.
 - **Status:** `docs/authoring-evals.md` shipped, alongside `architecture.md` and
   `abstractions.md`.
 - **Follow-on:** surface the guide's rules where they are checkable. Extend the messaging in
-  `prompt_assertion_leakage_findings` (`:796`) and `fixture_recommendations` (`:19251`) to point
+  `prompt_assertion_leakage_findings` (`:785`) and `fixture_recommendations` (`:19205`) to point
   at the relevant section.
 - **Testing:** assert the new hint strings appear for crafted manifests.
 
@@ -172,8 +172,8 @@ assumed.
   In `adewale/pythonbyexample` and `adewale/xampler` an example *is* an eval case: an input, an
   expected output, and a check that the output still matches. The harness has no equivalent of
   "this output equals this reference."
-- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:189`), implemented in
-  `assertion_result` (`:11185`). It reads `output.md` (or a named artifact), applies an optional
+- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:209`), implemented in
+  `assertion_result` (`:11139`). It reads `output.md` (or a named artifact), applies an optional
   normalization (trim, collapse whitespace, or a named normalizer), and compares to a reference
   file under the manifest dir. Evidence is a unified diff on mismatch.
 - **Design:** normalization is the whole game, so it is explicit and per-assertion, never
@@ -188,9 +188,9 @@ assumed.
   not name it.
 - **Abstractions used or changed:** an optional `oracle` tier on an assertion
   (`strong` / `demo` / `live`), defaulting by type (deterministic text/process are `strong`,
-  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:16735`)
+  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:16689`)
   reports, per case, the share of its pass rate carried by `strong` oracles;
-  `audit_manifest_report` (`:19558`) warns when a case passes only on weak ones. This extends
+  `audit_manifest_report` (`:19512`) warns when a case passes only on weak ones. This extends
   leakage lint (`:164`) from prompts to oracles.
 - **Strongest tier — the rendered-artifact oracle:** the top of the ladder is an oracle that
   builds or renders the artifact and inspects the result, not the source text.
@@ -205,8 +205,8 @@ assumed.
   splits "good poster" into seven `script` oracles, but each is forced all-or-nothing by the
   exit-code-only contract: a poster with six of seven drama carriers fails `drama_oracle` exactly
   like one with zero. That is the binary-saturation problem inside a single oracle.
-- **Abstractions used or changed:** extend `run_script_assertion` (`:11053`) and
-  `assertion_result` (`:11185`) to optionally parse a score from the oracle's stdout — a JSON line
+- **Abstractions used or changed:** extend `run_script_assertion` (`:11007`) and
+  `assertion_result` (`:11139`) to optionally parse a score from the oracle's stdout — a JSON line
   such as `{"score": 6, "max_score": 7}` (normalized to 0-1) — beside the existing
   `pass_exit_code`. The parsed score flows into the `score`/`severity` channel from 2.2, so a
   script oracle becomes a graded dimension while staying fully deterministic and model-free.
@@ -223,9 +223,9 @@ assumed.
   past it — either way, question it. This is the inverse of the saturation flag: saturation marks
   a case as too easy *now*; staleness marks a case that has never discriminated *over time*.
 - **Abstractions used or changed:** reads the cross-run history from 2.6. A `prune` report (or a
-  flag in `build_benchmark_report` (`:16735`)) marks a case a removal candidate when, across the
+  flag in `build_benchmark_report` (`:16689`)) marks a case a removal candidate when, across the
   last N runs, it never failed and never showed lift (`with_skill` == `without_skill` every time).
-  `audit_manifest_report` (`:19558`) lists the candidates; removal stays a human decision.
+  `audit_manifest_report` (`:19512`) lists the candidates; removal stays a human decision.
 - **Design:** the harness suggests, never deletes. A case may be kept deliberately as a
   regression guard even when stale; the report says so rather than acting.
 - **Depends on:** 2.6 (needs run history to judge "never failed over time").
@@ -239,12 +239,12 @@ assumed.
 ### 2.1 Multi-model fan-out (priority)
 - **Goal:** run the same cases across several models and compare lift per model. No surveyed
   framework does this; vitest-evals, eve, and viteval all push it onto the test runner.
-- **Abstractions used or changed:** `prepared_task_rows` (`:1568`) gains a `model` dimension
+- **Abstractions used or changed:** `prepared_task_rows` (`:1557`) gains a `model` dimension
   beside `variant` and `run_number`. Each row carries its target `model`, and `run_dir` gains a
   model segment (`<case>/<model>/<variant>/run-<n>`), kept backward-compatible when one model
   runs. Runners pass the row `model` through; per-run `model` already lands in `metadata.json`,
-  so grading needs no change. `build_benchmark_report` (`:16735`) groups `by_variant` within
-  `by_model`, and `build_paired_summary` (`:15316`) computes lift per (case, model).
+  so grading needs no change. `build_benchmark_report` (`:16689`) groups `by_variant` within
+  `by_model`, and `build_paired_summary` (`:15270`) computes lift per (case, model).
 - **Design:** model is a third axis, not a new variant. Variants stay orthogonal, giving a
   model-by-variant grid. CLI: `--models a,b,c` on `prepare`.
 - **Testing:** a fan-out test asserting row count equals cases × variants × runs × models with
@@ -261,7 +261,7 @@ assumed.
   no-regression floor. This spec ports those shapes into the harness rather than inventing new
   ones.
 - **Abstractions used or changed:**
-  - `assertion_result` (`:11185`) gains an optional `score` (0-1 or a normalized 1-5) and
+  - `assertion_result` (`:11139`) gains an optional `score` (0-1 or a normalized 1-5) and
     `severity` (`critical` / `gate` / `soft`), read from `critical`/`gate`/`soft`/`atLeast` on the
     assertion.
   - **`critical` (absorbing-barrier) tier — valley-dodging.** From the Jetty "valley-dodging"
@@ -276,13 +276,13 @@ assumed.
   - **Anchored `graded_dimensions`** as a `judge` assertion shape:
     `{name, scale: "1-5", rubric: "5 = …observable…; 1 = …observable…"}`. Anchors name what each
     score level looks like, so a judge scores against criteria, not a vibe. `judge_prompt`
-    (`:11768`) renders the dimensions; the result carries per-dimension scores in `evidence`.
+    (`:11722`) renders the dimensions; the result carries per-dimension scores in `evidence`.
   - **`dynamic_rubric`** as a second `judge` shape: `{instruction, minimum_criteria}`. The judge
     drafts 3-5 case-specific criteria before grading and must meet at least `minimum_criteria`.
-  - `grade_case_variant` (`:13872`) splits totals into critical, gated, and soft. A `critical`
+  - `grade_case_variant` (`:13826`) splits totals into critical, gated, and soft. A `critical`
     failure vetoes the case; a `gate` failure lowers the pass rate; a `soft` failure lowers
     neither and fills a `scored` bucket. A `--strict` flag promotes soft to gate.
-  - **Statistical lift** in `build_paired_summary` (`:15316`): alongside the raw delta, compute a
+  - **Statistical lift** in `build_paired_summary` (`:15270`): alongside the raw delta, compute a
     significance test over the per-case graded scores (paired bootstrap or sign-flip
     permutation, mirroring `score_delta.py`), so lift is tested, not eyeballed.
   - **Reference-anchor floor:** an optional `reference_score` / `reference_graded_score` on a
@@ -315,7 +315,7 @@ assumed.
 - **Goal:** deterministic re-runs that pay nothing for external dependencies, by recording tool
   inputs and outputs.
 - **Abstractions used or changed:** this lives in the runner, not core grading. Recording sits
-  beside `write_trace_artifacts` (`:8274`): a `tool-replay.json` keyed per tool, with
+  beside `write_trace_artifacts` (`:8269`): a `tool-replay.json` keyed per tool, with
   `sanitize` and `version`. Modes (`auto`, `record`, `off`, `strict`) come from an environment
   variable that `run_codex` and the Pi and subagent runners read.
 - **Design:** orthogonal to the disk re-grade the harness already does. Replay makes the agent
@@ -326,8 +326,8 @@ assumed.
 
 ### 2.4 OpenTelemetry GenAI normalization target
 - **Goal:** make the trace adapter boundary a standard rather than a bespoke schema.
-- **Abstractions used or changed:** `normalize_trace_record` (`:7331`) and
-  `normalize_trace_records` (`:7990`) keep their inputs but emit OTel GenAI semantic-key
+- **Abstractions used or changed:** `normalize_trace_record` (`:7326`) and
+  `normalize_trace_records` (`:7985`) keep their inputs but emit OTel GenAI semantic-key
   attributes; the `events.json` schema version bumps. Process and efficiency assertions read the
   new keys with backward-compatible fallbacks.
 - **Design:** additive schema. An old `events.json` still grades.
@@ -337,7 +337,7 @@ assumed.
 ### 2.5 Dataset abstraction
 - **Goal:** fan one case template over many rows instead of hand-authoring each case.
 - **Abstractions used or changed:** a new optional manifest construct (`datasets`, plus a case
-  `template` referencing a dataset id). `iter_cases` (`:603`) materializes template by row into
+  `template` referencing a dataset id). `iter_cases` (`:592`) materializes template by row into
   concrete cases before fan-out; `validate_manifest` validates rows and runs leakage lint per
   materialized case.
 - **Design:** materialization happens early, so prepare, grade, and report stay unchanged.
@@ -351,7 +351,7 @@ assumed.
 - **Goal:** watch lift, saturation, and token drift over time.
 - **Abstractions used or changed:** a consumer of `build_benchmark_report`. Add an append-only
   history store and a `trend` subcommand that diffs successive `benchmark.json` files, reusing
-  the `compare_results` (`:17917`) logic.
+  the `compare_results` (`:17871`) logic.
 - **Severity-weighted ranking (from the macro-evals notebook):** when surfacing recurring
   failures across runs, rank them by `prevalence × severity`, not raw count, so a rare but severe
   failure outranks a common trivial one. This is the floor-raising principle made quantitative;
@@ -377,8 +377,8 @@ assumed.
   it dispatches a subagent with a rubric whose "criteria [are] deliberately absent from
   generation rules."
 - **Abstractions used or changed:** mostly a discipline made first-class, not new machinery.
-  `prepared_task_rows` (`:1568`) already omits `review_rubric` from generation payloads unless
-  `--include-answer-key`; extend `validate_manifest` (`:1171`) to require that a `holdout`/
+  `prepared_task_rows` (`:1557`) already omits `review_rubric` from generation payloads unless
+  `--include-answer-key`; extend `validate_manifest` (`:1160`) to require that a `holdout`/
   `holdback` case's rubric stays out of the skill and public eval text, and pair it with the
   subagent judge from 2.7 and the graded scoring from 2.2. Track which rubrics were held out so
   the report can separate held-out scores from tune-visible ones.
@@ -390,7 +390,7 @@ assumed.
 ### 2.8 Interactive served report and richer artifacts
 - **Goal:** capture feedback in the browser and render image, PDF, and xlsx artifacts, beyond the
   static `render_viewer`.
-- **Abstractions used or changed:** extend `render_viewer` (`:18714`) with a `serve` mode and
+- **Abstractions used or changed:** extend `render_viewer` (`:18668`) with a `serve` mode and
   artifact encoders. Anthropic's `eval-viewer/generate_review.py` is the blueprint, including
   `feedback.json` persistence and a `--previous-workspace` diff.
 - **Testing:** unit-test the artifact embedding and categorization and the feedback round trip;
@@ -422,7 +422,7 @@ assumed.
 - **Goal:** evaluate conversational skills across a send/respond sequence.
 - **Abstractions changed (core contract):** a case gains an optional `turns` list. The
   run-output contract grows from one `output.md` to a turn-indexed transcript, so
-  `read_output_base` (`:6254`) and `discover_run_bases` learn the turn layout; runners drive the
+  `read_output_base` (`:6243`) and `discover_run_bases` learn the turn layout; runners drive the
   sequence; `grade_case_variant` grades per turn and aggregates.
 - **Design:** single-shot stays the default, so existing manifests are untouched.
 - **Testing:** a fixture multi-turn run asserting per-turn grading and aggregate, plus a
@@ -435,7 +435,7 @@ assumed.
   the model axis, plus a viewer panel.
 - **Slice-lift concentration (from the macro-evals notebook):** compute, per slice, where lift (or
   a failure) concentrates — `slice share ÷ overall share`, the macro-eval `lift` metric one level
-  up from per-case lift. `build_slice_summary` (`:15487`) already groups by domain/difficulty/
+  up from per-case lift. `build_slice_summary` (`:15441`) already groups by domain/difficulty/
   trigger/goal, so this is a ratio over groups it already forms, not new plumbing.
 - **Testing:** a report test over a two-model by two-variant fixture grid, plus a concentration
   test asserting a failure confined to one slice scores a high ratio there.
@@ -548,7 +548,7 @@ and upgrading to the new features should be something an agent can drive.
 
 ### Abstractions used or changed
 
-- `version` on the manifest (`validate_manifest:1171`) becomes meaningful: `validate` accepts both
+- `version` on the manifest (`validate_manifest:1160`) becomes meaningful: `validate` accepts both
   1 and 2, and warns (not errors) on a `version: 1` manifest once 2.2 has landed, pointing at
   `migrate`.
 - No grading abstraction changes for migration itself; it is a source-rewrite plus a guide.

--- a/docs/skill-ablation-spec.md
+++ b/docs/skill-ablation-spec.md
@@ -363,7 +363,7 @@ Opt in with `"invalid_skill": true` on the ablation: the run is tagged
 
 ## Validation additions
 
-`validate_manifest` (`skill_benchmark.py:1171`), per ablation:
+`validate_manifest` (`skill_benchmark.py:1160`), per ablation:
 
 - `id` unique and slug-formatted; keep `removed_component`.
 - If a removal is declared: exactly one of `mechanism`+`target` or `components`;

--- a/json_contracts.py
+++ b/json_contracts.py
@@ -35,6 +35,35 @@ def validate_json_value(value: Any, label: str) -> None:
     _validate_json_value(value, label, depth=0, ancestors=set())
 
 
+def unique_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise json.JSONDecodeError(f"duplicate object key: {key!r}", "", 0)
+        result[key] = value
+    return result
+
+
+def strict_json_loads(value: str | bytes | bytearray) -> Any:
+    """Parse strict, persistable JSON without last-key-wins shadowing."""
+    def reject_constant(constant: str) -> Any:
+        raise json.JSONDecodeError(
+            f"non-finite numeric constant is not valid JSON: {constant}", "", 0)
+
+    try:
+        parsed = json.loads(
+            value,
+            object_pairs_hook=unique_json_object,
+            parse_constant=reject_constant,
+        )
+        validate_json_value(parsed, "strict JSON")
+        return parsed
+    except json.JSONDecodeError:
+        raise
+    except (OverflowError, RecursionError, TypeError, ValueError) as exc:
+        raise json.JSONDecodeError(str(exc), "", 0) from exc
+
+
 def _validate_json_value(
     value: Any, label: str, *, depth: int, ancestors: set[int],
 ) -> None:
@@ -123,6 +152,22 @@ def freeze_json_mapping(
     if not isinstance(frozen, Mapping):  # pragma: no cover - established above
         raise TypeError(f"{label} must be a mapping")
     return frozen
+
+
+def thaw_json_value(value: Any, label: str = "frozen JSON value") -> Any:
+    """Return a detached mutable JSON wire shape from a validated frozen value."""
+    validate_json_value(value, label)
+    if isinstance(value, Mapping):
+        return {
+            key: thaw_json_value(item, f"{label}.{key}")
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [
+            thaw_json_value(item, f"{label}[{index}]")
+            for index, item in enumerate(value)
+        ]
+    return value
 
 
 def strict_json_equal(left: Any, right: Any) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ skill-pi-trigger-eval = "run_pi_trigger_eval:main"
 skill-trigger-matrix = "run_trigger_matrix:main"
 
 [tool.setuptools]
-py-modules = ["skill_benchmark", "run_pi_trigger_eval", "run_trigger_matrix", "ablation_model", "agent_capabilities", "telemetry", "trigger_contracts", "trigger_reporting", "trace_contracts", "runner_contracts", "judge_contracts", "judge_verdict", "experimental_pairs", "jetty_contracts", "gemini_contracts", "invocation_contracts", "json_contracts", "manifest_contracts", "text_contracts"]
+py-modules = ["skill_benchmark", "run_pi_trigger_eval", "run_trigger_matrix", "ablation_model", "agent_capabilities", "artifact_contracts", "telemetry", "trigger_contracts", "trigger_reporting", "trace_contracts", "runner_contracts", "judge_contracts", "judge_verdict", "experimental_pairs", "jetty_contracts", "gemini_contracts", "invocation_contracts", "json_contracts", "manifest_contracts", "text_contracts"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/skill_benchmark.py
+++ b/skill_benchmark.py
@@ -117,6 +117,15 @@ from agent_capabilities import (
     trace_dialect_implementations,
     workspace_builder_implementations,
 )
+from artifact_contracts import (
+    ARTIFACT_COMMIT_NAME,
+    ARTIFACT_CONTRACT_VERSION,
+    ARTIFACT_REQUIRED_FILES,
+    CompleteArtifactSet,
+    LegacyArtifactSet,
+    artifact_commit_valid,
+    observe_artifact_set,
+)
 from gemini_contracts import GeminiJsonResponse, GeminiStream
 from invocation_contracts import (
     InvocationRequest,
@@ -131,6 +140,9 @@ from jetty_contracts import (
     lifecycle_from_status,
 )
 from json_contracts import (
+    strict_json_loads,
+    thaw_json_value,
+    unique_json_object,
     validate_json_text,
     validate_json_value,
 )
@@ -163,7 +175,15 @@ from text_contracts import (
     comparison_note,
     parse_human_text_assertion,
 )
-from trace_contracts import EventState, event_is_completed, parse_event_state
+from trace_contracts import (
+    EventLogObservation,
+    EventState,
+    InvalidEventLog,
+    MissingEventLog,
+    event_is_completed,
+    parse_event_log,
+    parse_event_state,
+)
 from trigger_contracts import (
     InvocationOutcome,
     TraceEventKind,
@@ -176,7 +196,7 @@ from trigger_reporting import CompleteTriggerCohort, summarize_trigger_cohort
 
 VALID_SPLITS = frozenset(Split.values())
 HARNESS_SEMANTIC_MODULES = (
-    "ablation_model.py", "agent_capabilities.py", "experimental_pairs.py",
+    "ablation_model.py", "agent_capabilities.py", "artifact_contracts.py", "experimental_pairs.py",
     "gemini_contracts.py",
     "invocation_contracts.py", "jetty_contracts.py", "judge_contracts.py", "judge_verdict.py", "json_contracts.py", "manifest_contracts.py", "run_pi_trigger_eval.py",
     "run_trigger_matrix.py", "runner_contracts.py", "skill_benchmark.py",
@@ -352,37 +372,6 @@ def oracle_tier(assertion: dict[str, Any]) -> str:
 def die(msg: str) -> NoReturn:
     print(f"FAIL: {msg}", file=sys.stderr)
     raise SystemExit(1)
-
-
-def _unique_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
-    result: dict[str, Any] = {}
-    for key, value in pairs:
-        if key in result:
-            raise json.JSONDecodeError(f"duplicate object key: {key!r}", "", 0)
-        result[key] = value
-    return result
-
-
-def strict_json_loads(value: str | bytes | bytearray) -> Any:
-    """Parse JSON without allowing last-key-wins shadowing."""
-    def reject_constant(constant: str) -> Any:
-        raise json.JSONDecodeError(
-            f"non-finite numeric constant is not valid JSON: {constant}", "", 0)
-
-    try:
-        parsed = json.loads(
-            value, object_pairs_hook=_unique_json_object,
-            parse_constant=reject_constant)
-        reject_nonfinite_numbers(parsed)
-        validate_json_value(parsed, "strict JSON")
-        return parsed
-    except json.JSONDecodeError:
-        raise
-    except (OverflowError, RecursionError, TypeError, ValueError) as exc:
-        # Keep one stable exception surface for every syntactic, resource, and
-        # strict-persistability rejection so legacy callers cannot accidentally
-        # turn a new validation rule into an uncaught traceback.
-        raise json.JSONDecodeError(str(exc), "", 0) from exc
 
 
 def reject_nonfinite_numbers(value: Any, *, location: str = "$") -> None:
@@ -6270,13 +6259,14 @@ def read_output(runs: Path, case_id: str, variant: str) -> tuple[str | None, Pat
 
 
 def _with_committed_artifact_state(base: Path, data: dict[str, Any]) -> dict[str, Any]:
-    marker_present = (base / ARTIFACT_COMMIT_NAME).exists()
-    contract_declared = data.get("artifact_contract_version") == ARTIFACT_CONTRACT_VERSION
-    if not marker_present and not contract_declared:
+    declared_version = data.get("artifact_contract_version")
+    observation = observe_artifact_set(
+        base, declared_contract_version=declared_version)
+    if isinstance(observation, LegacyArtifactSet):
         error = metadata_lifecycle_error(data)
         return ({**data, "metadata_error": error, "metadata_artifact_valid": False}
                 if error else data)
-    committed = marker_present and contract_declared and artifact_commit_valid(base)
+    committed = isinstance(observation, CompleteArtifactSet)
     current = telemetry_domain.ObservationEvidence.from_run(data)
     evidence = telemetry_domain.ObservationEvidence(
         current.process, current.provider_response, current.trace,
@@ -6284,6 +6274,9 @@ def _with_committed_artifact_state(base: Path, data: dict[str, Any]) -> dict[str
     )
     enriched = dict(data)
     enriched["artifact_set_complete"] = committed
+    enriched["artifact_set_state"] = observation.state.value
+    if not committed:
+        enriched["artifact_set_error"] = observation.reason
     enriched["observation_evidence"] = evidence.to_dict()
     envelope = enriched.get("telemetry")
     if isinstance(envelope, dict):
@@ -6317,26 +6310,28 @@ def read_json_dict_or_list(path: Path) -> Any:
         return {"_error": f"invalid JSON in {path.name}: {exc}"}
 
 
+def read_event_log_base(base: Path) -> EventLogObservation:
+    path = base / "events.json"
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return MissingEventLog()
+    except OSError as exc:
+        return InvalidEventLog(f"could not read events.json: {exc}")
+    try:
+        raw = strict_json_loads(raw_text)
+    except json.JSONDecodeError as exc:
+        return InvalidEventLog(f"invalid JSON in events.json: {exc}")
+    return parse_event_log(raw)
+
+
 def read_events_base(base: Path) -> tuple[list[dict[str, Any]] | None, str | None]:
-    data = read_json_dict_or_list(base / "events.json")
-    if data is None:
-        return None, "missing events.json"
-    if isinstance(data, dict) and data.get("_error"):
-        return None, str(data["_error"])
-    version = data.get("schema_version") if isinstance(data, dict) else None
-    if version not in {None, 1, 2}:
-        return None, f"unsupported events.json schema_version {version!r}"
-    events = data.get("events") if isinstance(data, dict) else data
-    if not isinstance(events, list) or not all(isinstance(e, dict) for e in events):
-        return None, "events.json must contain an events list"
-    if version in {None, 1}:
-        events = [
-            ({**event, "status": EventState.COMPLETED.value,
-              "state_source": "legacy_assumed_completed"}
-             if event.get("status") is None else event)
-            for event in events
-        ]
-    return events, None
+    observation = read_event_log_base(base)
+    if isinstance(observation, MissingEventLog):
+        return None, observation.reason
+    if isinstance(observation, InvalidEventLog):
+        return None, observation.reason
+    return [thaw_json_value(event, "event log entry") for event in observation.events], None
 
 
 def read_metrics_base(base: Path) -> dict[str, Any]:
@@ -8505,11 +8500,6 @@ def final_answer_from_events(events: dict[str, Any]) -> str:
     return ""
 
 
-ARTIFACT_COMMIT_NAME = "artifact-commit.json"
-ARTIFACT_CONTRACT_VERSION = 1
-ARTIFACT_REQUIRED_FILES = ("output.md", "events.json", "metrics.json", "metadata.json")
-
-
 def _file_sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
@@ -8533,42 +8523,6 @@ def write_artifact_commit(run_dir: Path) -> None:
         "required_files": list(ARTIFACT_REQUIRED_FILES),
         "inventory_sha256": inventory,
     })
-
-
-def artifact_commit_valid(run_dir: Path) -> bool:
-    path = run_dir / ARTIFACT_COMMIT_NAME
-    try:
-        raw = strict_json_loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return False
-    if not isinstance(raw, dict) or raw.get("schema_version") != ARTIFACT_CONTRACT_VERSION:
-        return False
-    required = raw.get("required_files")
-    inventory = raw.get("inventory_sha256")
-    if required != list(ARTIFACT_REQUIRED_FILES) or not isinstance(inventory, dict):
-        return False
-    if any(not isinstance(name, str) or not isinstance(digest, str)
-           or Path(name).is_absolute() or ".." in Path(name).parts
-           for name, digest in inventory.items()):
-        return False
-    if any(name not in inventory for name in ARTIFACT_REQUIRED_FILES):
-        return False
-    try:
-        actual_files = {
-            candidate.relative_to(run_dir).as_posix()
-            for candidate in run_dir.rglob("*")
-            if candidate.name != ARTIFACT_COMMIT_NAME and candidate.is_file()
-            and not candidate.is_symlink()
-        }
-        if actual_files != set(inventory):
-            return False
-        if any(candidate.is_symlink() for candidate in run_dir.rglob("*")):
-            return False
-        return all(
-            (run_dir / name).is_file() and _file_sha256(run_dir / name) == digest
-            for name, digest in inventory.items())
-    except OSError:
-        return False
 
 
 def _install_staged_run(run_dir: Path, staged: Path) -> None:
@@ -11640,7 +11594,7 @@ def extract_json_object(text: str) -> dict[str, Any]:
             f"non-finite numeric constant is not valid JSON: {constant}", "", 0)
 
     decoder = json.JSONDecoder(
-        object_pairs_hook=_unique_json_object,
+        object_pairs_hook=unique_json_object,
         parse_constant=reject_constant)
     found: list[dict[str, Any]] = []
     i = 0

--- a/tests/test_artifact_contracts.py
+++ b/tests/test_artifact_contracts.py
@@ -1,0 +1,163 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import artifact_contracts as ac
+import skill_benchmark as sb
+import trace_contracts as tc
+
+
+class ArtifactSetObservationTests(unittest.TestCase):
+    def test_undeclared_directory_is_explicitly_legacy(self):
+        with tempfile.TemporaryDirectory() as td:
+            observation = ac.observe_artifact_set(Path(td))
+            self.assertIsInstance(observation, ac.LegacyArtifactSet)
+
+    def test_declared_directory_without_marker_is_missing(self):
+        with tempfile.TemporaryDirectory() as td:
+            observation = ac.observe_artifact_set(
+                Path(td), declared_contract_version=ac.ARTIFACT_CONTRACT_VERSION)
+            self.assertIsInstance(observation, ac.MissingArtifactCommit)
+
+    def test_malformed_marker_is_invalid(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            (base / ac.ARTIFACT_COMMIT_NAME).write_text("{bad", encoding="utf-8")
+            observation = ac.observe_artifact_set(
+                base, declared_contract_version=ac.ARTIFACT_CONTRACT_VERSION)
+            self.assertIsInstance(observation, ac.InvalidArtifactCommit)
+
+    def test_schema_versions_are_exact_integers(self):
+        for version in (True, False, 1.0, "1", 2):
+            with self.subTest(version=version), tempfile.TemporaryDirectory() as td:
+                base = Path(td)
+                for name in ac.ARTIFACT_REQUIRED_FILES:
+                    (base / name).write_text("{}", encoding="utf-8")
+                sb.write_artifact_commit(base)
+                marker = json.loads(
+                    (base / ac.ARTIFACT_COMMIT_NAME).read_text(encoding="utf-8"))
+                marker["schema_version"] = version
+                (base / ac.ARTIFACT_COMMIT_NAME).write_text(
+                    json.dumps(marker), encoding="utf-8")
+
+                observation = ac.observe_artifact_set(
+                    base, declared_contract_version=version)
+
+                self.assertIsInstance(observation, ac.InvalidArtifactCommit)
+
+    def test_dangling_and_live_marker_symlinks_are_invalid(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            marker = base / ac.ARTIFACT_COMMIT_NAME
+            marker.symlink_to(base / "missing-marker.json")
+            self.assertIsInstance(
+                ac.observe_artifact_set(base), ac.InvalidArtifactCommit)
+            marker.unlink()
+            target = base / "real-marker.json"
+            target.write_text("{}", encoding="utf-8")
+            marker.symlink_to(target)
+            self.assertIsInstance(
+                ac.observe_artifact_set(base), ac.InvalidArtifactCommit)
+
+    def test_missing_or_tampered_committed_file_is_incomplete(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            for name in ac.ARTIFACT_REQUIRED_FILES:
+                (base / name).write_text("{}", encoding="utf-8")
+            sb.write_artifact_commit(base)
+            (base / "events.json").write_text("[]", encoding="utf-8")
+
+            observation = ac.observe_artifact_set(
+                base, declared_contract_version=ac.ARTIFACT_CONTRACT_VERSION)
+
+            self.assertIsInstance(observation, ac.IncompleteArtifactSet)
+            self.assertFalse(ac.artifact_commit_valid(base))
+
+    def test_complete_inventory_is_immutable(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            for name in ac.ARTIFACT_REQUIRED_FILES:
+                (base / name).write_text("{}", encoding="utf-8")
+            sb.write_artifact_commit(base)
+
+            observation = ac.observe_artifact_set(
+                base, declared_contract_version=ac.ARTIFACT_CONTRACT_VERSION)
+
+            self.assertIsInstance(observation, ac.CompleteArtifactSet)
+            assert isinstance(observation, ac.CompleteArtifactSet)
+            with self.assertRaises(TypeError):
+                observation.inventory_sha256["shadow.txt"] = "digest"  # type: ignore[index]
+
+        with self.assertRaises(ValueError):
+            ac.CompleteArtifactSet({name: "x" for name in ac.ARTIFACT_REQUIRED_FILES})
+
+    def test_metadata_projection_exposes_reasoned_state_and_legacy_shape(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            self.assertEqual(sb.read_metadata_base(base), {})
+            (base / "metadata.json").write_text(json.dumps({
+                "artifact_contract_version": ac.ARTIFACT_CONTRACT_VERSION,
+            }), encoding="utf-8")
+
+            metadata = sb.read_metadata_base(base)
+
+            self.assertFalse(metadata["artifact_set_complete"])
+            self.assertEqual(metadata["artifact_set_state"], "missing_commit")
+            self.assertIn("commit marker", metadata["artifact_set_error"])
+
+
+class EventLogObservationTests(unittest.TestCase):
+    def test_missing_invalid_and_loaded_logs_are_distinct(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            self.assertIsInstance(sb.read_event_log_base(base), tc.MissingEventLog)
+
+            (base / "events.json").write_text("null", encoding="utf-8")
+            self.assertIsInstance(sb.read_event_log_base(base), tc.InvalidEventLog)
+
+            (base / "events.json").write_text(json.dumps({
+                "schema_version": 2,
+                "events": [{"type": "command", "status": "completed"}],
+            }), encoding="utf-8")
+            observation = sb.read_event_log_base(base)
+            self.assertIsInstance(observation, tc.LoadedEventLog)
+            assert isinstance(observation, tc.LoadedEventLog)
+            self.assertEqual(observation.schema_version, 2)
+            self.assertEqual(observation.events[0]["type"], "command")
+
+    def test_legacy_event_log_is_normalized_before_projection(self):
+        observation = tc.parse_event_log([{"type": "command"}])
+        self.assertIsInstance(observation, tc.LoadedEventLog)
+        assert isinstance(observation, tc.LoadedEventLog)
+        self.assertEqual(observation.schema_version, 1)
+        self.assertEqual(observation.events[0]["status"], "completed")
+        self.assertEqual(
+            observation.events[0]["state_source"], "legacy_assumed_completed")
+
+    def test_loaded_events_are_deeply_frozen_and_detached(self):
+        event = {"type": "command", "detail": {"paths": ["a"]}}
+        observation = tc.parse_event_log({
+            "schema_version": 2, "events": [event],
+        })
+        self.assertIsInstance(observation, tc.LoadedEventLog)
+        assert isinstance(observation, tc.LoadedEventLog)
+        event["detail"]["paths"].append("source-mutation")
+        self.assertEqual(observation.events[0]["detail"]["paths"], ("a",))
+        with self.assertRaises(TypeError):
+            observation.events[0]["detail"]["paths"] = []  # type: ignore[index]
+
+    def test_event_schema_versions_are_exact_integers(self):
+        for version in (None, True, False, 1.0, "1", 3):
+            with self.subTest(version=version):
+                observation = tc.parse_event_log({
+                    "schema_version": version, "events": [],
+                })
+                self.assertIsInstance(observation, tc.InvalidEventLog)
+
+        with self.assertRaises(ValueError):
+            tc.LoadedEventLog((), True)  # type: ignore[arg-type]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trace_contracts.py
+++ b/trace_contracts.py
@@ -1,9 +1,12 @@
 """Closed lifecycle states for normalized trace events."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import Any, Literal, TypeAlias
+
+from json_contracts import freeze_json_mapping
 
 
 class EventState(str, Enum):
@@ -25,6 +28,79 @@ class ParsedEventState:
     state: EventState
     source: EventStateSource
     raw: str | None = None
+
+
+class EventLogState(str, Enum):
+    MISSING = "missing"
+    INVALID = "invalid"
+    LOADED = "loaded"
+
+
+@dataclass(frozen=True)
+class MissingEventLog:
+    reason: str = "missing events.json"
+    state: Literal[EventLogState.MISSING] = field(
+        default=EventLogState.MISSING, init=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.reason, str) or not self.reason.strip():
+            raise ValueError("missing event log reason must be non-empty")
+
+
+@dataclass(frozen=True)
+class InvalidEventLog:
+    reason: str
+    state: Literal[EventLogState.INVALID] = field(
+        default=EventLogState.INVALID, init=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.reason, str) or not self.reason.strip():
+            raise ValueError("invalid event log reason must be non-empty")
+
+
+@dataclass(frozen=True)
+class LoadedEventLog:
+    events: tuple[Mapping[str, Any], ...]
+    schema_version: Literal[1, 2]
+    state: Literal[EventLogState.LOADED] = field(
+        default=EventLogState.LOADED, init=False)
+
+    def __post_init__(self) -> None:
+        if type(self.schema_version) is not int or self.schema_version not in {1, 2}:
+            raise ValueError("loaded event log schema_version must be exactly 1 or 2")
+        if not isinstance(self.events, tuple) or not all(
+            isinstance(event, Mapping) for event in self.events
+        ):
+            raise TypeError("loaded event log events must be a tuple of mappings")
+        object.__setattr__(self, "events", tuple(
+            freeze_json_mapping(event, f"events[{index}]")
+            for index, event in enumerate(self.events)
+        ))
+
+
+EventLogObservation: TypeAlias = MissingEventLog | InvalidEventLog | LoadedEventLog
+
+
+def parse_event_log(raw: Any) -> InvalidEventLog | LoadedEventLog:
+    """Parse a loaded JSON value into one normalized event-log observation."""
+    version_present = isinstance(raw, dict) and "schema_version" in raw
+    version = raw["schema_version"] if version_present else None
+    if version_present and (type(version) is not int or version not in {1, 2}):
+        return InvalidEventLog(f"unsupported events.json schema_version {version!r}")
+    events = raw.get("events") if isinstance(raw, dict) else raw
+    if not isinstance(events, list) or not all(isinstance(event, dict) for event in events):
+        return InvalidEventLog("events.json must contain an events list")
+    resolved_version: Literal[1, 2] = 2 if type(version) is int and version == 2 else 1
+    if resolved_version == 1:
+        events = [
+            ({
+                **event,
+                "status": EventState.COMPLETED.value,
+                "state_source": EventStateSource.LEGACY_ASSUMED_COMPLETED.value,
+            } if event.get("status") is None else event)
+            for event in events
+        ]
+    return LoadedEventLog(tuple(events), resolved_version)
 
 
 _COMPLETED = {"completed", "complete", "succeeded", "success", "done", "finished"}

--- a/type_tests/abstraction_contracts.py
+++ b/type_tests/abstraction_contracts.py
@@ -13,6 +13,14 @@ from typing import NoReturn
 from typing_extensions import assert_type
 
 from ablation_model import PreparedTask
+from artifact_contracts import (
+    ArtifactSetObservation,
+    CompleteArtifactSet,
+    IncompleteArtifactSet,
+    InvalidArtifactCommit,
+    LegacyArtifactSet,
+    MissingArtifactCommit,
+)
 from experimental_pairs import (
     ExperimentalPair,
     ExperimentalPairKey,
@@ -46,6 +54,12 @@ from runner_contracts import (
     ProviderFailed,
     SpawnFailed,
     TimedOut,
+)
+from trace_contracts import (
+    EventLogObservation,
+    InvalidEventLog,
+    LoadedEventLog,
+    MissingEventLog,
 )
 from trigger_contracts import (
     CompleteTriggerResult,
@@ -147,3 +161,32 @@ def provider_invocation_types_are_precise(
     _argv: tuple[str, ...] = plan.argv
     _environment: Mapping[str, str] | None = plan.environment
     _state: InvocationState = result.invocation_state
+
+
+def artifact_set_observation_is_exhaustive(
+    observation: ArtifactSetObservation,
+) -> None:
+    if isinstance(observation, LegacyArtifactSet):
+        _legacy: LegacyArtifactSet = observation
+    elif isinstance(observation, MissingArtifactCommit):
+        _missing_reason: str = observation.reason
+    elif isinstance(observation, InvalidArtifactCommit):
+        _invalid_reason: str = observation.reason
+    elif isinstance(observation, IncompleteArtifactSet):
+        _incomplete_reason: str = observation.reason
+    elif isinstance(observation, CompleteArtifactSet):
+        _inventory: Mapping[str, str] = observation.inventory_sha256
+    else:
+        _assert_never(observation)
+
+
+def event_log_observation_is_exhaustive(observation: EventLogObservation) -> None:
+    if isinstance(observation, MissingEventLog):
+        _missing_reason: str = observation.reason
+    elif isinstance(observation, InvalidEventLog):
+        _invalid_reason: str = observation.reason
+    elif isinstance(observation, LoadedEventLog):
+        _events: tuple[Mapping[str, object], ...] = observation.events
+        _schema_version: int = observation.schema_version
+    else:
+        _assert_never(observation)


### PR DESCRIPTION
## Summary

- classify artifact sets as legacy, missing-commit, invalid-commit, incomplete, or complete
- classify event logs as missing, invalid, or loaded before exposing the legacy projection
- require exact integer schema versions and validate marker inventories, paths, and lowercase SHA-256 digests
- reject symbolic links and recursively freeze loaded JSON while deep-thawing only at the compatibility edge

This is layer 5 of the `ty` migration stack and depends on #76.

## Why

The disk boundary previously collapsed malformed markers, interrupted writes, stale digests, missing files, and invalid logs into booleans or nullable tuples. The closed observations retain each failure reason and prevent mutation after validation.

## Compatibility and risk

Serialized artifact files and legacy reader signatures remain unchanged. An absent event schema keeps legacy-v1 behavior; a present `null`, boolean, float, string, or unsupported version is invalid. Declared artifact sets now fail closed on malformed inventories and live or dangling symlinks.

## Validation

- focused artifact-contract, integrity, trace, and legacy-projection tests
- adversarial coverage for direct construction, deep mutation, exact schema integers, digests, and symlinks
- top-of-stack integration: 1,335 passed, 7 skipped, 858 subtests
- warning-fatal `ty`, Ruff, byte compilation, doc-reference check, and `git diff --check`
