### PR TITLE
Type grading observations and judge tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,7 @@ skill-eval-harness/
 ├── agent_capabilities.py       # unified backend surfaces, capabilities, CLI options, smoke, and failure policy
 ├── artifact_contracts.py       # closed persisted-artifact observations and integrity verification
 ├── experimental_pairs.py       # exact pair identities and blocked-pair construction
+├── grading_contracts.py        # closed assertion observations and immutable judge tasks
 ├── runner_contracts.py         # closed answer-runner outcome union
 ├── judge_verdict.py            # strict imported/stored judge verdict variants
 ├── jetty_contracts.py          # closed Jetty lifecycle and observation contract

--- a/TODO.md
+++ b/TODO.md
@@ -71,7 +71,7 @@ Jetty runbooks emit a standardized machine-readable `validation_report.json` per
 (`jettyio/jettyio-skills`, `skills/create-runbook/SKILL.md`). Rubric evaluation scores 3-7
 dimensions on a 1-5 scale; programmatic evaluation returns `PASS` / `PARTIAL` / `FAIL`. The
 items below map that report onto the harness judge-result row `{judge_task_id, passed, score,
-threshold, evidence}` (`load_judge_results:11565`, merged in `grade_case_variant:13826`).
+threshold, evidence}` (`load_judge_results:11575`, merged in `grade_case_variant:13880`).
 
 - [ ] Export qualitative judge tasks to Jetty workflows using `simple_judge` where useful.
       Carry `judge_task_id` (`case::variant::run-n::assertion`) into the Jetty task so the

--- a/docs/abstractions.md
+++ b/docs/abstractions.md
@@ -174,10 +174,10 @@ Likewise, `read_event_log_base` produces `MissingEventLog | InvalidEventLog | Lo
 ## Runner / adapter
 
 An **answer runner** consumes prepared task rows and produces the run-output contract. The repo
-ships Pi answer smoke (`examples/adewale-workspace/run_pi_smoke.py`), Codex (`run_codex:10439`), Claude (`run_claude:10625`, capturing real
+ships Pi answer smoke (`examples/adewale-workspace/run_pi_smoke.py`), Codex (`run_codex:10449`), Claude (`run_claude:10635`, capturing real
 per-run cost), Gemini CLI and Mistral Vibe (`run-agent --agent gemini|vibe`, using isolated provider homes outside the workdir), the in-process
-subagent runner (`run_subagent:13171`, which hosts record/replay tool I/O via `ToolReplayStore`),
-Jetty (`JettyClient:3995` and the export/run/import commands), and any runner that writes the
+subagent runner (`run_subagent:13225`, which hosts record/replay tool I/O via `ToolReplayStore`),
+Jetty (`JettyClient:4005` and the export/run/import commands), and any runner that writes the
 contract directly. Each answer runner registers a workspace builder so one cross-runner invariant
 proves its `without_skill` arm is skill-free (CF.2). Autonomous trigger runners are separate: they
 read trigger cases from the manifest directly, never consume answer task rows, and emit trigger
@@ -217,7 +217,9 @@ Qualitative assertions defer. `collect_judge_tasks` gathers every `judge`/`rubri
 across runs and keys each by `judge_task_id` (`case::variant::run-n::assertion`, with a `model`
 segment on a multi-model run). `grade --judge-tasks` can serialize that queue, while the
 `judge` command reconstructs the same tasks from the manifest and run directory rather than
-reading the optional queue file. `judge_prompt` renders the case, expected behavior, rubric,
+reading the optional queue file. Before queuing, `grading_contracts.JudgeTask` validates and freezes
+the case/model/variant/run identity, paths, assertion, conversation, and prompt/evidence
+fingerprints. `judge_prompt` renders the case, expected behavior, rubric,
 and candidate output into a prompt — including the anchored dimensions or dynamic-rubric
 instruction for a graded assertion; `run_one_judge_task` pipes it to the `--judge-cmd` you
 supply or to a native `--judge-backend` (`claude`, `codex`, `gemini`, or `vibe`) plus
@@ -245,6 +247,12 @@ behind rather than a verdict. Grading reads from disk and calls no model, which 
 a default re-grade cheap and deterministic; opt-in script and embedding oracles are the explicit
 external-process exceptions.
 
+Before aggregation, every objective and qualitative row becomes one
+`SatisfiedAssertion | FailedAssertion | UnavailableAssertion | SkippedAssertion`. Severity and
+oracle tier are closed enums, scores must be finite, and unavailable/skipped rows cannot enter a
+pass-rate denominator. The legacy dictionary rows are serialized only after typed aggregation, so
+`passed: null`, dependency skips, and observed failures no longer share an implicit falsy branch.
+
 ## Benchmark report
 
 `build_benchmark_report` invokes the shared grader for each discovered run, then
@@ -262,7 +270,7 @@ those pairs; missing/ineligible arms remain in `pairing` diagnostics and duplica
 `build_slice_summary` breaks results down
 by domain, difficulty, trigger type, and success goal. Case flags mark saturated, no-lift,
 flaky, and with-skill-failed cases. These flags, the leakage lint
-(`prompt_assertion_leakage_findings:785`), and the split discipline are the part of the tool
+(`prompt_assertion_leakage_findings:795`), and the split discipline are the part of the tool
 no surveyed eval framework copies.
 
 The pairing key carries `CaseId`, `ModelId | None`, `RunNumber`, and the closed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,6 +146,8 @@ provider result -> Completed | TimedOut | SpawnFailed | ProviderFailed
 run evidence -> process × provider-response × trace × artifact-set state
 artifact set -> Legacy | MissingCommit | InvalidCommit | Incomplete | Complete
 event log -> Missing | Invalid | Loaded
+assertion result -> Satisfied | Failed | Unavailable | Skipped
+qualitative work -> JudgeTask
 judge process -> JudgeInvocation
 judge row -> Boolean | Scored | Dimension | Dynamic | Consensus verdict
 trace status -> Completed | InProgress | Failed | Unknown

--- a/docs/correctness-by-construction-audit.md
+++ b/docs/correctness-by-construction-audit.md
@@ -107,11 +107,14 @@ of the four variants.
 ## Judge invocation results
 
 `judge_contracts.JudgeInvocation` is the immutable process boundary shared by native judge
-backends and `--judge-cmd`. It requires string output channels and an exact integer return code,
+backends and `--judge-cmd`. It requires string output channels, an exact integer return code, and an
+explicit shared `InvocationState`,
 validates finite non-negative cost and usage measurements, recursively freezes usage, and closes
 usage provenance plus model identity. `run_one_judge_task` rejects any registered backend that
 returns another shape before JSON extraction, schema checks, typed verdict construction, or row
-assembly. A nonzero exit remains a valid diagnostic invocation but cannot become a complete judge
+assembly. Exit-zero provider-protocol failure retains return code zero with
+`InvocationState.PROVIDER_FAILED`; it cannot become a complete judge observation. A nonzero exit
+remains a valid diagnostic invocation but cannot become a complete judge
 observation. This changes no persisted judge-row fields; `judge_verdict.py` still re-establishes the
 boolean/scored/dimension/dynamic/consensus invariant at the storage boundary.
 
@@ -204,6 +207,27 @@ verify the marker and inventory before deriving `artifact_set_complete`; an inte
 missing or changed committed file, unsafe inventory path, or stale marker remains incomplete and
 unscorable. Later downstream artifacts such as `grading.json` do not alter the committed producer
 inventory.
+
+## Grading observations and judge tasks
+
+`grading_contracts.py` closes both sides of qualitative grading:
+
+```text
+assertion row -> Satisfied | Failed | Unavailable | Skipped
+judge work item -> JudgeTask(case, model, variant, run, paths, prompt, fingerprints)
+```
+
+- `passed: null` is unavailable evidence, not a behavioral failure. Dependency skips remain a
+  separate state even when an assertion had already produced an observed result before the
+  dependency fixed point resolved.
+- Severity and oracle tier are enums and scores are finite. Only satisfied/failed observations can
+  enter grading denominators; aggregation consumes the union and serializes dictionaries last.
+- `JudgeTask` validates the exact experimental identity, fingerprint syntax, and run paths before
+  the task is queued; `run_one_judge_task` recomputes the canonical input fingerprint against the
+  current output and trajectory before invocation. Assertion and conversation JSON are recursively frozen and
+  detached from their source rows, then deeply thawed only at serialization. A partially assembled
+  task cannot reach a judge backend.
+- `ty` checks exhaustive narrowing for the assertion union and precise judge-task identity fields.
 
 ## Imported judge verdicts
 

--- a/docs/eval-framework-roadmap-spec.md
+++ b/docs/eval-framework-roadmap-spec.md
@@ -17,7 +17,7 @@ One invariant governs every item: core grading stays local and deterministic and
 model, and the harness never picks a model for the user. Anything that needs a model lives
 behind an opt-in command or the external `--judge-cmd`. Two abstractions absorb most of the
 work, so the spec returns to them often: the assertion result shape in `assertion_result`
-(`skill_benchmark.py:11139`) and the fan-out in `prepared_task_rows` (`:1557`).
+(`skill_benchmark.py:11149`) and the fan-out in `prepared_task_rows` (`:1567`).
 
 ## Testing baseline
 
@@ -40,7 +40,7 @@ tests are where that claim is checked rather than trusted.
 
 The buckets below extend what the harness can measure. This floor decides whether the number it
 already prints can be believed. The harness reports one thing: lift, `with_skill` minus
-`without_skill` on the same case (`build_paired_summary` (`:15270`)). That number is believable only
+`without_skill` on the same case (`build_paired_summary` (`:15349`)). That number is believable only
 when three preconditions hold, each intended today, none enforced, and each restating a claim from
 `evals-are-not-tests.md`:
 
@@ -60,22 +60,22 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
   hiding the quantity the tool exists to measure.
 - **Abstractions used or changed:** none in the engine. Adds
   `tests/fixtures/detectors/<detector_id>/should-fire.*` and `should-pass.*` that exercise
-  `assertion_result` (`:11139`) directly. That function has no direct unit test today, and its
+  `assertion_result` (`:11149`) directly. That function has no direct unit test today, and its
   `contains_any`, `excludes_any`, and `not_regex` branches go unexercised even though their types
-  are declared in the assertion registries (`TEXT_ASSERTIONS:209`).
+  are declared in the assertion registries (`TEXT_ASSERTIONS:219`).
 - **Design:** one table-driven test loads every pair and asserts the detector fires on `should-fire`
   and stays silent on `should-pass`. A `should-pass` twin is mandatory: it enforces the
   false-positive bar `authoring-evals.md` already sets for skill authors ("check both presence and
   absence"). Each `should-pass` set includes a case where the baseline echoes the prompt, because a
   detector that passes on echoed prompt text is a false oracle; this ties the fixtures to leakage
-  lint (`prompt_assertion_leakage_findings` (`:785`)). Every detector bug then becomes a permanent
+  lint (`prompt_assertion_leakage_findings` (`:795`)). Every detector bug then becomes a permanent
   fixture pair, and `test_command_assertions_match_command_inputs_not_outputs` is the first.
 - **Why it is the keystone:** the fixture pair is also the registration contract. It is what lets a
   harvested or third-party detector be trusted on entry, so it gates the exapted detector library
   (TODO, end of 2026), and it raises the oracle-strength ladder (1.7) so that "strong" means
   fixture-verified, not only deterministic.
 - **Testing:** the fixtures are the test. A meta-test asserts every name in `OBJECTIVE_ASSERTIONS`
-  (`:246`) has a fixture pair, so a new detector cannot land unverified.
+  (`:256`) has a fixture pair, so a new detector cannot land unverified.
 
 ### CF.2 — One cross-runner baseline-isolation invariant
 - **Goal:** prove the baseline is skill-free by construction, so a measured lift is the skill's
@@ -101,7 +101,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 ### CF.4 — A guard that the core grade path calls no model and no network
 - **Goal:** make the governing invariant — "core grading stays local and deterministic and never
   calls a model" — executable rather than aspirational.
-- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:13826`).
+- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:13880`).
 - **Design:** patch `urllib` and `subprocess` to raise, then grade a fixture covering every
   objective family (text, process, efficiency) and assert it completes. The sanctioned exceptions —
   `script` oracles and `judge` plumbing — are excluded from this path by design and keep their own
@@ -111,7 +111,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 
 ### Boundary
 The set stops here deliberately. Report-level correctness — whether the saturation, no-lift, flaky,
-and negative-delta flags (`build_benchmark_report` (`:16689`)) are computed right — sits a layer
+and negative-delta flags (`build_benchmark_report` (`:16768`)) are computed right — sits a layer
 above the raw measurement, where the golden-report tests the buckets already plan (1.2, 2.6) cover
 it. CF.1–CF.4 are the floor underneath that work: once they pass, a printed lift carries a checked
 measurement, and every feature in the buckets builds on a number that has been verified rather than
@@ -125,9 +125,9 @@ assumed.
 - **Goal:** ship graders authors reach for often, so they stop hand-rolling rubrics.
 - **Abstractions used or changed:** `tool_call` and `structured_output` are deterministic, so
   they become new types in `TEXT_ASSERTIONS` / `PROCESS_ASSERTIONS` and gain a branch in
-  `assertion_result`. `tool_call` reuses `command_events` (`:6396`) and the `command_order`
+  `assertion_result`. `tool_call` reuses `command_events` (`:6406`) and the `command_order`
   logic; `structured_output` extends `json_field_equals` with JSON-Schema validation.
-  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:11722`) renders
+  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:11732`) renders
   and still runs through `--judge-cmd`.
 - **Design:** a preset expands to either a deterministic objective assertion or a `judge`
   assertion with a canned rubric and threshold. No new execution path.
@@ -146,7 +146,7 @@ assumed.
 ### 1.3 Judge config slot and the "judge is not the model under test" guard
 - **Goal:** make an existing convention enforceable.
 - **Abstractions used or changed:** read an optional `judge` block in the manifest; add a check
-  in `audit_manifest_report` (`:19512`) comparing the declared judge model against `jetty.model`
+  in `audit_manifest_report` (`:19591`) comparing the declared judge model against `jetty.model`
   or the run metadata `model`.
 - **Design:** warn by default, error under `--strict-judge`.
 - **Testing:** unit tests for matching and differing model ids.
@@ -163,7 +163,7 @@ assumed.
 - **Status:** `docs/authoring-evals.md` shipped, alongside `architecture.md` and
   `abstractions.md`.
 - **Follow-on:** surface the guide's rules where they are checkable. Extend the messaging in
-  `prompt_assertion_leakage_findings` (`:785`) and `fixture_recommendations` (`:19205`) to point
+  `prompt_assertion_leakage_findings` (`:795`) and `fixture_recommendations` (`:19284`) to point
   at the relevant section.
 - **Testing:** assert the new hint strings appear for crafted manifests.
 
@@ -172,8 +172,8 @@ assumed.
   In `adewale/pythonbyexample` and `adewale/xampler` an example *is* an eval case: an input, an
   expected output, and a check that the output still matches. The harness has no equivalent of
   "this output equals this reference."
-- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:209`), implemented in
-  `assertion_result` (`:11139`). It reads `output.md` (or a named artifact), applies an optional
+- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:219`), implemented in
+  `assertion_result` (`:11149`). It reads `output.md` (or a named artifact), applies an optional
   normalization (trim, collapse whitespace, or a named normalizer), and compares to a reference
   file under the manifest dir. Evidence is a unified diff on mismatch.
 - **Design:** normalization is the whole game, so it is explicit and per-assertion, never
@@ -188,9 +188,9 @@ assumed.
   not name it.
 - **Abstractions used or changed:** an optional `oracle` tier on an assertion
   (`strong` / `demo` / `live`), defaulting by type (deterministic text/process are `strong`,
-  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:16689`)
+  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:16768`)
   reports, per case, the share of its pass rate carried by `strong` oracles;
-  `audit_manifest_report` (`:19512`) warns when a case passes only on weak ones. This extends
+  `audit_manifest_report` (`:19591`) warns when a case passes only on weak ones. This extends
   leakage lint (`:164`) from prompts to oracles.
 - **Strongest tier — the rendered-artifact oracle:** the top of the ladder is an oracle that
   builds or renders the artifact and inspects the result, not the source text.
@@ -205,8 +205,8 @@ assumed.
   splits "good poster" into seven `script` oracles, but each is forced all-or-nothing by the
   exit-code-only contract: a poster with six of seven drama carriers fails `drama_oracle` exactly
   like one with zero. That is the binary-saturation problem inside a single oracle.
-- **Abstractions used or changed:** extend `run_script_assertion` (`:11007`) and
-  `assertion_result` (`:11139`) to optionally parse a score from the oracle's stdout — a JSON line
+- **Abstractions used or changed:** extend `run_script_assertion` (`:11017`) and
+  `assertion_result` (`:11149`) to optionally parse a score from the oracle's stdout — a JSON line
   such as `{"score": 6, "max_score": 7}` (normalized to 0-1) — beside the existing
   `pass_exit_code`. The parsed score flows into the `score`/`severity` channel from 2.2, so a
   script oracle becomes a graded dimension while staying fully deterministic and model-free.
@@ -223,9 +223,9 @@ assumed.
   past it — either way, question it. This is the inverse of the saturation flag: saturation marks
   a case as too easy *now*; staleness marks a case that has never discriminated *over time*.
 - **Abstractions used or changed:** reads the cross-run history from 2.6. A `prune` report (or a
-  flag in `build_benchmark_report` (`:16689`)) marks a case a removal candidate when, across the
+  flag in `build_benchmark_report` (`:16768`)) marks a case a removal candidate when, across the
   last N runs, it never failed and never showed lift (`with_skill` == `without_skill` every time).
-  `audit_manifest_report` (`:19512`) lists the candidates; removal stays a human decision.
+  `audit_manifest_report` (`:19591`) lists the candidates; removal stays a human decision.
 - **Design:** the harness suggests, never deletes. A case may be kept deliberately as a
   regression guard even when stale; the report says so rather than acting.
 - **Depends on:** 2.6 (needs run history to judge "never failed over time").
@@ -239,12 +239,12 @@ assumed.
 ### 2.1 Multi-model fan-out (priority)
 - **Goal:** run the same cases across several models and compare lift per model. No surveyed
   framework does this; vitest-evals, eve, and viteval all push it onto the test runner.
-- **Abstractions used or changed:** `prepared_task_rows` (`:1557`) gains a `model` dimension
+- **Abstractions used or changed:** `prepared_task_rows` (`:1567`) gains a `model` dimension
   beside `variant` and `run_number`. Each row carries its target `model`, and `run_dir` gains a
   model segment (`<case>/<model>/<variant>/run-<n>`), kept backward-compatible when one model
   runs. Runners pass the row `model` through; per-run `model` already lands in `metadata.json`,
-  so grading needs no change. `build_benchmark_report` (`:16689`) groups `by_variant` within
-  `by_model`, and `build_paired_summary` (`:15270`) computes lift per (case, model).
+  so grading needs no change. `build_benchmark_report` (`:16768`) groups `by_variant` within
+  `by_model`, and `build_paired_summary` (`:15349`) computes lift per (case, model).
 - **Design:** model is a third axis, not a new variant. Variants stay orthogonal, giving a
   model-by-variant grid. CLI: `--models a,b,c` on `prepare`.
 - **Testing:** a fan-out test asserting row count equals cases × variants × runs × models with
@@ -261,7 +261,7 @@ assumed.
   no-regression floor. This spec ports those shapes into the harness rather than inventing new
   ones.
 - **Abstractions used or changed:**
-  - `assertion_result` (`:11139`) gains an optional `score` (0-1 or a normalized 1-5) and
+  - `assertion_result` (`:11149`) gains an optional `score` (0-1 or a normalized 1-5) and
     `severity` (`critical` / `gate` / `soft`), read from `critical`/`gate`/`soft`/`atLeast` on the
     assertion.
   - **`critical` (absorbing-barrier) tier — valley-dodging.** From the Jetty "valley-dodging"
@@ -276,13 +276,13 @@ assumed.
   - **Anchored `graded_dimensions`** as a `judge` assertion shape:
     `{name, scale: "1-5", rubric: "5 = …observable…; 1 = …observable…"}`. Anchors name what each
     score level looks like, so a judge scores against criteria, not a vibe. `judge_prompt`
-    (`:11722`) renders the dimensions; the result carries per-dimension scores in `evidence`.
+    (`:11732`) renders the dimensions; the result carries per-dimension scores in `evidence`.
   - **`dynamic_rubric`** as a second `judge` shape: `{instruction, minimum_criteria}`. The judge
     drafts 3-5 case-specific criteria before grading and must meet at least `minimum_criteria`.
-  - `grade_case_variant` (`:13826`) splits totals into critical, gated, and soft. A `critical`
+  - `grade_case_variant` (`:13880`) splits totals into critical, gated, and soft. A `critical`
     failure vetoes the case; a `gate` failure lowers the pass rate; a `soft` failure lowers
     neither and fills a `scored` bucket. A `--strict` flag promotes soft to gate.
-  - **Statistical lift** in `build_paired_summary` (`:15270`): alongside the raw delta, compute a
+  - **Statistical lift** in `build_paired_summary` (`:15349`): alongside the raw delta, compute a
     significance test over the per-case graded scores (paired bootstrap or sign-flip
     permutation, mirroring `score_delta.py`), so lift is tested, not eyeballed.
   - **Reference-anchor floor:** an optional `reference_score` / `reference_graded_score` on a
@@ -315,7 +315,7 @@ assumed.
 - **Goal:** deterministic re-runs that pay nothing for external dependencies, by recording tool
   inputs and outputs.
 - **Abstractions used or changed:** this lives in the runner, not core grading. Recording sits
-  beside `write_trace_artifacts` (`:8269`): a `tool-replay.json` keyed per tool, with
+  beside `write_trace_artifacts` (`:8279`): a `tool-replay.json` keyed per tool, with
   `sanitize` and `version`. Modes (`auto`, `record`, `off`, `strict`) come from an environment
   variable that `run_codex` and the Pi and subagent runners read.
 - **Design:** orthogonal to the disk re-grade the harness already does. Replay makes the agent
@@ -326,8 +326,8 @@ assumed.
 
 ### 2.4 OpenTelemetry GenAI normalization target
 - **Goal:** make the trace adapter boundary a standard rather than a bespoke schema.
-- **Abstractions used or changed:** `normalize_trace_record` (`:7326`) and
-  `normalize_trace_records` (`:7985`) keep their inputs but emit OTel GenAI semantic-key
+- **Abstractions used or changed:** `normalize_trace_record` (`:7336`) and
+  `normalize_trace_records` (`:7995`) keep their inputs but emit OTel GenAI semantic-key
   attributes; the `events.json` schema version bumps. Process and efficiency assertions read the
   new keys with backward-compatible fallbacks.
 - **Design:** additive schema. An old `events.json` still grades.
@@ -337,7 +337,7 @@ assumed.
 ### 2.5 Dataset abstraction
 - **Goal:** fan one case template over many rows instead of hand-authoring each case.
 - **Abstractions used or changed:** a new optional manifest construct (`datasets`, plus a case
-  `template` referencing a dataset id). `iter_cases` (`:592`) materializes template by row into
+  `template` referencing a dataset id). `iter_cases` (`:602`) materializes template by row into
   concrete cases before fan-out; `validate_manifest` validates rows and runs leakage lint per
   materialized case.
 - **Design:** materialization happens early, so prepare, grade, and report stay unchanged.
@@ -351,7 +351,7 @@ assumed.
 - **Goal:** watch lift, saturation, and token drift over time.
 - **Abstractions used or changed:** a consumer of `build_benchmark_report`. Add an append-only
   history store and a `trend` subcommand that diffs successive `benchmark.json` files, reusing
-  the `compare_results` (`:17871`) logic.
+  the `compare_results` (`:17950`) logic.
 - **Severity-weighted ranking (from the macro-evals notebook):** when surfacing recurring
   failures across runs, rank them by `prevalence × severity`, not raw count, so a rare but severe
   failure outranks a common trivial one. This is the floor-raising principle made quantitative;
@@ -377,8 +377,8 @@ assumed.
   it dispatches a subagent with a rubric whose "criteria [are] deliberately absent from
   generation rules."
 - **Abstractions used or changed:** mostly a discipline made first-class, not new machinery.
-  `prepared_task_rows` (`:1557`) already omits `review_rubric` from generation payloads unless
-  `--include-answer-key`; extend `validate_manifest` (`:1160`) to require that a `holdout`/
+  `prepared_task_rows` (`:1567`) already omits `review_rubric` from generation payloads unless
+  `--include-answer-key`; extend `validate_manifest` (`:1170`) to require that a `holdout`/
   `holdback` case's rubric stays out of the skill and public eval text, and pair it with the
   subagent judge from 2.7 and the graded scoring from 2.2. Track which rubrics were held out so
   the report can separate held-out scores from tune-visible ones.
@@ -390,7 +390,7 @@ assumed.
 ### 2.8 Interactive served report and richer artifacts
 - **Goal:** capture feedback in the browser and render image, PDF, and xlsx artifacts, beyond the
   static `render_viewer`.
-- **Abstractions used or changed:** extend `render_viewer` (`:18668`) with a `serve` mode and
+- **Abstractions used or changed:** extend `render_viewer` (`:18747`) with a `serve` mode and
   artifact encoders. Anthropic's `eval-viewer/generate_review.py` is the blueprint, including
   `feedback.json` persistence and a `--previous-workspace` diff.
 - **Testing:** unit-test the artifact embedding and categorization and the feedback round trip;
@@ -422,7 +422,7 @@ assumed.
 - **Goal:** evaluate conversational skills across a send/respond sequence.
 - **Abstractions changed (core contract):** a case gains an optional `turns` list. The
   run-output contract grows from one `output.md` to a turn-indexed transcript, so
-  `read_output_base` (`:6243`) and `discover_run_bases` learn the turn layout; runners drive the
+  `read_output_base` (`:6253`) and `discover_run_bases` learn the turn layout; runners drive the
   sequence; `grade_case_variant` grades per turn and aggregates.
 - **Design:** single-shot stays the default, so existing manifests are untouched.
 - **Testing:** a fixture multi-turn run asserting per-turn grading and aggregate, plus a
@@ -435,7 +435,7 @@ assumed.
   the model axis, plus a viewer panel.
 - **Slice-lift concentration (from the macro-evals notebook):** compute, per slice, where lift (or
   a failure) concentrates — `slice share ÷ overall share`, the macro-eval `lift` metric one level
-  up from per-case lift. `build_slice_summary` (`:15441`) already groups by domain/difficulty/
+  up from per-case lift. `build_slice_summary` (`:15520`) already groups by domain/difficulty/
   trigger/goal, so this is a ratio over groups it already forms, not new plumbing.
 - **Testing:** a report test over a two-model by two-variant fixture grid, plus a concentration
   test asserting a failure confined to one slice scores a high ratio there.
@@ -548,7 +548,7 @@ and upgrading to the new features should be something an agent can drive.
 
 ### Abstractions used or changed
 
-- `version` on the manifest (`validate_manifest:1160`) becomes meaningful: `validate` accepts both
+- `version` on the manifest (`validate_manifest:1170`) becomes meaningful: `validate` accepts both
   1 and 2, and warns (not errors) on a `version: 1` manifest once 2.2 has landed, pointing at
   `migrate`.
 - No grading abstraction changes for migration itself; it is a source-rewrite plus a guide.

--- a/docs/skill-ablation-spec.md
+++ b/docs/skill-ablation-spec.md
@@ -363,7 +363,7 @@ Opt in with `"invalid_skill": true` on the ablation: the run is tagged
 
 ## Validation additions
 
-`validate_manifest` (`skill_benchmark.py:1160`), per ablation:
+`validate_manifest` (`skill_benchmark.py:1170`), per ablation:
 
 - `id` unique and slug-formatted; keep `removed_component`.
 - If a removal is declared: exactly one of `mechanism`+`target` or `components`;

--- a/grading_contracts.py
+++ b/grading_contracts.py
@@ -1,0 +1,375 @@
+"""Closed grading observations and immutable qualitative judge tasks."""
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Literal, TypeAlias
+
+from json_contracts import freeze_json_mapping, thaw_json_value, validate_json_text
+from manifest_contracts import CaseId, ExecutionVariant, ModelId, RunNumber
+
+
+class Severity(str, Enum):
+    SOFT = "soft"
+    GATE = "gate"
+    CRITICAL = "critical"
+
+
+class OracleTier(str, Enum):
+    DEMO = "demo"
+    LIVE = "live"
+    STRONG = "strong"
+
+
+class AssertionState(str, Enum):
+    SATISFIED = "satisfied"
+    FAILED = "failed"
+    UNAVAILABLE = "unavailable"
+    SKIPPED = "skipped"
+
+
+@dataclass(frozen=True)
+class _AssertionObservation:
+    name: str
+    assertion_type: str
+    evidence: str
+    score: float | None
+    severity: Severity
+    oracle: OracleTier
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("assertion name", self.name),
+            ("assertion type", self.assertion_type),
+            ("assertion evidence", self.evidence),
+        ):
+            if not isinstance(value, str):
+                raise TypeError(f"{label} must be text")
+            if label != "assertion evidence" and not value.strip():
+                raise ValueError(f"{label} must be non-empty")
+            validate_json_text(value, label)
+        try:
+            object.__setattr__(self, "severity", Severity(self.severity))
+            object.__setattr__(self, "oracle", OracleTier(self.oracle))
+        except ValueError as exc:
+            raise ValueError("assertion severity or oracle tier is unsupported") from exc
+        if self.score is not None:
+            if (
+                isinstance(self.score, bool)
+                or not isinstance(self.score, (int, float))
+                or not math.isfinite(float(self.score))
+            ):
+                raise ValueError("assertion score must be a finite number or None")
+            object.__setattr__(self, "score", float(self.score))
+        if not isinstance(self.extra, Mapping):
+            raise TypeError("assertion extra fields must be a mapping")
+        object.__setattr__(self, "extra", freeze_json_mapping(
+            self.extra, "assertion extra fields"))
+
+    def _row(self) -> dict[str, Any]:
+        return {
+            **thaw_json_value(self.extra, "assertion extra fields"),
+            "name": self.name,
+            "type": self.assertion_type,
+            "evidence": self.evidence,
+            "score": self.score,
+            "severity": self.severity.value,
+            "oracle": self.oracle.value,
+        }
+
+
+@dataclass(frozen=True)
+class SatisfiedAssertion(_AssertionObservation):
+    state: Literal[AssertionState.SATISFIED] = field(
+        default=AssertionState.SATISFIED, init=False)
+
+    def to_row(self) -> dict[str, Any]:
+        return {**self._row(), "passed": True, "availability": "complete"}
+
+
+@dataclass(frozen=True)
+class FailedAssertion(_AssertionObservation):
+    state: Literal[AssertionState.FAILED] = field(
+        default=AssertionState.FAILED, init=False)
+
+    def to_row(self) -> dict[str, Any]:
+        return {**self._row(), "passed": False, "availability": "complete"}
+
+
+@dataclass(frozen=True)
+class UnavailableAssertion(_AssertionObservation):
+    observed_passed: bool | None = None
+    state: Literal[AssertionState.UNAVAILABLE] = field(
+        default=AssertionState.UNAVAILABLE, init=False)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.observed_passed is not None and not isinstance(self.observed_passed, bool):
+            raise TypeError("unavailable assertion observed_passed must be boolean or None")
+
+    def to_row(self) -> dict[str, Any]:
+        return {
+            **self._row(),
+            "passed": self.observed_passed,
+            "availability": "partial",
+        }
+
+
+@dataclass(frozen=True)
+class SkippedAssertion(_AssertionObservation):
+    skip_reason: str = "skipped"
+    observed_passed: bool | None = None
+    availability: Literal["complete", "partial"] = "complete"
+    state: Literal[AssertionState.SKIPPED] = field(
+        default=AssertionState.SKIPPED, init=False)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if not isinstance(self.skip_reason, str) or not self.skip_reason.strip():
+            raise ValueError("skipped assertion requires a non-empty reason")
+        validate_json_text(self.skip_reason, "skipped assertion reason")
+        if self.observed_passed is not None and not isinstance(self.observed_passed, bool):
+            raise TypeError("skipped assertion observed_passed must be boolean or None")
+        if self.availability not in {"complete", "partial"}:
+            raise ValueError("skipped assertion availability is unsupported")
+
+    def to_row(self) -> dict[str, Any]:
+        return {
+            **self._row(),
+            "passed": self.observed_passed,
+            "availability": self.availability,
+            "skipped": True,
+            "skip_reason": self.skip_reason,
+        }
+
+
+AssertionObservation: TypeAlias = (
+    SatisfiedAssertion | FailedAssertion | UnavailableAssertion | SkippedAssertion
+)
+
+
+_ASSERTION_FIELDS = frozenset({
+    "name", "type", "passed", "availability", "evidence", "score",
+    "severity", "oracle", "skipped", "skip_reason",
+})
+
+
+def assertion_observation_from_row(raw: Mapping[str, Any]) -> AssertionObservation:
+    """Re-establish one mutually exclusive grading state from a result row."""
+    if not isinstance(raw, Mapping):
+        raise TypeError("assertion result must be a mapping")
+    name = raw.get("name")
+    assertion_type = raw.get("type")
+    evidence = raw.get("evidence", "")
+    score = raw.get("score")
+    severity = raw.get("severity", Severity.GATE.value)
+    oracle = raw.get("oracle", OracleTier.STRONG.value)
+    passed = raw.get("passed")
+    availability = raw.get("availability", "complete")
+    skipped = raw.get("skipped", False)
+    if not isinstance(name, str) or not isinstance(assertion_type, str):
+        raise TypeError("assertion result name and type must be strings")
+    if not isinstance(evidence, str):
+        raise TypeError("assertion result evidence must be text")
+    if not isinstance(skipped, bool):
+        raise TypeError("assertion skipped must be boolean")
+    if passed is not None and not isinstance(passed, bool):
+        raise TypeError("assertion passed must be boolean or None")
+    if availability not in {"complete", "partial"}:
+        raise ValueError("assertion availability must be complete or partial")
+    common = {
+        "name": name,
+        "assertion_type": assertion_type,
+        "evidence": evidence,
+        "score": score,
+        "severity": severity,
+        "oracle": oracle,
+        "extra": {key: value for key, value in raw.items() if key not in _ASSERTION_FIELDS},
+    }
+    if skipped:
+        return SkippedAssertion(
+            **common,
+            skip_reason=raw.get("skip_reason", "skipped"),
+            observed_passed=passed,
+            availability=availability,
+        )
+    if availability == "partial" or passed is None:
+        return UnavailableAssertion(**common, observed_passed=passed)
+    if passed:
+        return SatisfiedAssertion(**common)
+    return FailedAssertion(**common)
+
+
+class JudgeTaskId(str):
+    def __new__(cls, value: str) -> JudgeTaskId:
+        if not isinstance(value, str):
+            raise TypeError("judge task id must be a string")
+        if not value.strip():
+            raise ValueError("judge task id must be non-empty")
+        validate_json_text(value, "judge task id")
+        return str.__new__(cls, value)
+
+
+_SHA256_RE = re.compile(r"(?:sha256:)?[0-9a-f]{64}")
+
+
+def _sha256(value: Any, label: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None:
+        raise ValueError(
+            f"{label} must be a lowercase SHA-256 digest with an optional sha256: prefix")
+    return value
+
+
+def _text_list(value: Any, label: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{label} must be a list of strings")
+    for item in value:
+        validate_json_text(item, label)
+    return tuple(value)
+
+
+_JUDGE_TASK_FIELDS = frozenset({
+    "judge_task_id", "case_id", "model", "variant", "run_number",
+    "assertion", "output_path", "run_base", "prompt", "prompt_ref",
+    "expected_behavior", "review_rubric", "conversation",
+    "trajectory_steps_sha256", "judge_input_sha256",
+})
+
+
+@dataclass(frozen=True)
+class JudgeTask:
+    judge_task_id: JudgeTaskId
+    case_id: CaseId
+    variant: ExecutionVariant
+    run_number: RunNumber
+    assertion: Mapping[str, Any]
+    output_path: Path
+    run_base: Path
+    prompt: str
+    expected_behavior: tuple[str, ...]
+    review_rubric: tuple[str, ...]
+    judge_input_sha256: str
+    model: ModelId | None = None
+    prompt_ref: str | None = None
+    conversation: tuple[Mapping[str, Any], ...] = ()
+    trajectory_steps_sha256: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "judge_task_id", JudgeTaskId(self.judge_task_id))
+        object.__setattr__(self, "case_id", CaseId(self.case_id))
+        object.__setattr__(self, "variant", ExecutionVariant(self.variant))
+        object.__setattr__(self, "run_number", RunNumber(self.run_number))
+        if self.model is not None:
+            object.__setattr__(self, "model", ModelId(self.model))
+        if not isinstance(self.assertion, Mapping):
+            raise TypeError("judge task assertion must be a mapping")
+        object.__setattr__(self, "assertion", freeze_json_mapping(
+            self.assertion, "judge task assertion"))
+        if not isinstance(self.output_path, Path) or not isinstance(self.run_base, Path):
+            raise TypeError("judge task paths must be pathlib Paths")
+        if not isinstance(self.prompt, str):
+            raise TypeError("judge task prompt must be text")
+        validate_json_text(self.prompt, "judge task prompt")
+        if self.prompt_ref is not None:
+            if not isinstance(self.prompt_ref, str):
+                raise TypeError("judge task prompt_ref must be text or None")
+            validate_json_text(self.prompt_ref, "judge task prompt_ref")
+        for label, values in (
+            ("expected_behavior", self.expected_behavior),
+            ("review_rubric", self.review_rubric),
+        ):
+            if not isinstance(values, tuple) or not all(isinstance(item, str) for item in values):
+                raise TypeError(f"judge task {label} must be a tuple of strings")
+            for item in values:
+                validate_json_text(item, f"judge task {label}")
+        if not isinstance(self.conversation, tuple) or not all(
+            isinstance(item, Mapping) for item in self.conversation
+        ):
+            raise TypeError("judge task conversation must be a tuple of mappings")
+        object.__setattr__(self, "conversation", tuple(
+            freeze_json_mapping(item, f"judge task conversation[{index}]")
+            for index, item in enumerate(self.conversation)))
+        object.__setattr__(self, "judge_input_sha256", _sha256(
+            self.judge_input_sha256, "judge_input_sha256"))
+        object.__setattr__(self, "trajectory_steps_sha256", _sha256(
+            self.trajectory_steps_sha256,
+            "trajectory_steps_sha256",
+            optional=True,
+        ))
+
+    @classmethod
+    def from_row(cls, raw: Mapping[str, Any]) -> JudgeTask:
+        if not isinstance(raw, Mapping):
+            raise TypeError("judge task must be a mapping")
+        unknown = sorted(set(raw) - _JUDGE_TASK_FIELDS)
+        if unknown:
+            raise ValueError(
+                f"judge task contains unknown field(s): {', '.join(unknown)}")
+        assertion = raw.get("assertion")
+        if not isinstance(assertion, Mapping):
+            raise TypeError("judge task assertion must be a mapping")
+        conversation = raw.get("conversation", [])
+        if not isinstance(conversation, list):
+            raise TypeError("judge task conversation must be a list")
+        judge_task_id = raw.get("judge_task_id")
+        output_path = raw.get("output_path")
+        run_base = raw.get("run_base")
+        prompt = raw.get("prompt")
+        judge_input_sha256 = raw.get("judge_input_sha256")
+        if not all(isinstance(value, str) for value in (
+            judge_task_id, output_path, run_base, prompt, judge_input_sha256,
+        )):
+            raise TypeError("judge task id, paths, prompt, and input digest must be strings")
+        assert isinstance(judge_task_id, str)
+        assert isinstance(output_path, str)
+        assert isinstance(run_base, str)
+        assert isinstance(prompt, str)
+        assert isinstance(judge_input_sha256, str)
+        return cls(
+            judge_task_id=JudgeTaskId(judge_task_id),
+            case_id=CaseId.parse(raw.get("case_id")),
+            variant=ExecutionVariant.parse(raw.get("variant")),
+            run_number=RunNumber.parse(raw.get("run_number")),
+            model=(ModelId.parse(raw.get("model")) if raw.get("model") is not None else None),
+            assertion=assertion,
+            output_path=Path(output_path),
+            run_base=Path(run_base),
+            prompt=prompt,
+            prompt_ref=raw.get("prompt_ref"),
+            expected_behavior=_text_list(raw.get("expected_behavior", []), "expected_behavior"),
+            review_rubric=_text_list(raw.get("review_rubric", []), "review_rubric"),
+            conversation=tuple(conversation),
+            trajectory_steps_sha256=raw.get("trajectory_steps_sha256"),
+            judge_input_sha256=judge_input_sha256,
+        )
+
+    def to_row(self) -> dict[str, Any]:
+        return {
+            "judge_task_id": str(self.judge_task_id),
+            "case_id": str(self.case_id),
+            **({"model": str(self.model)} if self.model is not None else {}),
+            "variant": str(self.variant),
+            "run_number": int(self.run_number),
+            "assertion": thaw_json_value(self.assertion, "judge task assertion"),
+            "output_path": str(self.output_path),
+            "run_base": str(self.run_base),
+            "prompt": self.prompt,
+            "prompt_ref": self.prompt_ref,
+            "expected_behavior": list(self.expected_behavior),
+            "review_rubric": list(self.review_rubric),
+            **({"conversation": [
+                thaw_json_value(item, f"judge task conversation[{index}]")
+                for index, item in enumerate(self.conversation)
+            ]}
+               if self.conversation else {}),
+            **({"trajectory_steps_sha256": self.trajectory_steps_sha256}
+               if self.trajectory_steps_sha256 is not None else {}),
+            "judge_input_sha256": self.judge_input_sha256,
+        }

--- a/invocation_contracts.py
+++ b/invocation_contracts.py
@@ -28,6 +28,61 @@ class InvocationState(str, Enum):
     HARNESS_FAILED = "harness_failed"
 
 
+def validate_invocation_lifecycle(
+    state: InvocationState,
+    returncode: int | None,
+    provider_error: str | None = None,
+    *,
+    allow_harness_failure: bool = False,
+    allow_nonzero_completion: bool = False,
+) -> None:
+    """Validate the shared process/provider lifecycle discriminant.
+
+    A provider failure is an exit-zero response/protocol failure.  A nonzero
+    exit remains a process failure even when provider diagnostics explain it.
+    """
+    if not isinstance(state, InvocationState):
+        raise TypeError("invocation state must be InvocationState")
+    if returncode is not None and type(returncode) is not int:
+        raise TypeError("invocation returncode must be an integer or None")
+    if provider_error is not None and (
+        not isinstance(provider_error, str) or not provider_error.strip()
+    ):
+        raise ValueError("provider_error must be a non-empty string")
+
+    if state is InvocationState.COMPLETE:
+        if returncode != 0 and not (
+            allow_nonzero_completion
+            and returncode is not None
+            and returncode != 0
+        ):
+            raise ValueError("complete invocation requires returncode 0")
+        if provider_error is not None:
+            raise ValueError("complete invocation cannot carry a provider error")
+    elif state is InvocationState.TIMED_OUT:
+        if returncode != 124:
+            raise ValueError("timed-out invocation requires returncode 124")
+        if provider_error is not None:
+            raise ValueError("timed-out invocation cannot carry a provider error")
+    elif state is InvocationState.SPAWN_FAILED:
+        if returncode != 127:
+            raise ValueError("spawn-failed invocation requires returncode 127")
+        if provider_error is not None:
+            raise ValueError("spawn-failed invocation cannot carry a provider error")
+    elif state is InvocationState.PROCESS_FAILED:
+        if returncode in {None, 0}:
+            raise ValueError("process-failed invocation requires nonzero returncode")
+    elif state is InvocationState.PROVIDER_FAILED:
+        if returncode != 0 or provider_error is None:
+            raise ValueError(
+                "provider-failed invocation requires returncode 0 and provider_error")
+    elif state is InvocationState.HARNESS_FAILED:
+        if not allow_harness_failure or returncode is not None:
+            raise ValueError("process invocation cannot represent harness failure")
+        if provider_error is not None:
+            raise ValueError("harness failure cannot carry a provider error")
+
+
 class TimeoutSeconds(int):
     """A positive provider invocation timeout."""
 
@@ -184,20 +239,18 @@ class InvocationResult:
             raise TypeError("invocation UTF-8 validity fields must be boolean")
         if not isinstance(self.timed_out, bool):
             raise TypeError("invocation timed_out must be boolean")
-        expected = {
-            InvocationState.COMPLETE: (0, False),
-            InvocationState.TIMED_OUT: (124, True),
-            InvocationState.SPAWN_FAILED: (127, False),
-        }
-        if self.invocation_state in expected:
-            code, timed_out = expected[self.invocation_state]
-            if self.returncode != code or self.timed_out is not timed_out:
-                raise ValueError("invocation state contradicts returncode/timed_out")
-        elif self.invocation_state is InvocationState.PROCESS_FAILED:
-            if self.returncode == 0 or self.timed_out:
-                raise ValueError("process failure requires nonzero exit without timeout")
-        else:
+        if self.invocation_state not in {
+            InvocationState.COMPLETE,
+            InvocationState.TIMED_OUT,
+            InvocationState.SPAWN_FAILED,
+            InvocationState.PROCESS_FAILED,
+        }:
             raise ValueError("InvocationResult requires a process-boundary state")
+        validate_invocation_lifecycle(self.invocation_state, self.returncode)
+        if self.timed_out is not (
+            self.invocation_state is InvocationState.TIMED_OUT
+        ):
+            raise ValueError("invocation state contradicts timed_out")
         if self.adapter_metadata is not None:
             frozen_metadata = freeze_json_mapping(
                 self.adapter_metadata, "invocation adapter metadata")

--- a/judge_contracts.py
+++ b/judge_contracts.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 import telemetry
+from invocation_contracts import InvocationState, validate_invocation_lifecycle
 from json_contracts import freeze_json_mapping, validate_json_text
 
 JudgeUsageSource = Literal["provider_reported", "trace_normalized"]
@@ -50,6 +51,8 @@ class JudgeInvocation:
     stdout: str
     stderr: str
     returncode: int
+    invocation_state: InvocationState
+    provider_error: str | None = None
     usage: Mapping[str, Any] | None = None
     cost_usd: float | None = None
     usage_source: JudgeUsageSource = "provider_reported"
@@ -64,6 +67,10 @@ class JudgeInvocation:
         validate_json_text(self.stderr, "judge stderr")
         if type(self.returncode) is not int:
             raise TypeError("judge returncode must be an integer")
+        validate_invocation_lifecycle(
+            self.invocation_state, self.returncode, self.provider_error)
+        if self.provider_error is not None:
+            validate_json_text(self.provider_error, "judge provider_error")
         if self.usage_source not in JUDGE_USAGE_SOURCES:
             raise ValueError(
                 f"unknown judge usage source {self.usage_source!r}")
@@ -97,4 +104,4 @@ class JudgeInvocation:
 
     @property
     def succeeded(self) -> bool:
-        return self.returncode == 0
+        return self.invocation_state is InvocationState.COMPLETE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ skill-pi-trigger-eval = "run_pi_trigger_eval:main"
 skill-trigger-matrix = "run_trigger_matrix:main"
 
 [tool.setuptools]
-py-modules = ["skill_benchmark", "run_pi_trigger_eval", "run_trigger_matrix", "ablation_model", "agent_capabilities", "artifact_contracts", "telemetry", "trigger_contracts", "trigger_reporting", "trace_contracts", "runner_contracts", "judge_contracts", "judge_verdict", "experimental_pairs", "jetty_contracts", "gemini_contracts", "invocation_contracts", "json_contracts", "manifest_contracts", "text_contracts"]
+py-modules = ["skill_benchmark", "run_pi_trigger_eval", "run_trigger_matrix", "ablation_model", "agent_capabilities", "artifact_contracts", "telemetry", "trigger_contracts", "trigger_reporting", "trace_contracts", "runner_contracts", "judge_contracts", "judge_verdict", "experimental_pairs", "jetty_contracts", "gemini_contracts", "grading_contracts", "invocation_contracts", "json_contracts", "manifest_contracts", "text_contracts"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
@@ -58,6 +58,7 @@ required-version = "==0.16.0"
 "ablation_model.py" = ["F401", "TRY004"]
 "experimental_pairs.py" = ["PYI034", "TRY004"]
 "gemini_contracts.py" = ["TRY004"]
+"grading_contracts.py" = ["PYI034", "TRY004"]
 "judge_verdict.py" = ["TRY004"]
 "invocation_contracts.py" = ["PYI034", "TRY004"]
 "manifest_contracts.py" = ["PYI034", "TRY004"]

--- a/skill_benchmark.py
+++ b/skill_benchmark.py
@@ -127,6 +127,16 @@ from artifact_contracts import (
     observe_artifact_set,
 )
 from gemini_contracts import GeminiJsonResponse, GeminiStream
+from grading_contracts import (
+    FailedAssertion,
+    JudgeTask,
+    OracleTier,
+    SatisfiedAssertion,
+    Severity,
+    SkippedAssertion,
+    UnavailableAssertion,
+    assertion_observation_from_row,
+)
 from invocation_contracts import (
     InvocationRequest,
     InvocationResult,
@@ -197,7 +207,7 @@ from trigger_reporting import CompleteTriggerCohort, summarize_trigger_cohort
 VALID_SPLITS = frozenset(Split.values())
 HARNESS_SEMANTIC_MODULES = (
     "ablation_model.py", "agent_capabilities.py", "artifact_contracts.py", "experimental_pairs.py",
-    "gemini_contracts.py",
+    "gemini_contracts.py", "grading_contracts.py",
     "invocation_contracts.py", "jetty_contracts.py", "judge_contracts.py", "judge_verdict.py", "json_contracts.py", "manifest_contracts.py", "run_pi_trigger_eval.py",
     "run_trigger_matrix.py", "runner_contracts.py", "skill_benchmark.py",
     "telemetry.py", "trace_contracts.py", "trigger_contracts.py",
@@ -245,8 +255,8 @@ EFFICIENCY_ASSERTIONS = {
 }
 OBJECTIVE_ASSERTIONS = TEXT_ASSERTIONS | PROCESS_ASSERTIONS | EFFICIENCY_ASSERTIONS
 QUALITATIVE_ASSERTIONS = {"judge", "rubric", "factuality"}
-SEVERITIES = {"critical", "gate", "soft"}
-ORACLE_TIERS = {"strong", "demo", "live"}
+SEVERITIES = {item.value for item in Severity}
+ORACLE_TIERS = {item.value for item in OracleTier}
 ASSERTION_COMMON_FIELDS = {
     "type", "name", "description", "ci", "severity", "critical", "gate",
     "soft", "oracle", "variants", "only_variants", "except_variants",
@@ -11868,6 +11878,28 @@ def judge_artifact_inventory(run_base: Path) -> list[str]:
 JUDGE_EXPLORE_TOOLS = "Read,Grep,Glob,LS"
 
 
+def _judge_invocation_state(
+    raw: Mapping[str, Any], *, returncode: int,
+    provider_error: str | None = None,
+) -> InvocationState:
+    """Retain process provenance while classifying provider-response failure."""
+    if provider_error and returncode == 0:
+        return InvocationState.PROVIDER_FAILED
+    raw_state = raw.get("invocation_state")
+    if raw_state is not None:
+        try:
+            state = InvocationState(raw_state)
+        except ValueError as exc:
+            raise ValueError("judge backend returned an invalid invocation_state") from exc
+        if state is InvocationState.HARNESS_FAILED:
+            raise ValueError("judge backend harness failure cannot be a process record")
+        if state is InvocationState.PROVIDER_FAILED and returncode != 0:
+            return InvocationState.PROCESS_FAILED
+        return state
+    return (InvocationState.COMPLETE if returncode == 0
+            else InvocationState.PROCESS_FAILED)
+
+
 def sanitized_run_copy(run_base: Path, dest: Path) -> Path | None:
     """Safety-by-construction for the tool-using judge (G1 follow-on). Copies the
     run dir to `dest` with every oracle file removed — anything whose name carries a
@@ -11908,14 +11940,16 @@ def claude_judge_invoke(prompt: str, *, judge_model: str | None, claude_bin: str
                             extra_args=claude_extra_args, cwd=explore_hint)
     provider_error = res.get("provider_error")
     returncode = cast(int, res.get("returncode"))
-    if returncode == 0 and isinstance(provider_error, str):
-        returncode = 1
     return JudgeInvocation(
         stdout=res.get("answer", ""),
         stderr=(_stderr_with_warning(res.get("stderr", "") or "", provider_error)
                 if isinstance(provider_error, str)
                 else res.get("stderr", "") or ""),
         returncode=returncode,
+        invocation_state=_judge_invocation_state(
+            res, returncode=returncode,
+            provider_error=(provider_error if isinstance(provider_error, str) else None)),
+        provider_error=(provider_error if isinstance(provider_error, str) else None),
         cost_usd=res.get("cost_usd"),
         usage=res.get("usage") if isinstance(res.get("usage"), dict) else None,
         usage_source="provider_reported",
@@ -11929,10 +11963,16 @@ def codex_judge_invoke(prompt: str, *, judge_model: str | None, codex_cmd: str,
     res = codex_cli_invoke(prompt, model=judge_model, codex_cmd=codex_cmd,
                            output_schema=assertion_schema, cwd=explore_hint)
     usage = res.get("usage") if isinstance(res.get("usage"), dict) else None
+    returncode = cast(int, res.get("returncode"))
+    provider_error = res.get("provider_error")
     return JudgeInvocation(
         stdout=res.get("answer") or "",
         stderr=res.get("stderr", "") or "",
-        returncode=cast(int, res.get("returncode")),
+        returncode=returncode,
+        invocation_state=_judge_invocation_state(
+            res, returncode=returncode,
+            provider_error=(provider_error if isinstance(provider_error, str) else None)),
+        provider_error=(provider_error if isinstance(provider_error, str) else None),
         cost_usd=res.get("cost_usd"),
         usage=usage,
         usage_source="trace_normalized" if usage else "provider_reported",
@@ -11979,10 +12019,6 @@ def gemini_judge_invoke(
         if process_returncode == 0 and tool_error is not None
         else None
     )
-    effective_returncode = (
-        1 if process_returncode == 0 and isinstance(error, str) and error
-        else process_returncode
-    )
     stderr = result.get("stderr", "") or ""
     if isinstance(error, str):
         stderr = _stderr_with_warning(stderr, error)
@@ -11993,7 +12029,11 @@ def gemini_judge_invoke(
     return JudgeInvocation(
         stdout=result.get("answer") or "",
         stderr=stderr,
-        returncode=effective_returncode,
+        returncode=process_returncode,
+        invocation_state=_judge_invocation_state(
+            result, returncode=process_returncode,
+            provider_error=error),
+        provider_error=error,
         usage=(result.get("usage")
                if isinstance(result.get("usage"), Mapping) else None),
         cost_usd=None,
@@ -12015,10 +12055,16 @@ def vibe_judge_invoke(prompt: str, *, judge_model: str | None, vibe_cmd: str,
                       explore_hint: str | None, **_: Any) -> JudgeInvocation:
     res = vibe_cli_invoke(prompt, model=judge_model, vibe_cmd=vibe_cmd, output="json",
                           tools=VIBE_NO_TOOLS, cwd=explore_hint)
+    returncode = cast(int, res.get("returncode"))
+    provider_error = res.get("provider_error")
     return JudgeInvocation(
         stdout=res.get("answer", ""),
         stderr=res.get("stderr", "") or "",
-        returncode=cast(int, res.get("returncode")),
+        returncode=returncode,
+        invocation_state=_judge_invocation_state(
+            res, returncode=returncode,
+            provider_error=(provider_error if isinstance(provider_error, str) else None)),
+        provider_error=(provider_error if isinstance(provider_error, str) else None),
         cost_usd=res.get("cost_usd"),
         usage=res.get("usage") if isinstance(res.get("usage"), dict) else None,
         usage_source="provider_reported",
@@ -12034,6 +12080,8 @@ def shell_judge_invoke(prompt: str, *, judge_cmd: str,
         capture_output=True, check=False)
     return JudgeInvocation(
         stdout=proc.stdout, stderr=proc.stderr or "", returncode=proc.returncode,
+        invocation_state=(InvocationState.COMPLETE if proc.returncode == 0
+                          else InvocationState.PROCESS_FAILED),
         model_label=model_label)
 
 
@@ -12266,6 +12314,7 @@ def run_one_judge_task(task: dict[str, Any], judge_cmd: str | None = None, trans
     stdout = invocation.stdout
     stderr = invocation.stderr
     returncode = invocation.returncode
+    invocation_complete = invocation.succeeded
     cost_usd = invocation.cost_usd
     judge_usage = dict(invocation.usage) if invocation.usage is not None else None
     usage_source = invocation.usage_source
@@ -12339,7 +12388,9 @@ def run_one_judge_task(task: dict[str, Any], judge_cmd: str | None = None, trans
             plain_payload = ({**parsed, "threshold": threshold}
                              if parsed.get("score") is not None else parsed)
             passed = judge_verdict_passed(plain_payload)
-    evidence = parse_error or parsed.get("evidence") or parsed.get("rationale") or parsed.get("reasoning") or "judge command completed"
+    evidence = (invocation.provider_error or parse_error
+                or parsed.get("evidence") or parsed.get("rationale")
+                or parsed.get("reasoning") or "judge command completed")
     row = {
         **graded_payload,
         **_judge_row_identity(task, judge_model=judge_model_label,
@@ -12354,10 +12405,13 @@ def run_one_judge_task(task: dict[str, Any], judge_cmd: str | None = None, trans
         "judge_evidence_mode": evidence_mode,
         **({"judge_context_sha256": context_sha256}
            if context_sha256 is not None else {}),
-        "judge_observation_complete": returncode == 0 and parse_error is None,
-        "availability": ("complete" if returncode == 0 and parse_error is None
+        "judge_observation_complete": invocation_complete and parse_error is None,
+        "invocation_state": invocation.invocation_state.value,
+        **({"provider_error": invocation.provider_error}
+           if invocation.provider_error is not None else {}),
+        "availability": ("complete" if invocation_complete and parse_error is None
                          else "partial"),
-        "passed": passed and returncode == 0 and parse_error is None,
+        "passed": passed and invocation_complete and parse_error is None,
         **({"score": score} if score is not None else {}),
         **({"threshold": threshold} if score is not None and "criteria" not in graded_payload else {}),
         "evidence": evidence,
@@ -14002,6 +14056,7 @@ def grade_case_variant(
                 judge_task, unit_text or "", run_base=unit_base,
                 steps=current_steps)
             judge_task["judge_input_sha256"] = current_input_fingerprint
+            judge_task = JudgeTask.from_row(judge_task).to_row()
             judged = judge_results.get(jid)
             if judged:
                 evidence_mode = judged.get("judge_evidence_mode")
@@ -14096,6 +14151,10 @@ def grade_case_variant(
                 break
         for r in objective + qualitative:
             r.pop("_dep_label", None)   # transient resolver key; never serialized
+    objective_observations = [assertion_observation_from_row(row) for row in objective]
+    qualitative_observations = [assertion_observation_from_row(row) for row in qualitative]
+    objective = [observation.to_row() for observation in objective_observations]
+    qualitative = [observation.to_row() for observation in qualitative_observations]
     for summary_row in turn_summaries:
         n = summary_row["turn"]
         all_rows_for_turn = [r for r in objective + qualitative
@@ -14112,46 +14171,62 @@ def grade_case_variant(
     # the graded `scored` bucket instead. A failing critical assertion is the
     # absorbing barrier: it VETOES the run — every rate collapses to 0.0 and the
     # graded score is withheld, so no mean can average the catastrophe away.
-    blocked_rows = [r for r in objective + qualitative
-                    if not r.get("skipped")
-                    and r.get("availability", "complete") != "complete"]
-    observed_rows = [r for r in objective + qualitative
-                     if r.get("availability", "complete") == "complete"]
-    gate_objective = [r for r in objective if r in observed_rows
-                      and r.get("severity") in {"gate", "critical"} and not r.get("skipped")]
-    soft_rows = [r for r in observed_rows if r.get("severity") == "soft" and not r.get("skipped")]
+    all_observations = objective_observations + qualitative_observations
+    blocked_rows = [observation for observation in all_observations
+                    if isinstance(observation, UnavailableAssertion)]
+    observed_rows = [observation for observation in all_observations
+                     if isinstance(observation, (SatisfiedAssertion, FailedAssertion))]
+    gate_objective = [observation for observation in objective_observations
+                      if observation in observed_rows
+                      and observation.severity.value in {"gate", "critical"}]
+    soft_rows = [observation for observation in observed_rows
+                 if observation.severity.value == "soft"]
     # G2: a SKIPPED dependent is excluded here, so a never-run critical dependent
     # cannot veto — the veto stays owned by the prerequisite's own severity.
-    critical_rows = [r for r in observed_rows if r.get("severity") == "critical" and not r.get("skipped")]
-    critical_failures = [r["name"] for r in critical_rows if not r["passed"]]
+    critical_rows = [observation for observation in observed_rows
+                     if observation.severity.value == "critical"]
+    critical_failures = [observation.name for observation in critical_rows
+                         if isinstance(observation, FailedAssertion)]
     vetoed = bool(critical_failures)
-    objective_passed = sum(1 for r in gate_objective if r["passed"])
+    objective_passed = sum(
+        1 for observation in gate_objective
+        if isinstance(observation, SatisfiedAssertion))
     objective_total = len(gate_objective)
-    process_rows = [r for r in gate_objective if r.get("type") in PROCESS_ASSERTIONS]
-    efficiency_rows = [r for r in gate_objective if r.get("type") in EFFICIENCY_ASSERTIONS]
-    process_passed = sum(1 for r in process_rows if r["passed"])
-    efficiency_passed = sum(1 for r in efficiency_rows if r["passed"])
+    process_rows = [observation for observation in gate_objective
+                    if observation.assertion_type in PROCESS_ASSERTIONS]
+    efficiency_rows = [observation for observation in gate_objective
+                       if observation.assertion_type in EFFICIENCY_ASSERTIONS]
+    process_passed = sum(
+        1 for observation in process_rows
+        if isinstance(observation, SatisfiedAssertion))
+    efficiency_passed = sum(
+        1 for observation in efficiency_rows
+        if isinstance(observation, SatisfiedAssertion))
     # Soft qualitative rows (the judge/rubric default) feed ONLY the graded
     # channel; the qualitative/combined pass rates are carried by gate and
     # critical qualitative rows, mirroring the objective split above. Declare
     # severity: "gate" on a judge assertion to keep it in the pass rate.
-    gate_qualitative = [r for r in qualitative if r in observed_rows
-                        and r.get("severity") in {"gate", "critical"} and not r.get("skipped")]
-    qualitative_passed = sum(1 for r in gate_qualitative if r["passed"])
+    gate_qualitative = [observation for observation in qualitative_observations
+                        if observation in observed_rows
+                        and observation.severity.value in {"gate", "critical"}]
+    qualitative_passed = sum(
+        1 for observation in gate_qualitative
+        if isinstance(observation, SatisfiedAssertion))
     qualitative_total = len(gate_qualitative)
     combined_passed = objective_passed + qualitative_passed
     combined_total = objective_total + qualitative_total
-    soft_scores = [r["score"] for r in soft_rows if isinstance(r.get("score"), (int, float))]
+    soft_scores = [observation.score for observation in soft_rows
+                   if observation.score is not None]
     graded_score = round(statistics.mean(soft_scores), 4) if soft_scores and not vetoed else None
     floor = reference_floor(case)
     below_floor: list[str] = []
     if floor is not None:
-        for r in soft_rows:
-            if isinstance(r.get("score"), (int, float)) and r["score"] < floor:
-                below_floor.append(str(r["name"]))
-            for dim, raw in (r.get("dimension_scores") or {}).items():
+        for observation in soft_rows:
+            if observation.score is not None and observation.score < floor:
+                below_floor.append(observation.name)
+            for dim, raw in (observation.extra.get("dimension_scores") or {}).items():
                 if isinstance(raw, (int, float)) and (raw - 1.0) / 4.0 < floor:
-                    below_floor.append(f"{r['name']}:{dim}")
+                    below_floor.append(f"{observation.name}:{dim}")
     result = {
         "case_id": case["id"],
         "split": case["split"],
@@ -14190,8 +14265,12 @@ def grade_case_variant(
         "critical_failures": critical_failures,
         "vetoed": vetoed,
         "soft_total": len(soft_rows),
-        "soft_passed": sum(1 for r in soft_rows if r["passed"]),
-        "skipped_total": sum(1 for r in objective + qualitative if r.get("skipped")),
+        "soft_passed": sum(
+            1 for observation in soft_rows
+            if isinstance(observation, SatisfiedAssertion)),
+        "skipped_total": sum(
+            1 for observation in all_observations
+            if isinstance(observation, SkippedAssertion)),
         "graded_score": graded_score,
         "below_reference_floor": below_floor,
         **({"turns": turn_summaries} if turn_specs else {}),
@@ -14200,9 +14279,9 @@ def grade_case_variant(
         "deferred_judge_tasks": len(judge_tasks),
         "grading_availability": "partial" if blocked_rows or judge_tasks else "complete",
         "blocked_assertions": [
-            {"name": row.get("name"), "type": row.get("type"),
-             "evidence": row.get("evidence")}
-            for row in blocked_rows
+            {"name": observation.name, "type": observation.assertion_type,
+             "evidence": observation.evidence}
+            for observation in blocked_rows
         ],
         "metadata": metadata,
     }

--- a/tests/test_gemini_backend.py
+++ b/tests/test_gemini_backend.py
@@ -1603,7 +1603,10 @@ class GeminiJudgeBackendTests(unittest.TestCase):
                 "prompt", judge_model="gemini-judge", gemini_cmd="gemini",
                 explore_hint=None)
 
-        self.assertNotEqual(invocation.returncode, 0)
+        self.assertEqual(invocation.returncode, 0)
+        self.assertIs(
+            invocation.invocation_state, sb.InvocationState.PROVIDER_FAILED)
+        self.assertFalse(invocation.succeeded)
         self.assertIn("observed 1 tool lifecycle", invocation.stderr)
 
     def test_programmatic_judge_materializes_registry_default_command(self):

--- a/tests/test_grading_contracts.py
+++ b/tests/test_grading_contracts.py
@@ -1,0 +1,126 @@
+import math
+import unittest
+from dataclasses import replace
+
+import grading_contracts as gc
+from manifest_contracts import CaseId, ExecutionVariant, ModelId, RunNumber
+
+
+class AssertionObservationTests(unittest.TestCase):
+    def row(self, **changes):
+        return {
+            "name": "contains alpha",
+            "type": "contains",
+            "passed": True,
+            "availability": "complete",
+            "evidence": "found alpha",
+            "score": 1.0,
+            "severity": "gate",
+            "oracle": "strong",
+            **changes,
+        }
+
+    def test_pass_fail_unavailable_and_skipped_are_distinct(self):
+        self.assertIsInstance(
+            gc.assertion_observation_from_row(self.row()),
+            gc.SatisfiedAssertion,
+        )
+        self.assertIsInstance(
+            gc.assertion_observation_from_row(self.row(passed=False, score=0.0)),
+            gc.FailedAssertion,
+        )
+        self.assertIsInstance(
+            gc.assertion_observation_from_row(self.row(
+                passed=None, score=None, availability="partial")),
+            gc.UnavailableAssertion,
+        )
+        self.assertIsInstance(
+            gc.assertion_observation_from_row(self.row(
+                skipped=True, skip_reason="prerequisite failed")),
+            gc.SkippedAssertion,
+        )
+
+    def test_projection_preserves_nonsemantic_fields(self):
+        observation = gc.assertion_observation_from_row(self.row(
+            comparison="rendered-v1", turn=2))
+        self.assertEqual(observation.to_row()["comparison"], "rendered-v1")
+        self.assertEqual(observation.to_row()["turn"], 2)
+
+    def test_extra_fields_are_detached_deeply_frozen_and_thawed_on_projection(self):
+        detail = {"paths": ["a"]}
+        observation = gc.assertion_observation_from_row(self.row(detail=detail))
+        detail["paths"].append("source-mutation")
+        self.assertEqual(observation.extra["detail"]["paths"], ("a",))
+        projected = observation.to_row()
+        projected["detail"]["paths"].append("projection-mutation")
+        self.assertEqual(observation.extra["detail"]["paths"], ("a",))
+
+    def test_invalid_boolean_and_nonfinite_score_are_rejected(self):
+        with self.assertRaises(TypeError):
+            gc.assertion_observation_from_row(self.row(passed=1))
+        with self.assertRaises(ValueError):
+            gc.assertion_observation_from_row(self.row(score=math.nan))
+
+
+class JudgeTaskTests(unittest.TestCase):
+    def task_row(self):
+        return {
+            "judge_task_id": "case-1::with_skill::run-2::quality",
+            "case_id": "case-1",
+            "model": "model-a",
+            "variant": "with_skill",
+            "run_number": 2,
+            "assertion": {"name": "quality", "type": "judge"},
+            "output_path": "/runs/case-1/output.md",
+            "run_base": "/runs/case-1",
+            "prompt": "Review the answer.",
+            "prompt_ref": None,
+            "expected_behavior": ["Grounded"],
+            "review_rubric": ["Accurate"],
+            "judge_input_sha256": "a" * 64,
+        }
+
+    def test_identity_and_paths_are_typed(self):
+        task = gc.JudgeTask.from_row(self.task_row())
+        self.assertIsInstance(task.case_id, CaseId)
+        self.assertIsInstance(task.variant, ExecutionVariant)
+        self.assertIsInstance(task.run_number, RunNumber)
+        self.assertIsInstance(task.model, ModelId)
+        with self.assertRaises(TypeError):
+            task.assertion["shadow"] = True  # type: ignore[index]
+        self.assertEqual(task.to_row(), self.task_row())
+
+    def test_bad_digest_and_run_identity_fail_before_judging(self):
+        with self.assertRaises(ValueError):
+            gc.JudgeTask.from_row({**self.task_row(), "judge_input_sha256": "short"})
+        with self.assertRaises(ValueError):
+            gc.JudgeTask.from_row({**self.task_row(), "run_number": 0})
+
+    def test_nested_payloads_are_detached_frozen_and_wire_thawed(self):
+        row = self.task_row()
+        row["assertion"] = {"name": "quality", "type": "judge",
+                            "rubric": {"items": ["a"]}}
+        row["conversation"] = [{"role": "assistant", "content": ["one"]}]
+        task = gc.JudgeTask.from_row(row)
+        row["assertion"]["rubric"]["items"].append("source")
+        row["conversation"][0]["content"].append("source")
+        self.assertEqual(task.assertion["rubric"]["items"], ("a",))
+        self.assertEqual(task.conversation[0]["content"], ("one",))
+
+        projected = task.to_row()
+        projected["assertion"]["rubric"]["items"].append("projection")
+        projected["conversation"][0]["content"].append("projection")
+        self.assertEqual(task.assertion["rubric"]["items"], ("a",))
+        self.assertEqual(task.conversation[0]["content"], ("one",))
+
+    def test_task_rows_are_closed_and_direct_text_lists_are_utf8_safe(self):
+        with self.assertRaisesRegex(ValueError, "unknown field"):
+            gc.JudgeTask.from_row({**self.task_row(), "unknown_extension": True})
+
+        task = gc.JudgeTask.from_row(self.task_row())
+        with self.assertRaisesRegex(ValueError, "surrogate"):
+            replace(task, expected_behavior=("\ud800",))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_invocation_contracts.py
+++ b/tests/test_invocation_contracts.py
@@ -89,7 +89,7 @@ class InvocationPlanContractTests(unittest.TestCase):
             stderr_utf8_valid=True,
         )
         self.assertFalse(completed.timed_out)
-        with self.assertRaisesRegex(ValueError, "contradicts"):
+        with self.assertRaisesRegex(ValueError, "requires returncode"):
             InvocationResult(
                 stdout="",
                 stderr="",

--- a/tests/test_judge_contracts.py
+++ b/tests/test_judge_contracts.py
@@ -6,6 +6,7 @@ import unittest
 from dataclasses import FrozenInstanceError
 
 import judge_contracts as jc
+from invocation_contracts import InvocationState
 
 
 class JudgeInvocationTests(unittest.TestCase):
@@ -14,6 +15,7 @@ class JudgeInvocationTests(unittest.TestCase):
             stdout='{"passed":true}',
             stderr="diagnostic",
             returncode=0,
+            invocation_state=InvocationState.COMPLETE,
             usage={"input_tokens": 3, "cache": {"read_tokens": 1}},
             cost_usd=0.02,
             usage_source="trace_normalized",
@@ -31,7 +33,8 @@ class JudgeInvocationTests(unittest.TestCase):
 
     def test_nonzero_exit_is_an_explicit_unsuccessful_invocation(self):
         invocation = jc.JudgeInvocation(
-            stdout="", stderr="provider failed", returncode=17)
+            stdout="", stderr="provider failed", returncode=17,
+            invocation_state=InvocationState.PROCESS_FAILED)
         self.assertFalse(invocation.succeeded)
 
     def test_wire_scalars_and_identity_are_closed(self):
@@ -48,7 +51,8 @@ class JudgeInvocationTests(unittest.TestCase):
         for overrides in invalid:
             with self.subTest(overrides=overrides), self.assertRaises(
                     (TypeError, ValueError)):
-                values = {"stdout": "", "stderr": "", "returncode": 0}
+                values = {"stdout": "", "stderr": "", "returncode": 0,
+                          "invocation_state": InvocationState.COMPLETE}
                 values.update(overrides)
                 jc.JudgeInvocation(**values)
 
@@ -69,22 +73,62 @@ class JudgeInvocationTests(unittest.TestCase):
         for overrides in invalid:
             with self.subTest(overrides=overrides), self.assertRaises(
                     (TypeError, ValueError)):
-                values = {"stdout": "", "stderr": "", "returncode": 0}
+                values = {"stdout": "", "stderr": "", "returncode": 0,
+                          "invocation_state": InvocationState.COMPLETE}
                 values.update(overrides)
                 jc.JudgeInvocation(**values)
 
         with self.assertRaises(ValueError):
             jc.JudgeInvocation(
-                stdout="", stderr="", returncode=0, cost_usd=10 ** 400)
+                stdout="", stderr="", returncode=0,
+                invocation_state=InvocationState.COMPLETE, cost_usd=10 ** 400)
 
     def test_large_integer_usage_is_exact_and_surrogates_are_rejected(self):
         huge = 10 ** 400
         invocation = jc.JudgeInvocation(
             stdout="{}", stderr="", returncode=0,
+            invocation_state=InvocationState.COMPLETE,
             usage={"input_tokens": huge})
         self.assertEqual(invocation.usage["input_tokens"], huge)
         with self.assertRaisesRegex(ValueError, "surrogate"):
-            jc.JudgeInvocation(stdout="\ud800", stderr="", returncode=0)
+            jc.JudgeInvocation(
+                stdout="\ud800", stderr="", returncode=0,
+                invocation_state=InvocationState.COMPLETE)
+
+    def test_lifecycle_discriminant_preserves_exit_zero_provider_failure(self):
+        invocation = jc.JudgeInvocation(
+            stdout="malformed provider envelope", stderr="protocol failed",
+            returncode=0, invocation_state=InvocationState.PROVIDER_FAILED,
+            provider_error="protocol failed")
+        self.assertFalse(invocation.succeeded)
+        self.assertEqual(invocation.returncode, 0)
+
+        contradictory = (
+            (InvocationState.COMPLETE, 1),
+            (InvocationState.TIMED_OUT, 0),
+            (InvocationState.SPAWN_FAILED, 0),
+            (InvocationState.PROCESS_FAILED, 0),
+            (InvocationState.HARNESS_FAILED, 0),
+            (InvocationState.PROVIDER_FAILED, 1),
+        )
+        for state, returncode in contradictory:
+            with self.subTest(state=state), self.assertRaises(ValueError):
+                jc.JudgeInvocation(
+                    stdout="", stderr="", returncode=returncode,
+                    invocation_state=state,
+                    provider_error=("provider failed"
+                                    if state is InvocationState.PROVIDER_FAILED else None))
+
+        with self.assertRaisesRegex(ValueError, "provider-failed"):
+            jc.JudgeInvocation(
+                stdout="", stderr="", returncode=0,
+                invocation_state=InvocationState.PROVIDER_FAILED)
+
+        process_failure = jc.JudgeInvocation(
+            stdout="", stderr="provider exited", returncode=17,
+            invocation_state=InvocationState.PROCESS_FAILED,
+            provider_error="provider reported a terminal error")
+        self.assertFalse(process_failure.succeeded)
 
 
 if __name__ == "__main__":

--- a/tests/test_judging.py
+++ b/tests/test_judging.py
@@ -445,6 +445,7 @@ class VerdictSchemaTests(unittest.TestCase):
     def test_shell_judge_uses_the_same_typed_boundary(self):
         invocation = jc.JudgeInvocation(
             stdout='{"passed":true}', stderr="", returncode=0,
+            invocation_state=sb.InvocationState.COMPLETE,
             model_label="opaque-shell-judge")
         with tempfile.TemporaryDirectory() as td, mock.patch.object(
                 sb, "shell_judge_invoke", return_value=invocation) as invoke:
@@ -454,6 +455,25 @@ class VerdictSchemaTests(unittest.TestCase):
         invoke.assert_called_once()
         self.assertTrue(row["passed"])
         self.assertEqual(row["judge_model"], "opaque-shell-judge")
+        self.assertEqual(row["invocation_state"], "complete")
+
+    def test_provider_failure_state_and_evidence_survive_result_projection(self):
+        invocation = jc.JudgeInvocation(
+            stdout="", stderr="protocol diagnostics", returncode=0,
+            invocation_state=sb.InvocationState.PROVIDER_FAILED,
+            provider_error="provider envelope was malformed",
+            model_label="opaque-shell-judge")
+        with tempfile.TemporaryDirectory() as td, mock.patch.object(
+                sb, "shell_judge_invoke", return_value=invocation):
+            row = sb.run_one_judge_task(
+                self._task(td), judge_cmd="unused",
+                judge_model="opaque-shell-judge")
+
+        self.assertFalse(row["passed"])
+        self.assertFalse(row["judge_observation_complete"])
+        self.assertEqual(row["invocation_state"], "provider_failed")
+        self.assertEqual(row["provider_error"], "provider envelope was malformed")
+        self.assertEqual(row["evidence"], "provider envelope was malformed")
 
     def test_registry_rejects_an_untyped_judge_backend_result(self):
         def broken_backend(prompt, **kwargs):

--- a/tests/test_trigger_contracts.py
+++ b/tests/test_trigger_contracts.py
@@ -179,13 +179,14 @@ class PiStreamContractTests(unittest.TestCase):
         self.assertEqual(invocation.provider_error, "final provider failure")
         self.assertEqual(invocation.provider_payload.usage_normalized, {"source": "missing"})
 
-    def test_nonzero_process_with_terminal_provider_error_is_provider_failed(self):
+    def test_nonzero_process_with_terminal_provider_error_retains_process_failure(self):
         raw = (FIXTURES / "provider-error-exit-zero.jsonl").read_text(encoding="utf-8")
         invocation = pi_invocation_outcome(InvocationOutcome.from_process(
             stdout=raw, stderr="", returncode=1, elapsed_ms=1,
         ))
-        self.assertIs(invocation.state, InvocationState.PROVIDER_FAILED)
+        self.assertIs(invocation.state, InvocationState.PROCESS_FAILED)
         self.assertEqual(invocation.returncode, 1)
+        self.assertIn("invalid model", invocation.provider_error or "")
 
     def test_timeout_remains_a_timeout_when_its_partial_stream_has_no_terminal_event(self):
         process = InvocationOutcome.from_timeout(

--- a/trigger_contracts.py
+++ b/trigger_contracts.py
@@ -15,7 +15,7 @@ from types import MappingProxyType
 from typing import Any, TypeAlias
 
 import telemetry as telemetry_domain
-from invocation_contracts import InvocationState
+from invocation_contracts import InvocationState, validate_invocation_lifecycle
 from json_contracts import (
     freeze_json_mapping,
     strict_json_equal,
@@ -83,22 +83,17 @@ class InvocationOutcome:
             elif (self.returncode is None
                   or self.completion_evidence is not CompletionEvidence.AGENT_WINDOW_EXHAUSTED):
                 raise ValueError("non-zero completion requires a spawned process and explicit agent-window evidence")
-            if self.provider_error is not None:
-                raise ValueError("a complete invocation cannot carry a provider error")
         elif self.completion_evidence is not None:
             raise ValueError("only complete invocations can carry completion evidence")
 
-        if self.state is InvocationState.TIMED_OUT and self.returncode != 124:
-            raise ValueError("timed-out invocation must use returncode 124")
-        if self.state is InvocationState.SPAWN_FAILED and self.returncode != 127:
-            raise ValueError("spawn failure must use returncode 127")
-        if self.state is InvocationState.PROCESS_FAILED and self.returncode in {None, 0}:
-            raise ValueError("process failure requires a non-zero returncode")
-        if self.state is InvocationState.PROVIDER_FAILED:
-            if self.returncode is None or self.provider_error is None:
-                raise ValueError("provider failure requires a spawned process and provider_error")
-        elif self.provider_error is not None:
-            raise ValueError("provider_error requires PROVIDER_FAILED state")
+        validate_invocation_lifecycle(
+            self.state,
+            self.returncode,
+            self.provider_error,
+            allow_harness_failure=True,
+            allow_nonzero_completion=(
+                self.completion_evidence is CompletionEvidence.AGENT_WINDOW_EXHAUSTED),
+        )
         if self.state is InvocationState.HARNESS_FAILED:
             if self.returncode is not None or self.elapsed_ms is not None:
                 raise ValueError("harness failure has no process returncode or measured elapsed time")
@@ -226,9 +221,13 @@ class InvocationOutcome:
                 raise ValueError(f"{agent}.invoke cannot be complete and provider-failed")
             if timed_out:
                 raise ValueError(f"{agent}.invoke cannot be both timed out and provider-failed")
-            if invocation_state not in {None, InvocationState.PROVIDER_FAILED}:
+            provider_state = (
+                InvocationState.PROVIDER_FAILED
+                if returncode == 0 else InvocationState.PROCESS_FAILED
+            )
+            if invocation_state not in {None, provider_state}:
                 raise ValueError(f"{agent}.invoke provider failure contradicts invocation_state")
-            return cls(stdout, stderr, returncode, elapsed_ms, InvocationState.PROVIDER_FAILED,
+            return cls(stdout, stderr, returncode, elapsed_ms, provider_state,
                        provider_error=provider_error, metadata=metadata)
         if timed_out:
             if complete or returncode != 124:
@@ -286,7 +285,11 @@ class InvocationOutcome:
     def with_provider_error(self, error: str | None, *, payload: Any = None) -> InvocationOutcome:
         if not error or self.state in {InvocationState.TIMED_OUT, InvocationState.SPAWN_FAILED, InvocationState.HARNESS_FAILED}:
             return replace(self, provider_payload=payload if payload is not None else self.provider_payload)
-        return replace(self, state=InvocationState.PROVIDER_FAILED,
+        state = (
+            InvocationState.PROVIDER_FAILED
+            if self.returncode == 0 else InvocationState.PROCESS_FAILED
+        )
+        return replace(self, state=state,
                        completion_evidence=None, provider_error=error.strip(),
                        provider_payload=payload if payload is not None else self.provider_payload)
 

--- a/type_tests/abstraction_contracts.py
+++ b/type_tests/abstraction_contracts.py
@@ -26,6 +26,14 @@ from experimental_pairs import (
     ExperimentalPairKey,
     ExperimentalPopulation,
 )
+from grading_contracts import (
+    AssertionObservation,
+    FailedAssertion,
+    JudgeTask,
+    SatisfiedAssertion,
+    SkippedAssertion,
+    UnavailableAssertion,
+)
 from invocation_contracts import (
     InvocationRequest,
     InvocationResult,
@@ -190,3 +198,26 @@ def event_log_observation_is_exhaustive(observation: EventLogObservation) -> Non
         _schema_version: int = observation.schema_version
     else:
         _assert_never(observation)
+
+
+def assertion_observation_is_exhaustive(
+    observation: AssertionObservation,
+) -> None:
+    if isinstance(observation, SatisfiedAssertion):
+        _satisfied: SatisfiedAssertion = observation
+    elif isinstance(observation, FailedAssertion):
+        _failed: FailedAssertion = observation
+    elif isinstance(observation, UnavailableAssertion):
+        _observed_passed: bool | None = observation.observed_passed
+    elif isinstance(observation, SkippedAssertion):
+        _skip_reason: str = observation.skip_reason
+    else:
+        _assert_never(observation)
+
+
+def judge_task_identity_is_precise(task: JudgeTask) -> None:
+    _case_id: CaseId = task.case_id
+    _variant: ExecutionVariant = task.variant
+    _run_number: RunNumber = task.run_number
+    _model: ModelId | None = task.model
+    _assertion: Mapping[str, object] = task.assertion


### PR DESCRIPTION
## Summary

- classify assertion results as satisfied, failed, unavailable, or skipped before aggregation
- make persisted `JudgeTask` values closed, recursively immutable, UTF-8 safe, and lossless at their declared boundary
- make `JudgeInvocation` carry the canonical lifecycle state and provider diagnostics
- centralize lifecycle validation so answer, trigger, process-result, and judge paths preserve the same process provenance

This is layer 6 of the `ty` migration stack and depends on #77.

## Why

Dictionary truthiness blurred failed, unavailable, skipped, process-failed, and exit-zero provider/protocol failures. The closed contracts make denominator and lifecycle decisions structural.

## Compatibility and risk

Complete judge rows retain their existing wire values and gain explicit lifecycle evidence. `PROVIDER_FAILED` now means an exit-zero provider/response failure with `provider_error`; a nonzero exit remains `PROCESS_FAILED` even when provider diagnostics explain it. Judge result rows preserve `invocation_state` and `provider_error` instead of collapsing them back to booleans.

## Validation

- focused grading, judge-contract, trigger-contract, Gemini, and full judging tests
- adversarial construction, UTF-8, unknown-field, deep-freeze, and lifecycle-provenance coverage
- top-of-stack integration: 1,335 passed, 7 skipped, 858 subtests
- warning-fatal `ty`, Ruff, byte compilation, doc-reference check, and `git diff --check`
