### PR TITLE
Type report coverage cohorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@ skill-eval-harness/
 ├── artifact_contracts.py       # closed persisted-artifact observations and integrity verification
 ├── experimental_pairs.py       # exact pair identities and blocked-pair construction
 ├── grading_contracts.py        # closed assertion observations and immutable judge tasks
+├── report_contracts.py         # empty/complete/partial report coverage cohorts and rates
 ├── runner_contracts.py         # closed answer-runner outcome union
 ├── judge_verdict.py            # strict imported/stored judge verdict variants
 ├── jetty_contracts.py          # closed Jetty lifecycle and observation contract

--- a/TODO.md
+++ b/TODO.md
@@ -71,7 +71,7 @@ Jetty runbooks emit a standardized machine-readable `validation_report.json` per
 (`jettyio/jettyio-skills`, `skills/create-runbook/SKILL.md`). Rubric evaluation scores 3-7
 dimensions on a 1-5 scale; programmatic evaluation returns `PASS` / `PARTIAL` / `FAIL`. The
 items below map that report onto the harness judge-result row `{judge_task_id, passed, score,
-threshold, evidence}` (`load_judge_results:11575`, merged in `grade_case_variant:13880`).
+threshold, evidence}` (`load_judge_results:11578`, merged in `grade_case_variant:13883`).
 
 - [ ] Export qualitative judge tasks to Jetty workflows using `simple_judge` where useful.
       Carry `judge_task_id` (`case::variant::run-n::assertion`) into the Jetty task so the

--- a/docs/abstractions.md
+++ b/docs/abstractions.md
@@ -174,10 +174,10 @@ Likewise, `read_event_log_base` produces `MissingEventLog | InvalidEventLog | Lo
 ## Runner / adapter
 
 An **answer runner** consumes prepared task rows and produces the run-output contract. The repo
-ships Pi answer smoke (`examples/adewale-workspace/run_pi_smoke.py`), Codex (`run_codex:10449`), Claude (`run_claude:10635`, capturing real
+ships Pi answer smoke (`examples/adewale-workspace/run_pi_smoke.py`), Codex (`run_codex:10452`), Claude (`run_claude:10638`, capturing real
 per-run cost), Gemini CLI and Mistral Vibe (`run-agent --agent gemini|vibe`, using isolated provider homes outside the workdir), the in-process
-subagent runner (`run_subagent:13225`, which hosts record/replay tool I/O via `ToolReplayStore`),
-Jetty (`JettyClient:4005` and the export/run/import commands), and any runner that writes the
+subagent runner (`run_subagent:13228`, which hosts record/replay tool I/O via `ToolReplayStore`),
+Jetty (`JettyClient:4008` and the export/run/import commands), and any runner that writes the
 contract directly. Each answer runner registers a workspace builder so one cross-runner invariant
 proves its `without_skill` arm is skill-free (CF.2). Autonomous trigger runners are separate: they
 read trigger cases from the manifest directly, never consume answer task rows, and emit trigger
@@ -270,8 +270,19 @@ those pairs; missing/ineligible arms remain in `pairing` diagnostics and duplica
 `build_slice_summary` breaks results down
 by domain, difficulty, trigger type, and success goal. Case flags mark saturated, no-lift,
 flaky, and with-skill-failed cases. These flags, the leakage lint
-(`prompt_assertion_leakage_findings:795`), and the split discipline are the part of the tool
+(`prompt_assertion_leakage_findings:798`), and the split discipline are the part of the tool
 no surveyed eval framework copies.
+
+`report_contracts.report_cohort` classifies each attempted reporting population as
+`EmptyReportCohort | CompleteReportCohort | PartialReportCohort |
+NotApplicableReportCohort` from one stable-identity attempt sequence before computing variant and
+slice headlines. `metric_cohort` then refines that same population per rate: row completeness can
+never authorize a survivor-only metric mean. Partial cohorts expose observed diagnostics but
+withhold headline means; empty and non-applicable populations remain distinct. `UnitRate` rejects
+booleans, non-finite numbers, and values
+outside `[0, 1]` before `statistics` can aggregate them. Attempted, observed, and blocked counts are
+derived from the same deeply frozen attempt dispositions, preventing consumers from assembling
+inconsistent coverage or relying on Python object identity.
 
 The pairing key carries `CaseId`, `ModelId | None`, `RunNumber`, and the closed
 `ExperimentalPopulation` enum. The pair also carries a contrast whose canonical factor coordinates

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -147,6 +147,7 @@ run evidence -> process × provider-response × trace × artifact-set state
 artifact set -> Legacy | MissingCommit | InvalidCommit | Incomplete | Complete
 event log -> Missing | Invalid | Loaded
 assertion result -> Satisfied | Failed | Unavailable | Skipped
+report coverage -> Empty | Complete | Partial
 qualitative work -> JudgeTask
 judge process -> JudgeInvocation
 judge row -> Boolean | Scored | Dimension | Dynamic | Consensus verdict

--- a/docs/correctness-by-construction-audit.md
+++ b/docs/correctness-by-construction-audit.md
@@ -366,6 +366,28 @@ raw output string
   replaces runtime parsing: manifest dictionaries and external embedding/script values remain
   untrusted wire data.
 
+## Report coverage cohorts
+
+Variant and slice summaries consume one closed report population:
+
+```text
+attempted rows + stable identity + eligibility -> Empty | Complete | Partial | NotApplicable
+row cohort + metric key/applicability -> metric-specific cohort
+observed numeric rate -> UnitRate(0 <= value <= 1)
+```
+
+- Empty populations remain distinct from fully observed non-empty populations.
+- Attempts that exist but have no applicable denominator remain distinct from empty and blocked
+  populations.
+- A partial population owns the attempted, observed, and blocked counts plus its reason. Its
+  observed means remain diagnostics while headline means are unavailable.
+- Every row is classified once from the attempted sequence, carries a stable run identity, is
+  recursively frozen, and cannot repeat that identity. No membership rule depends on object `id()`.
+- Each rate gets its own refined cohort. A complete row set with one absent rate is metric-partial,
+  never permission to average only the surviving values.
+- Rate validation rejects bool, NaN, infinity, and out-of-range values before aggregation.
+- `ty` checks exhaustive narrowing across all four coverage states.
+
 ## Ablation provenance vocabulary
 
 Answer-population ablation confirmation uses the same exact case/model/repetition pairs, requires

--- a/docs/eval-framework-roadmap-spec.md
+++ b/docs/eval-framework-roadmap-spec.md
@@ -17,7 +17,7 @@ One invariant governs every item: core grading stays local and deterministic and
 model, and the harness never picks a model for the user. Anything that needs a model lives
 behind an opt-in command or the external `--judge-cmd`. Two abstractions absorb most of the
 work, so the spec returns to them often: the assertion result shape in `assertion_result`
-(`skill_benchmark.py:11149`) and the fan-out in `prepared_task_rows` (`:1567`).
+(`skill_benchmark.py:11152`) and the fan-out in `prepared_task_rows` (`:1570`).
 
 ## Testing baseline
 
@@ -40,7 +40,7 @@ tests are where that claim is checked rather than trusted.
 
 The buckets below extend what the harness can measure. This floor decides whether the number it
 already prints can be believed. The harness reports one thing: lift, `with_skill` minus
-`without_skill` on the same case (`build_paired_summary` (`:15349`)). That number is believable only
+`without_skill` on the same case (`build_paired_summary` (`:15352`)). That number is believable only
 when three preconditions hold, each intended today, none enforced, and each restating a claim from
 `evals-are-not-tests.md`:
 
@@ -60,22 +60,22 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
   hiding the quantity the tool exists to measure.
 - **Abstractions used or changed:** none in the engine. Adds
   `tests/fixtures/detectors/<detector_id>/should-fire.*` and `should-pass.*` that exercise
-  `assertion_result` (`:11149`) directly. That function has no direct unit test today, and its
+  `assertion_result` (`:11152`) directly. That function has no direct unit test today, and its
   `contains_any`, `excludes_any`, and `not_regex` branches go unexercised even though their types
-  are declared in the assertion registries (`TEXT_ASSERTIONS:219`).
+  are declared in the assertion registries (`TEXT_ASSERTIONS:222`).
 - **Design:** one table-driven test loads every pair and asserts the detector fires on `should-fire`
   and stays silent on `should-pass`. A `should-pass` twin is mandatory: it enforces the
   false-positive bar `authoring-evals.md` already sets for skill authors ("check both presence and
   absence"). Each `should-pass` set includes a case where the baseline echoes the prompt, because a
   detector that passes on echoed prompt text is a false oracle; this ties the fixtures to leakage
-  lint (`prompt_assertion_leakage_findings` (`:795`)). Every detector bug then becomes a permanent
+  lint (`prompt_assertion_leakage_findings` (`:798`)). Every detector bug then becomes a permanent
   fixture pair, and `test_command_assertions_match_command_inputs_not_outputs` is the first.
 - **Why it is the keystone:** the fixture pair is also the registration contract. It is what lets a
   harvested or third-party detector be trusted on entry, so it gates the exapted detector library
   (TODO, end of 2026), and it raises the oracle-strength ladder (1.7) so that "strong" means
   fixture-verified, not only deterministic.
 - **Testing:** the fixtures are the test. A meta-test asserts every name in `OBJECTIVE_ASSERTIONS`
-  (`:256`) has a fixture pair, so a new detector cannot land unverified.
+  (`:259`) has a fixture pair, so a new detector cannot land unverified.
 
 ### CF.2 — One cross-runner baseline-isolation invariant
 - **Goal:** prove the baseline is skill-free by construction, so a measured lift is the skill's
@@ -101,7 +101,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 ### CF.4 — A guard that the core grade path calls no model and no network
 - **Goal:** make the governing invariant — "core grading stays local and deterministic and never
   calls a model" — executable rather than aspirational.
-- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:13880`).
+- **Abstractions used or changed:** none. A test-time guard around `grade_case_variant` (`:13883`).
 - **Design:** patch `urllib` and `subprocess` to raise, then grade a fixture covering every
   objective family (text, process, efficiency) and assert it completes. The sanctioned exceptions —
   `script` oracles and `judge` plumbing — are excluded from this path by design and keep their own
@@ -111,7 +111,7 @@ multi-model (2.1) feature built on unverified detectors only scales an unverifie
 
 ### Boundary
 The set stops here deliberately. Report-level correctness — whether the saturation, no-lift, flaky,
-and negative-delta flags (`build_benchmark_report` (`:16768`)) are computed right — sits a layer
+and negative-delta flags (`build_benchmark_report` (`:16915`)) are computed right — sits a layer
 above the raw measurement, where the golden-report tests the buckets already plan (1.2, 2.6) cover
 it. CF.1–CF.4 are the floor underneath that work: once they pass, a printed lift carries a checked
 measurement, and every feature in the buckets builds on a number that has been verified rather than
@@ -125,9 +125,9 @@ assumed.
 - **Goal:** ship graders authors reach for often, so they stop hand-rolling rubrics.
 - **Abstractions used or changed:** `tool_call` and `structured_output` are deterministic, so
   they become new types in `TEXT_ASSERTIONS` / `PROCESS_ASSERTIONS` and gain a branch in
-  `assertion_result`. `tool_call` reuses `command_events` (`:6406`) and the `command_order`
+  `assertion_result`. `tool_call` reuses `command_events` (`:6409`) and the `command_order`
   logic; `structured_output` extends `json_field_equals` with JSON-Schema validation.
-  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:11732`) renders
+  `factuality` adds no core code: it is a named rubric that `judge_prompt` (`:11735`) renders
   and still runs through `--judge-cmd`.
 - **Design:** a preset expands to either a deterministic objective assertion or a `judge`
   assertion with a canned rubric and threshold. No new execution path.
@@ -146,7 +146,7 @@ assumed.
 ### 1.3 Judge config slot and the "judge is not the model under test" guard
 - **Goal:** make an existing convention enforceable.
 - **Abstractions used or changed:** read an optional `judge` block in the manifest; add a check
-  in `audit_manifest_report` (`:19591`) comparing the declared judge model against `jetty.model`
+  in `audit_manifest_report` (`:19738`) comparing the declared judge model against `jetty.model`
   or the run metadata `model`.
 - **Design:** warn by default, error under `--strict-judge`.
 - **Testing:** unit tests for matching and differing model ids.
@@ -163,7 +163,7 @@ assumed.
 - **Status:** `docs/authoring-evals.md` shipped, alongside `architecture.md` and
   `abstractions.md`.
 - **Follow-on:** surface the guide's rules where they are checkable. Extend the messaging in
-  `prompt_assertion_leakage_findings` (`:795`) and `fixture_recommendations` (`:19284`) to point
+  `prompt_assertion_leakage_findings` (`:798`) and `fixture_recommendations` (`:19431`) to point
   at the relevant section.
 - **Testing:** assert the new hint strings appear for crafted manifests.
 
@@ -172,8 +172,8 @@ assumed.
   In `adewale/pythonbyexample` and `adewale/xampler` an example *is* an eval case: an input, an
   expected output, and a check that the output still matches. The harness has no equivalent of
   "this output equals this reference."
-- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:219`), implemented in
-  `assertion_result` (`:11149`). It reads `output.md` (or a named artifact), applies an optional
+- **Abstractions used or changed:** a new type in `TEXT_ASSERTIONS` (`:222`), implemented in
+  `assertion_result` (`:11152`). It reads `output.md` (or a named artifact), applies an optional
   normalization (trim, collapse whitespace, or a named normalizer), and compares to a reference
   file under the manifest dir. Evidence is a unified diff on mismatch.
 - **Design:** normalization is the whole game, so it is explicit and per-assertion, never
@@ -188,9 +188,9 @@ assumed.
   not name it.
 - **Abstractions used or changed:** an optional `oracle` tier on an assertion
   (`strong` / `demo` / `live`), defaulting by type (deterministic text/process are `strong`,
-  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:16768`)
+  `script` is `demo` unless marked, judge/live are `live`). `build_benchmark_report` (`:16915`)
   reports, per case, the share of its pass rate carried by `strong` oracles;
-  `audit_manifest_report` (`:19591`) warns when a case passes only on weak ones. This extends
+  `audit_manifest_report` (`:19738`) warns when a case passes only on weak ones. This extends
   leakage lint (`:164`) from prompts to oracles.
 - **Strongest tier — the rendered-artifact oracle:** the top of the ladder is an oracle that
   builds or renders the artifact and inspects the result, not the source text.
@@ -205,8 +205,8 @@ assumed.
   splits "good poster" into seven `script` oracles, but each is forced all-or-nothing by the
   exit-code-only contract: a poster with six of seven drama carriers fails `drama_oracle` exactly
   like one with zero. That is the binary-saturation problem inside a single oracle.
-- **Abstractions used or changed:** extend `run_script_assertion` (`:11017`) and
-  `assertion_result` (`:11149`) to optionally parse a score from the oracle's stdout — a JSON line
+- **Abstractions used or changed:** extend `run_script_assertion` (`:11020`) and
+  `assertion_result` (`:11152`) to optionally parse a score from the oracle's stdout — a JSON line
   such as `{"score": 6, "max_score": 7}` (normalized to 0-1) — beside the existing
   `pass_exit_code`. The parsed score flows into the `score`/`severity` channel from 2.2, so a
   script oracle becomes a graded dimension while staying fully deterministic and model-free.
@@ -223,9 +223,9 @@ assumed.
   past it — either way, question it. This is the inverse of the saturation flag: saturation marks
   a case as too easy *now*; staleness marks a case that has never discriminated *over time*.
 - **Abstractions used or changed:** reads the cross-run history from 2.6. A `prune` report (or a
-  flag in `build_benchmark_report` (`:16768`)) marks a case a removal candidate when, across the
+  flag in `build_benchmark_report` (`:16915`)) marks a case a removal candidate when, across the
   last N runs, it never failed and never showed lift (`with_skill` == `without_skill` every time).
-  `audit_manifest_report` (`:19591`) lists the candidates; removal stays a human decision.
+  `audit_manifest_report` (`:19738`) lists the candidates; removal stays a human decision.
 - **Design:** the harness suggests, never deletes. A case may be kept deliberately as a
   regression guard even when stale; the report says so rather than acting.
 - **Depends on:** 2.6 (needs run history to judge "never failed over time").
@@ -239,12 +239,12 @@ assumed.
 ### 2.1 Multi-model fan-out (priority)
 - **Goal:** run the same cases across several models and compare lift per model. No surveyed
   framework does this; vitest-evals, eve, and viteval all push it onto the test runner.
-- **Abstractions used or changed:** `prepared_task_rows` (`:1567`) gains a `model` dimension
+- **Abstractions used or changed:** `prepared_task_rows` (`:1570`) gains a `model` dimension
   beside `variant` and `run_number`. Each row carries its target `model`, and `run_dir` gains a
   model segment (`<case>/<model>/<variant>/run-<n>`), kept backward-compatible when one model
   runs. Runners pass the row `model` through; per-run `model` already lands in `metadata.json`,
-  so grading needs no change. `build_benchmark_report` (`:16768`) groups `by_variant` within
-  `by_model`, and `build_paired_summary` (`:15349`) computes lift per (case, model).
+  so grading needs no change. `build_benchmark_report` (`:16915`) groups `by_variant` within
+  `by_model`, and `build_paired_summary` (`:15352`) computes lift per (case, model).
 - **Design:** model is a third axis, not a new variant. Variants stay orthogonal, giving a
   model-by-variant grid. CLI: `--models a,b,c` on `prepare`.
 - **Testing:** a fan-out test asserting row count equals cases × variants × runs × models with
@@ -261,7 +261,7 @@ assumed.
   no-regression floor. This spec ports those shapes into the harness rather than inventing new
   ones.
 - **Abstractions used or changed:**
-  - `assertion_result` (`:11149`) gains an optional `score` (0-1 or a normalized 1-5) and
+  - `assertion_result` (`:11152`) gains an optional `score` (0-1 or a normalized 1-5) and
     `severity` (`critical` / `gate` / `soft`), read from `critical`/`gate`/`soft`/`atLeast` on the
     assertion.
   - **`critical` (absorbing-barrier) tier — valley-dodging.** From the Jetty "valley-dodging"
@@ -276,13 +276,13 @@ assumed.
   - **Anchored `graded_dimensions`** as a `judge` assertion shape:
     `{name, scale: "1-5", rubric: "5 = …observable…; 1 = …observable…"}`. Anchors name what each
     score level looks like, so a judge scores against criteria, not a vibe. `judge_prompt`
-    (`:11732`) renders the dimensions; the result carries per-dimension scores in `evidence`.
+    (`:11735`) renders the dimensions; the result carries per-dimension scores in `evidence`.
   - **`dynamic_rubric`** as a second `judge` shape: `{instruction, minimum_criteria}`. The judge
     drafts 3-5 case-specific criteria before grading and must meet at least `minimum_criteria`.
-  - `grade_case_variant` (`:13880`) splits totals into critical, gated, and soft. A `critical`
+  - `grade_case_variant` (`:13883`) splits totals into critical, gated, and soft. A `critical`
     failure vetoes the case; a `gate` failure lowers the pass rate; a `soft` failure lowers
     neither and fills a `scored` bucket. A `--strict` flag promotes soft to gate.
-  - **Statistical lift** in `build_paired_summary` (`:15349`): alongside the raw delta, compute a
+  - **Statistical lift** in `build_paired_summary` (`:15352`): alongside the raw delta, compute a
     significance test over the per-case graded scores (paired bootstrap or sign-flip
     permutation, mirroring `score_delta.py`), so lift is tested, not eyeballed.
   - **Reference-anchor floor:** an optional `reference_score` / `reference_graded_score` on a
@@ -315,7 +315,7 @@ assumed.
 - **Goal:** deterministic re-runs that pay nothing for external dependencies, by recording tool
   inputs and outputs.
 - **Abstractions used or changed:** this lives in the runner, not core grading. Recording sits
-  beside `write_trace_artifacts` (`:8279`): a `tool-replay.json` keyed per tool, with
+  beside `write_trace_artifacts` (`:8282`): a `tool-replay.json` keyed per tool, with
   `sanitize` and `version`. Modes (`auto`, `record`, `off`, `strict`) come from an environment
   variable that `run_codex` and the Pi and subagent runners read.
 - **Design:** orthogonal to the disk re-grade the harness already does. Replay makes the agent
@@ -326,8 +326,8 @@ assumed.
 
 ### 2.4 OpenTelemetry GenAI normalization target
 - **Goal:** make the trace adapter boundary a standard rather than a bespoke schema.
-- **Abstractions used or changed:** `normalize_trace_record` (`:7336`) and
-  `normalize_trace_records` (`:7995`) keep their inputs but emit OTel GenAI semantic-key
+- **Abstractions used or changed:** `normalize_trace_record` (`:7339`) and
+  `normalize_trace_records` (`:7998`) keep their inputs but emit OTel GenAI semantic-key
   attributes; the `events.json` schema version bumps. Process and efficiency assertions read the
   new keys with backward-compatible fallbacks.
 - **Design:** additive schema. An old `events.json` still grades.
@@ -337,7 +337,7 @@ assumed.
 ### 2.5 Dataset abstraction
 - **Goal:** fan one case template over many rows instead of hand-authoring each case.
 - **Abstractions used or changed:** a new optional manifest construct (`datasets`, plus a case
-  `template` referencing a dataset id). `iter_cases` (`:602`) materializes template by row into
+  `template` referencing a dataset id). `iter_cases` (`:605`) materializes template by row into
   concrete cases before fan-out; `validate_manifest` validates rows and runs leakage lint per
   materialized case.
 - **Design:** materialization happens early, so prepare, grade, and report stay unchanged.
@@ -351,7 +351,7 @@ assumed.
 - **Goal:** watch lift, saturation, and token drift over time.
 - **Abstractions used or changed:** a consumer of `build_benchmark_report`. Add an append-only
   history store and a `trend` subcommand that diffs successive `benchmark.json` files, reusing
-  the `compare_results` (`:17950`) logic.
+  the `compare_results` (`:18097`) logic.
 - **Severity-weighted ranking (from the macro-evals notebook):** when surfacing recurring
   failures across runs, rank them by `prevalence × severity`, not raw count, so a rare but severe
   failure outranks a common trivial one. This is the floor-raising principle made quantitative;
@@ -377,8 +377,8 @@ assumed.
   it dispatches a subagent with a rubric whose "criteria [are] deliberately absent from
   generation rules."
 - **Abstractions used or changed:** mostly a discipline made first-class, not new machinery.
-  `prepared_task_rows` (`:1567`) already omits `review_rubric` from generation payloads unless
-  `--include-answer-key`; extend `validate_manifest` (`:1170`) to require that a `holdout`/
+  `prepared_task_rows` (`:1570`) already omits `review_rubric` from generation payloads unless
+  `--include-answer-key`; extend `validate_manifest` (`:1173`) to require that a `holdout`/
   `holdback` case's rubric stays out of the skill and public eval text, and pair it with the
   subagent judge from 2.7 and the graded scoring from 2.2. Track which rubrics were held out so
   the report can separate held-out scores from tune-visible ones.
@@ -390,7 +390,7 @@ assumed.
 ### 2.8 Interactive served report and richer artifacts
 - **Goal:** capture feedback in the browser and render image, PDF, and xlsx artifacts, beyond the
   static `render_viewer`.
-- **Abstractions used or changed:** extend `render_viewer` (`:18747`) with a `serve` mode and
+- **Abstractions used or changed:** extend `render_viewer` (`:18894`) with a `serve` mode and
   artifact encoders. Anthropic's `eval-viewer/generate_review.py` is the blueprint, including
   `feedback.json` persistence and a `--previous-workspace` diff.
 - **Testing:** unit-test the artifact embedding and categorization and the feedback round trip;
@@ -422,7 +422,7 @@ assumed.
 - **Goal:** evaluate conversational skills across a send/respond sequence.
 - **Abstractions changed (core contract):** a case gains an optional `turns` list. The
   run-output contract grows from one `output.md` to a turn-indexed transcript, so
-  `read_output_base` (`:6253`) and `discover_run_bases` learn the turn layout; runners drive the
+  `read_output_base` (`:6256`) and `discover_run_bases` learn the turn layout; runners drive the
   sequence; `grade_case_variant` grades per turn and aggregates.
 - **Design:** single-shot stays the default, so existing manifests are untouched.
 - **Testing:** a fixture multi-turn run asserting per-turn grading and aggregate, plus a
@@ -435,7 +435,7 @@ assumed.
   the model axis, plus a viewer panel.
 - **Slice-lift concentration (from the macro-evals notebook):** compute, per slice, where lift (or
   a failure) concentrates — `slice share ÷ overall share`, the macro-eval `lift` metric one level
-  up from per-case lift. `build_slice_summary` (`:15520`) already groups by domain/difficulty/
+  up from per-case lift. `build_slice_summary` (`:15578`) already groups by domain/difficulty/
   trigger/goal, so this is a ratio over groups it already forms, not new plumbing.
 - **Testing:** a report test over a two-model by two-variant fixture grid, plus a concentration
   test asserting a failure confined to one slice scores a high ratio there.
@@ -548,7 +548,7 @@ and upgrading to the new features should be something an agent can drive.
 
 ### Abstractions used or changed
 
-- `version` on the manifest (`validate_manifest:1170`) becomes meaningful: `validate` accepts both
+- `version` on the manifest (`validate_manifest:1173`) becomes meaningful: `validate` accepts both
   1 and 2, and warns (not errors) on a `version: 1` manifest once 2.2 has landed, pointing at
   `migrate`.
 - No grading abstraction changes for migration itself; it is a source-rewrite plus a guide.

--- a/docs/skill-ablation-spec.md
+++ b/docs/skill-ablation-spec.md
@@ -363,7 +363,7 @@ Opt in with `"invalid_skill": true` on the ablation: the run is tagged
 
 ## Validation additions
 
-`validate_manifest` (`skill_benchmark.py:1170`), per ablation:
+`validate_manifest` (`skill_benchmark.py:1173`), per ablation:
 
 - `id` unique and slug-formatted; keep `removed_component`.
 - If a removal is declared: exactly one of `mechanism`+`target` or `components`;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ skill-pi-trigger-eval = "run_pi_trigger_eval:main"
 skill-trigger-matrix = "run_trigger_matrix:main"
 
 [tool.setuptools]
-py-modules = ["skill_benchmark", "run_pi_trigger_eval", "run_trigger_matrix", "ablation_model", "agent_capabilities", "artifact_contracts", "telemetry", "trigger_contracts", "trigger_reporting", "trace_contracts", "runner_contracts", "judge_contracts", "judge_verdict", "experimental_pairs", "jetty_contracts", "gemini_contracts", "grading_contracts", "invocation_contracts", "json_contracts", "manifest_contracts", "text_contracts"]
+py-modules = ["skill_benchmark", "run_pi_trigger_eval", "run_trigger_matrix", "ablation_model", "agent_capabilities", "artifact_contracts", "telemetry", "trigger_contracts", "trigger_reporting", "trace_contracts", "runner_contracts", "judge_contracts", "judge_verdict", "experimental_pairs", "jetty_contracts", "gemini_contracts", "grading_contracts", "invocation_contracts", "json_contracts", "manifest_contracts", "report_contracts", "text_contracts"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
@@ -62,6 +62,7 @@ required-version = "==0.16.0"
 "judge_verdict.py" = ["TRY004"]
 "invocation_contracts.py" = ["PYI034", "TRY004"]
 "manifest_contracts.py" = ["PYI034", "TRY004"]
+"report_contracts.py" = ["PYI034", "TRY004"]
 "runner_contracts.py" = ["TRY004"]
 "telemetry.py" = ["TRY004"]
 # Runner boundaries must report arbitrary provider/CLI failures as evaluation

--- a/report_contracts.py
+++ b/report_contracts.py
@@ -1,0 +1,294 @@
+"""Closed, identity-stable coverage cohorts for report aggregation."""
+from __future__ import annotations
+
+import math
+from collections import Counter
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from numbers import Real
+from types import MappingProxyType
+from typing import Any, Literal, TypeAlias, TypeVar
+
+from json_contracts import freeze_json_mapping
+
+
+class ReportCoverageState(str, Enum):
+    EMPTY = "empty"
+    COMPLETE = "complete"
+    PARTIAL = "partial"
+    NOT_APPLICABLE = "not_applicable"
+
+
+class UnitRate(float):
+    """One finite observed rate in the closed interval [0, 1]."""
+
+    def __new__(cls, value: Real) -> UnitRate:
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, Real)
+            or not math.isfinite(float(value))
+            or not 0 <= float(value) <= 1
+        ):
+            raise ValueError("report rate must be a finite number in [0, 1]")
+        return float.__new__(cls, float(value))
+
+
+@dataclass(frozen=True)
+class ReportAttempt:
+    identity: str
+    row: Mapping[str, Any]
+    observed: bool
+    applicable: bool = True
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.identity, str) or not self.identity.strip():
+            raise ValueError("report attempt identity must be non-empty")
+        if not isinstance(self.row, Mapping):
+            raise TypeError("report attempt row must be a mapping")
+        if not isinstance(self.observed, bool) or not isinstance(self.applicable, bool):
+            raise TypeError("report attempt disposition must be boolean")
+        if self.observed and not self.applicable:
+            raise ValueError("a non-applicable report attempt cannot be observed")
+        if self.observed and self.reason is not None:
+            raise ValueError("an observed report attempt cannot carry a reason")
+        if not self.observed and (
+            not isinstance(self.reason, str) or not self.reason.strip()
+        ):
+            raise ValueError("an unobserved report attempt requires a reason")
+        object.__setattr__(self, "row", freeze_json_mapping(
+            self.row, f"report attempt {self.identity}"))
+
+
+def _validate_attempts(attempts: tuple[ReportAttempt, ...]) -> None:
+    if not isinstance(attempts, tuple) or not all(
+        isinstance(item, ReportAttempt) for item in attempts
+    ):
+        raise TypeError("report cohort attempts must be ReportAttempt values")
+    identities = [item.identity for item in attempts]
+    if len(set(identities)) != len(identities):
+        raise ValueError("report cohort cannot repeat an attempt identity")
+
+
+class _CohortCounts:
+    attempts: tuple[ReportAttempt, ...]
+
+    @property
+    def rows(self) -> tuple[Mapping[str, Any], ...]:
+        return tuple(item.row for item in self.attempts if item.observed)
+
+    @property
+    def attempted(self) -> int:
+        return len(self.attempts)
+
+    @property
+    def applicable(self) -> int:
+        return sum(item.applicable for item in self.attempts)
+
+    @property
+    def not_applicable(self) -> int:
+        return self.attempted - self.applicable
+
+    @property
+    def blocked(self) -> int:
+        return sum(item.applicable and not item.observed for item in self.attempts)
+
+
+@dataclass(frozen=True)
+class EmptyReportCohort(_CohortCounts):
+    attempts: tuple[ReportAttempt, ...] = field(default=(), init=False)
+    state: Literal[ReportCoverageState.EMPTY] = field(
+        default=ReportCoverageState.EMPTY, init=False)
+
+
+@dataclass(frozen=True)
+class CompleteReportCohort(_CohortCounts):
+    attempts: tuple[ReportAttempt, ...]
+    state: Literal[ReportCoverageState.COMPLETE] = field(
+        default=ReportCoverageState.COMPLETE, init=False)
+
+    def __post_init__(self) -> None:
+        _validate_attempts(self.attempts)
+        if not self.attempts or not any(item.applicable for item in self.attempts):
+            raise ValueError("complete report cohort needs an applicable attempt")
+        if any(item.applicable and not item.observed for item in self.attempts):
+            raise ValueError("complete report cohort cannot contain blocked attempts")
+
+
+@dataclass(frozen=True)
+class PartialReportCohort(_CohortCounts):
+    attempts: tuple[ReportAttempt, ...]
+    reason_counts: Mapping[str, int]
+    state: Literal[ReportCoverageState.PARTIAL] = field(
+        default=ReportCoverageState.PARTIAL, init=False)
+
+    def __post_init__(self) -> None:
+        _validate_attempts(self.attempts)
+        if not self.attempts or not any(
+            item.applicable and not item.observed for item in self.attempts
+        ):
+            raise ValueError("partial report cohort needs a blocked applicable attempt")
+        expected = Counter(
+            item.reason for item in self.attempts
+            if item.applicable and not item.observed
+        )
+        if dict(self.reason_counts) != dict(expected):
+            raise ValueError("partial report reason counts do not match its attempts")
+        object.__setattr__(self, "reason_counts", MappingProxyType(dict(expected)))
+
+    @property
+    def reason(self) -> str:
+        return ", ".join(sorted(self.reason_counts))
+
+
+@dataclass(frozen=True)
+class NotApplicableReportCohort(_CohortCounts):
+    attempts: tuple[ReportAttempt, ...]
+    state: Literal[ReportCoverageState.NOT_APPLICABLE] = field(
+        default=ReportCoverageState.NOT_APPLICABLE, init=False)
+
+    def __post_init__(self) -> None:
+        _validate_attempts(self.attempts)
+        if not self.attempts or any(item.applicable for item in self.attempts):
+            raise ValueError("not-applicable cohort cannot contain applicable attempts")
+
+
+ReportCohort: TypeAlias = (
+    EmptyReportCohort
+    | CompleteReportCohort
+    | PartialReportCohort
+    | NotApplicableReportCohort
+)
+RowT = TypeVar("RowT", bound=Mapping[str, Any])
+Disposition: TypeAlias = tuple[bool | None, str | None]
+
+
+def _cohort_from_attempts(attempts: tuple[ReportAttempt, ...]) -> ReportCohort:
+    if not attempts:
+        return EmptyReportCohort()
+    if not any(item.applicable for item in attempts):
+        return NotApplicableReportCohort(attempts)
+    blocked = [item for item in attempts if item.applicable and not item.observed]
+    if blocked:
+        return PartialReportCohort(
+            attempts, Counter(str(item.reason) for item in blocked))
+    return CompleteReportCohort(attempts)
+
+
+def report_cohort(
+    attempted_rows: Sequence[RowT],
+    *,
+    identity: Callable[[RowT], str],
+    eligibility: Callable[[RowT], Disposition],
+) -> ReportCohort:
+    """Classify each stable attempt exactly once before computing headlines.
+
+    Eligibility returns ``(True, None)`` for observed, ``(False, reason)`` for
+    unavailable, and ``(None, reason)`` for not applicable. No second list and
+    no Python object identity are involved.
+    """
+    attempts: list[ReportAttempt] = []
+    for row in attempted_rows:
+        if not isinstance(row, Mapping):
+            raise TypeError("report cohort rows must be mappings")
+        observed, reason = eligibility(row)
+        if observed is not True and observed is not False and observed is not None:
+            raise TypeError("report eligibility must be True, False, or None")
+        attempts.append(ReportAttempt(
+            identity(row), row, observed is True,
+            applicable=observed is not None,
+            reason=reason,
+        ))
+    return _cohort_from_attempts(tuple(attempts))
+
+
+def metric_cohort(
+    cohort: ReportCohort,
+    key: str,
+    *,
+    applicability: Callable[[Mapping[str, Any]], bool] | None = None,
+) -> ReportCohort:
+    """Refine row coverage to the availability of one particular rate."""
+    attempts: list[ReportAttempt] = []
+    for attempt in cohort.attempts:
+        if not attempt.applicable:
+            attempts.append(ReportAttempt(
+                attempt.identity, attempt.row, False, False, attempt.reason))
+            continue
+        applicable = (
+            True if applicability is None
+            else applicability(attempt.row)
+        )
+        if not isinstance(applicable, bool):
+            raise TypeError("metric applicability must be boolean")
+        if not applicable:
+            attempts.append(ReportAttempt(
+                attempt.identity, attempt.row, False, False,
+                f"{key}_not_applicable"))
+            continue
+        value = attempt.row.get(key)
+        has_rate = value is not None
+        if has_rate:
+            UnitRate(value)
+        observed = attempt.observed and has_rate
+        reason = None if observed else (
+            attempt.reason if not attempt.observed else f"missing_{key}")
+        attempts.append(ReportAttempt(
+            attempt.identity, attempt.row, observed, True, reason))
+    return _cohort_from_attempts(tuple(attempts))
+
+
+def observed_rows(cohort: ReportCohort) -> tuple[Mapping[str, Any], ...]:
+    return cohort.rows
+
+
+def attempted_rows(cohort: ReportCohort) -> tuple[Mapping[str, Any], ...]:
+    return tuple(item.row for item in cohort.attempts)
+
+
+def attempted_count(cohort: ReportCohort) -> int:
+    return cohort.attempted
+
+
+def blocked_count(cohort: ReportCohort) -> int:
+    return cohort.blocked
+
+
+def observed_rates(cohort: ReportCohort, key: str) -> tuple[UnitRate, ...]:
+    rates: list[UnitRate] = []
+    for row in cohort.rows:
+        value = row.get(key)
+        if value is None:
+            raise ValueError(f"observed report row is missing {key}")
+        rates.append(UnitRate(value))
+    return tuple(rates)
+
+
+def diagnostic_rates(cohort: ReportCohort, key: str) -> tuple[UnitRate, ...]:
+    """Valid raw values, including blocked attempts, for named diagnostics only."""
+    return tuple(
+        UnitRate(value)
+        for attempt in cohort.attempts
+        if (value := attempt.row.get(key)) is not None
+    )
+
+
+def headline_value(cohort: ReportCohort, observed: Any) -> Any:
+    """Publish a headline only for a complete metric denominator."""
+    return observed if isinstance(cohort, CompleteReportCohort) else None
+
+
+def coverage_fields(cohort: ReportCohort) -> dict[str, Any]:
+    fields: dict[str, Any] = {
+        "attempted_runs": cohort.attempted,
+        "runs": len(cohort.rows),
+        "blocked_runs": cohort.blocked,
+        "availability": cohort.state.value,
+    }
+    if cohort.not_applicable:
+        fields["not_applicable_runs"] = cohort.not_applicable
+    if isinstance(cohort, PartialReportCohort):
+        fields["reason"] = cohort.reason
+        fields["blocked_reason_counts"] = dict(cohort.reason_counts)
+    return fields

--- a/skill_benchmark.py
+++ b/skill_benchmark.py
@@ -40,7 +40,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import zipfile
-from collections.abc import Callable, Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass as _dataclass
 from decimal import ROUND_CEILING, Decimal
 from pathlib import Path
@@ -58,6 +58,7 @@ from yaml.constructor import ConstructorError
 from yaml.resolver import BaseResolver
 
 import experimental_pairs as pair_domain
+import report_contracts as report_domain
 import telemetry as telemetry_domain
 from ablation_model import (
     CLAUDE_FAILURE,
@@ -166,9 +167,11 @@ from judge_verdict import (
 )
 from manifest_contracts import (
     DEFAULT_EXECUTION_VARIANTS,
+    CaseId,
     CaseKind,
     CasePopulation,
     ExecutionVariant,
+    ModelId,
     RunNumber,
     Split,
 )
@@ -209,7 +212,7 @@ HARNESS_SEMANTIC_MODULES = (
     "ablation_model.py", "agent_capabilities.py", "artifact_contracts.py", "experimental_pairs.py",
     "gemini_contracts.py", "grading_contracts.py",
     "invocation_contracts.py", "jetty_contracts.py", "judge_contracts.py", "judge_verdict.py", "json_contracts.py", "manifest_contracts.py", "run_pi_trigger_eval.py",
-    "run_trigger_matrix.py", "runner_contracts.py", "skill_benchmark.py",
+    "report_contracts.py", "run_trigger_matrix.py", "runner_contracts.py", "skill_benchmark.py",
     "telemetry.py", "trace_contracts.py", "trigger_contracts.py",
     "trigger_reporting.py",
 )
@@ -14394,7 +14397,7 @@ def grade(args: argparse.Namespace) -> int:
                 fh.write(json.dumps(task, ensure_ascii=False) + "\n")
     return 0
 
-def stats(values: list[float]) -> dict[str, float | None]:
+def stats(values: Sequence[float]) -> dict[str, float | None]:
     clean = [float(v) for v in values if v is not None]
     if not clean:
         return {"mean": None, "stddev": None, "min": None, "max": None, "median": None, "n": 0}
@@ -15517,23 +15520,114 @@ def slice_lift_fields(paired: dict[str, Any], overall_lift: float | None) -> dic
     return fields
 
 
+def _report_attempt_identity(row: Mapping[str, Any]) -> str:
+    """Stable identity for one attempted answer-run report row."""
+    required = ("case_id", "variant", "run_number")
+    if any(row.get(key) is None for key in required):
+        raise ValueError("report row requires case_id, variant, and run_number identity")
+    case_id = CaseId.parse(row["case_id"])
+    model = (None if row.get("model") is None
+             else ModelId.parse(row["model"]))
+    variant = ExecutionVariant.parse(row["variant"])
+    run_number = RunNumber.parse(row["run_number"])
+    return canonical_json_sha256({
+        "case_id": str(case_id),
+        "model": None if model is None else str(model),
+        "variant": str(variant),
+        "run_number": int(run_number),
+        "population": "answer",
+    })
+
+
+_RATE_TOTAL_FIELDS = {
+    "objective_pass_rate": "objective_total",
+    "combined_pass_rate": "combined_total",
+    "process_pass_rate": "process_total",
+    "efficiency_pass_rate": "efficiency_total",
+}
+
+
+def _report_metric_applicable(row: Mapping[str, Any], key: str) -> bool:
+    """An explicit zero denominator is N/A; absence remains unknown coverage."""
+    total_key = _RATE_TOTAL_FIELDS[key]
+    if total_key not in row:
+        return True
+    total = row[total_key]
+    if type(total) is not int or total < 0:
+        raise ValueError(f"report {total_key} must be a non-negative integer")
+    if total == 0 and row.get(key) is not None:
+        raise ValueError(f"report {key} contradicts zero {total_key}")
+    return total != 0
+
+
+def _report_row_eligibility(row: Mapping[str, Any]) -> report_domain.Disposition:
+    if not scorable_run(row):
+        return False, "unscorable_attempt"
+    if row.get("grading_availability") != "complete":
+        return False, "grading_evidence_incomplete"
+    return True, None
+
+
+def _report_execution_eligibility(
+    row: Mapping[str, Any],
+) -> report_domain.Disposition:
+    return ((True, None) if scorable_run(row)
+            else (False, "unscorable_attempt"))
+
+
 def build_slice_summary(results: list[dict[str, Any]], variants: list[str]) -> dict[str, Any]:
     out: dict[str, Any] = {"domain": {}, "difficulty": {}, "trigger_type": {}, "success_goals": {}}
     # Each slice routes through ResultSet so the scorable predicate is never
     # re-rolled inline; the value enumeration is over all rows (it lists which
     # slices exist), the scoring is over the scorable subset.
     def slice_stats(rs: ResultSet) -> dict[str, Any]:
-        attempted = len(rs)
-        s = rs.scorable()
-        blocked = attempted - len(s)
-        objective = s.mean_rate("objective_pass_rate")
-        combined = s.mean_rate("combined_pass_rate")
-        return {"attempted_runs": attempted, "runs": len(s), "blocked_runs": blocked,
-                "availability": "partial" if blocked else "complete",
-                "mean_objective_pass_rate": None if blocked else objective,
-                "mean_combined_pass_rate": None if blocked else combined,
-                "observed_mean_objective_pass_rate": objective,
-                "observed_mean_combined_pass_rate": combined}
+        cohort = report_domain.report_cohort(
+            rs.all,
+            identity=_report_attempt_identity,
+            eligibility=_report_row_eligibility,
+        )
+        diagnostic_cohort = report_domain.report_cohort(
+            rs.all,
+            identity=_report_attempt_identity,
+            eligibility=_report_execution_eligibility,
+        )
+        objective_cohort = report_domain.metric_cohort(
+            cohort, "objective_pass_rate",
+            applicability=lambda row: _report_metric_applicable(
+                row, "objective_pass_rate"))
+        combined_cohort = report_domain.metric_cohort(
+            cohort, "combined_pass_rate",
+            applicability=lambda row: _report_metric_applicable(
+                row, "combined_pass_rate"))
+        objective_values = report_domain.observed_rates(
+            objective_cohort, "objective_pass_rate")
+        combined_values = report_domain.observed_rates(
+            combined_cohort, "combined_pass_rate")
+        objective = statistics.mean(objective_values) if objective_values else None
+        combined = statistics.mean(combined_values) if combined_values else None
+        diagnostic_objective = report_domain.observed_rates(
+            report_domain.metric_cohort(
+                diagnostic_cohort, "objective_pass_rate",
+                applicability=lambda row: _report_metric_applicable(
+                    row, "objective_pass_rate")),
+            "objective_pass_rate")
+        diagnostic_combined = report_domain.observed_rates(
+            report_domain.metric_cohort(
+                diagnostic_cohort, "combined_pass_rate",
+                applicability=lambda row: _report_metric_applicable(
+                    row, "combined_pass_rate")),
+            "combined_pass_rate")
+        return {**report_domain.coverage_fields(cohort),
+                "mean_objective_pass_rate": report_domain.headline_value(
+                    objective_cohort, objective),
+                "mean_combined_pass_rate": report_domain.headline_value(
+                    combined_cohort, combined),
+                "observed_mean_objective_pass_rate": (
+                    statistics.mean(diagnostic_objective)
+                    if diagnostic_objective else None),
+                "observed_mean_combined_pass_rate": (
+                    statistics.mean(diagnostic_combined)
+                    if diagnostic_combined else None)}
 
     everything = ResultSet(results)
     overall_lift = (build_paired_summary(results) or {}).get("absolute_delta")
@@ -16346,19 +16440,44 @@ def qualitative_by_visibility(results: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def variant_summary_block(rows: list[dict[str, Any]]) -> dict[str, Any]:
-    scorable_rows = [row for row in ResultSet(rows).scorable().all
-                     if row.get("grading_availability") == "complete"]
-    blocked_runs = len(rows) - len(scorable_rows)
-    objective_rates = [r["objective_pass_rate"] for r in scorable_rows if r["objective_pass_rate"] is not None]
-    combined_rates = [r["combined_pass_rate"] for r in scorable_rows if r.get("combined_pass_rate") is not None]
-    process_rates = [r["process_pass_rate"] for r in scorable_rows if r.get("process_pass_rate") is not None]
-    efficiency_rates = [r["efficiency_pass_rate"] for r in scorable_rows if r.get("efficiency_pass_rate") is not None]
+    cohort = report_domain.report_cohort(
+        rows,
+        identity=_report_attempt_identity,
+        eligibility=_report_row_eligibility,
+    )
+    execution_cohort = report_domain.report_cohort(
+        rows,
+        identity=_report_attempt_identity,
+        eligibility=_report_execution_eligibility,
+    )
+    execution_rows = [
+        thaw_json_value(row, "report row")
+        for row in report_domain.observed_rows(execution_cohort)
+    ]
+    metric_cohorts = {
+        key: report_domain.metric_cohort(
+            cohort, key,
+            applicability=lambda row, metric=key: _report_metric_applicable(
+                row, metric))
+        for key in (
+            "objective_pass_rate", "combined_pass_rate",
+            "process_pass_rate", "efficiency_pass_rate",
+        )
+    }
+    objective_rates = list(report_domain.observed_rates(
+        metric_cohorts["objective_pass_rate"], "objective_pass_rate"))
+    combined_rates = list(report_domain.observed_rates(
+        metric_cohorts["combined_pass_rate"], "combined_pass_rate"))
+    process_rates = list(report_domain.observed_rates(
+        metric_cohorts["process_pass_rate"], "process_pass_rate"))
+    efficiency_rates = list(report_domain.observed_rates(
+        metric_cohorts["efficiency_pass_rate"], "efficiency_pass_rate"))
     # Timing/token/command central tendencies describe SCORABLE runs, matching
     # the pass-rate block above — a timed-out run's full duration must not drag
     # the mean (the failure count is disclosed separately as execution_errors).
-    facts = [result_cost_facts(r) for r in scorable_rows]
+    facts = [result_cost_facts(r) for r in execution_rows]
     command_measurements = []
-    for row in scorable_rows:
+    for row in execution_rows:
         merged = dict(row.get("metadata", {}) or {})
         merged.update(read_metrics_base(Path(row.get("run_base", ""))))
         command_measurements.append(telemetry_domain.measurement_from_envelope_or_nonnegative(merged, "commands"))
@@ -16368,7 +16487,7 @@ def variant_summary_block(rows: list[dict[str, Any]]) -> dict[str, Any]:
     cost_total = _money_aggregate_fields(cost_measurements)
     elapsed = [m.value for m in elapsed_measurements if m.availability == telemetry_domain.AVAILABLE]
     tokens = [m.value for m in token_measurements if m.availability == telemetry_domain.AVAILABLE]
-    observed_rates = {
+    diagnostic_rate_fields = {
         "mean_objective_pass_rate": statistics.mean(objective_rates) if objective_rates else None,
         "mean_combined_pass_rate": statistics.mean(combined_rates) if combined_rates else None,
         "mean_process_pass_rate": statistics.mean(process_rates) if process_rates else None,
@@ -16378,14 +16497,32 @@ def variant_summary_block(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "process_pass_rate": stats(process_rates),
         "efficiency_pass_rate": stats(efficiency_rates),
     }
+    field_metric = {
+        "mean_objective_pass_rate": "objective_pass_rate",
+        "objective_pass_rate": "objective_pass_rate",
+        "mean_combined_pass_rate": "combined_pass_rate",
+        "combined_pass_rate": "combined_pass_rate",
+        "mean_process_pass_rate": "process_pass_rate",
+        "process_pass_rate": "process_pass_rate",
+        "mean_efficiency_pass_rate": "efficiency_pass_rate",
+        "efficiency_pass_rate": "efficiency_pass_rate",
+    }
+    published_rate_fields = {
+        field: report_domain.headline_value(
+            metric_cohorts[field_metric[field]], value)
+        for field, value in diagnostic_rate_fields.items()
+    }
     out = {
         "cases": len({r["case_id"] for r in rows}),
-        "runs": len(rows),
-        "scorable_runs": len(scorable_rows),
-        "blocked_runs": blocked_runs,
+        "runs": report_domain.attempted_count(cohort),
+        "scorable_runs": len(execution_rows),
+        "blocked_runs": report_domain.blocked_count(cohort),
         "missing_outputs": sum(1 for r in rows if r["missing_output"]),
         "execution_errors": sum(1 for r in rows if not r["missing_output"] and not r.get("execution_valid", True)),
-        **observed_rates,
+        **published_rate_fields,
+        "metric_availability": {
+            key: metric.state.value for key, metric in metric_cohorts.items()
+        },
         "elapsed_ms": measurement_stats(elapsed_measurements),
         "total_tokens": measurement_stats(token_measurements),
         "command_count": measurement_stats(command_measurements),
@@ -16401,14 +16538,24 @@ def variant_summary_block(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "median_elapsed_ms": statistics.median(elapsed) if elapsed else None,
         "median_total_tokens": statistics.median(tokens) if tokens else None,
     }
-    if blocked_runs:
-        out["availability"] = "partial"
-        out["reason"] = "unscorable_or_incompletely_graded_attempts"
-        for key, value in observed_rates.items():
-            out[f"observed_{key}"] = value
+    if isinstance(cohort, report_domain.PartialReportCohort):
+        out["availability"] = cohort.state.value
+        out["reason"] = cohort.reason
+        for key, value in diagnostic_rate_fields.items():
+            if isinstance(
+                metric_cohorts[field_metric[key]],
+                report_domain.PartialReportCohort,
+            ):
+                out[f"observed_{key}"] = value
             out[key] = None
     else:
-        out["availability"] = "complete"
+        out["availability"] = cohort.state.value
+        for key, value in diagnostic_rate_fields.items():
+            if isinstance(
+                metric_cohorts[field_metric[key]],
+                report_domain.PartialReportCohort,
+            ):
+                out[f"observed_{key}"] = value
     return out
 
 

--- a/tests/test_report_contracts.py
+++ b/tests/test_report_contracts.py
@@ -1,0 +1,187 @@
+import unittest
+
+import report_contracts as rc
+import skill_benchmark as sb
+
+
+class ReportCohortTests(unittest.TestCase):
+    @staticmethod
+    def cohort(rows, observed_ids):
+        return rc.report_cohort(
+            rows,
+            identity=lambda row: row["id"],
+            eligibility=lambda row: (
+                (True, None) if row["id"] in observed_ids
+                else (False, "blocked")
+            ),
+        )
+
+    def test_empty_complete_and_partial_are_distinct(self):
+        first = {"id": "first", "objective_pass_rate": 1.0}
+        second = {"id": "second", "objective_pass_rate": 0.0}
+
+        empty = self.cohort([], set())
+        complete = self.cohort([first, second], {"first", "second"})
+        partial = self.cohort([first, second], {"first"})
+
+        self.assertIsInstance(empty, rc.EmptyReportCohort)
+        self.assertIsInstance(complete, rc.CompleteReportCohort)
+        self.assertIsInstance(partial, rc.PartialReportCohort)
+        self.assertEqual(rc.observed_rates(complete, "objective_pass_rate"), (1.0, 0.0))
+        self.assertIsNone(rc.headline_value(partial, 1.0))
+        self.assertEqual(rc.headline_value(complete, 0.5), 0.5)
+
+    def test_attempt_identity_is_stable_and_unique(self):
+        with self.assertRaises(ValueError):
+            rc.report_cohort(
+                [{"id": "same"}, {"id": "same"}],
+                identity=lambda row: row["id"],
+                eligibility=lambda row: (True, None),
+            )
+
+    def test_invalid_rate_never_reaches_a_report_headline(self):
+        row = {"objective_pass_rate": 1.1}
+        cohort = rc.report_cohort(
+            [row], identity=lambda unused: "row",
+            eligibility=lambda unused: (True, None))
+        with self.assertRaises(ValueError):
+            rc.observed_rates(cohort, "objective_pass_rate")
+
+    def test_coverage_fields_keep_observed_and_attempted_counts_together(self):
+        observed = {"id": "observed", "objective_pass_rate": 1.0}
+        blocked = {"id": "blocked", "objective_pass_rate": None}
+        cohort = rc.report_cohort(
+            [observed, blocked],
+            identity=lambda row: row["id"],
+            eligibility=lambda row: (
+                (True, None) if row["id"] == "observed"
+                else (False, "missing evidence")),
+        )
+        self.assertEqual(rc.coverage_fields(cohort), {
+            "attempted_runs": 2,
+            "runs": 1,
+            "blocked_runs": 1,
+            "availability": "partial",
+            "reason": "missing evidence",
+            "blocked_reason_counts": {"missing evidence": 1},
+        })
+
+    def test_metric_missing_from_complete_rows_is_partial_not_a_survivor_headline(self):
+        rows = [
+            {"id": "first", "objective_pass_rate": 1.0},
+            {"id": "second", "objective_pass_rate": None},
+        ]
+        row_cohort = self.cohort(rows, {"first", "second"})
+        metric = rc.metric_cohort(row_cohort, "objective_pass_rate")
+
+        self.assertIsInstance(metric, rc.PartialReportCohort)
+        self.assertEqual(rc.observed_rates(metric, "objective_pass_rate"), (1.0,))
+        self.assertIsNone(rc.headline_value(metric, 1.0))
+        self.assertEqual(rc.diagnostic_rates(metric, "objective_pass_rate"), (1.0,))
+
+    def test_not_applicable_metric_is_distinct_from_empty_and_unavailable(self):
+        cohort = self.cohort([{"id": "one", "process_pass_rate": None}], {"one"})
+        metric = rc.metric_cohort(
+            cohort, "process_pass_rate", applicability=lambda row: False)
+
+        self.assertIsInstance(metric, rc.NotApplicableReportCohort)
+        self.assertEqual(rc.coverage_fields(metric), {
+            "attempted_runs": 1,
+            "runs": 0,
+            "blocked_runs": 0,
+            "availability": "not_applicable",
+            "not_applicable_runs": 1,
+        })
+
+    def test_metric_refinement_cannot_resurrect_base_not_applicable_attempt(self):
+        base = rc.report_cohort(
+            [{"id": "one", "process_pass_rate": 1.0}],
+            identity=lambda row: row["id"],
+            eligibility=lambda row: (None, "outside_population"),
+        )
+        callback_called = False
+
+        def applicable(row):
+            nonlocal callback_called
+            callback_called = True
+            return True
+
+        metric = rc.metric_cohort(
+            base, "process_pass_rate", applicability=applicable)
+
+        self.assertIsInstance(metric, rc.NotApplicableReportCohort)
+        self.assertFalse(callback_called)
+
+    def test_empty_variant_summary_is_named_empty(self):
+        summary = sb.variant_summary_block([])
+        self.assertEqual(summary["availability"], "empty")
+        self.assertEqual(summary["runs"], 0)
+        self.assertEqual(summary["scorable_runs"], 0)
+
+    @staticmethod
+    def result_row(run_number=1, *, grading="complete", elapsed_ms=10):
+        return {
+            "case_id": "case-1",
+            "variant": "with_skill",
+            "run_number": run_number,
+            "missing_output": False,
+            "execution_valid": True,
+            "grading_availability": grading,
+            "objective_total": 1,
+            "objective_pass_rate": 1.0,
+            "combined_total": 1,
+            "combined_pass_rate": 1.0,
+            "process_total": 0,
+            "process_pass_rate": None,
+            "efficiency_total": 0,
+            "efficiency_pass_rate": None,
+            "metadata": {"elapsed_ms": elapsed_ms},
+            "run_base": "/definitely/not/a/run",
+        }
+
+    def test_zero_denominator_metrics_are_not_applicable_in_production_summary(self):
+        summary = sb.variant_summary_block([self.result_row()])
+
+        self.assertEqual(summary["availability"], "complete")
+        self.assertEqual(summary["metric_availability"], {
+            "objective_pass_rate": "complete",
+            "combined_pass_rate": "complete",
+            "process_pass_rate": "not_applicable",
+            "efficiency_pass_rate": "not_applicable",
+        })
+        self.assertIsNone(summary["mean_process_pass_rate"])
+        self.assertNotIn("observed_mean_process_pass_rate", summary)
+
+    def test_grading_incompleteness_does_not_discard_execution_telemetry(self):
+        rows = [
+            self.result_row(1, elapsed_ms=10),
+            self.result_row(2, grading="partial", elapsed_ms=100),
+        ]
+        summary = sb.variant_summary_block(rows)
+
+        self.assertEqual(summary["availability"], "partial")
+        self.assertEqual(summary["scorable_runs"], 2)
+        self.assertEqual(summary["elapsed_ms"]["n"], 2)
+        self.assertEqual(summary["elapsed_ms"]["mean"], 55)
+
+    def test_report_attempt_identity_rejects_boolean_run_number(self):
+        row = self.result_row()
+        row["run_number"] = True
+        with self.assertRaises(ValueError):
+            sb.variant_summary_block([row])
+
+    def test_metric_totals_reject_coercion_and_zero_rate_contradictions(self):
+        for total in (False, 0.0, -1, "0"):
+            row = self.result_row()
+            row["process_total"] = total
+            with self.subTest(total=total), self.assertRaises(ValueError):
+                sb.variant_summary_block([row])
+
+        row = self.result_row()
+        row["process_pass_rate"] = 0.0
+        with self.assertRaisesRegex(ValueError, "contradicts"):
+            sb.variant_summary_block([row])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -267,6 +267,27 @@ class PerModelAnalysisTests(unittest.TestCase):
         self.assertEqual(domain["pairing"]["eligible_pairs"], 0)
         self.assertEqual(domain["pairing"]["blocked_pairs"], 2)
 
+    def test_partial_grading_cannot_publish_a_slice_headline(self):
+        row = {
+            "case_id": "c", "model": "m", "variant": "with_skill",
+            "run_number": 1, "domain": "docs", "missing_output": False,
+            "execution_valid": True, "grading_availability": "partial",
+            "objective_pass_rate": 1.0, "combined_pass_rate": 1.0,
+            "metadata": {},
+        }
+
+        block = sb.build_slice_summary(
+            [row], ["with_skill"])["domain"]["docs"]["with_skill"]
+
+        self.assertEqual(block["availability"], "partial")
+        self.assertEqual(block["attempted_runs"], 1)
+        self.assertEqual(block["runs"], 0)
+        self.assertEqual(block["blocked_runs"], 1)
+        self.assertIsNone(block["mean_objective_pass_rate"])
+        self.assertIsNone(block["mean_combined_pass_rate"])
+        self.assertEqual(block["observed_mean_objective_pass_rate"], 1.0)
+        self.assertEqual(block["observed_mean_combined_pass_rate"], 1.0)
+
     def test_no_model_axis_yields_empty_analysis(self):
         self.assertEqual(sb.model_analysis_from_paired({"absolute_delta": 0.5}), {})
 

--- a/type_tests/abstraction_contracts.py
+++ b/type_tests/abstraction_contracts.py
@@ -56,6 +56,14 @@ from manifest_contracts import (
     RunNumber,
     Split,
 )
+from report_contracts import (
+    CompleteReportCohort,
+    EmptyReportCohort,
+    NotApplicableReportCohort,
+    PartialReportCohort,
+    ReportCohort,
+    UnitRate,
+)
 from runner_contracts import (
     AnswerOutcome,
     Completed,
@@ -221,3 +229,20 @@ def judge_task_identity_is_precise(task: JudgeTask) -> None:
     _run_number: RunNumber = task.run_number
     _model: ModelId | None = task.model
     _assertion: Mapping[str, object] = task.assertion
+
+
+def report_cohort_is_exhaustive(cohort: ReportCohort) -> None:
+    if isinstance(cohort, EmptyReportCohort):
+        _empty: EmptyReportCohort = cohort
+    elif isinstance(cohort, CompleteReportCohort):
+        _complete_rows: tuple[Mapping[str, object], ...] = cohort.rows
+    elif isinstance(cohort, PartialReportCohort):
+        _reason: str = cohort.reason
+    elif isinstance(cohort, NotApplicableReportCohort):
+        _attempted: int = cohort.attempted
+    else:
+        _assert_never(cohort)
+
+
+def report_rate_is_precise(rate: UnitRate) -> None:
+    _rate: float = rate


### PR DESCRIPTION
## Summary

- derive empty, complete, partial, and not-applicable report cohorts from one stable attempted sequence
- refine coverage per metric without resurrecting base non-applicable attempts
- require exact non-negative integer metric denominators and classify explicit zero denominators as not applicable
- withhold survivor-only headlines while retaining named partial diagnostics
- aggregate execution telemetry independently from grading completeness

This is layer 7 of the `ty` migration stack and depends on #78.

## Why

Independent counts and nullable means allowed zero-attempt cohorts, missing metrics, and survivor-only values to look complete. Grading incompleteness could also discard valid timing and token observations. Stable `ReportAttempt` identities and metric-specific cohorts prevent those denominator errors.

## Compatibility and risk

Complete report shapes remain compatible. Zero-denominator metrics now report `not_applicable`; malformed totals and zero-total/non-null-rate contradictions fail. Partial cohorts never publish a headline, and telemetry keeps every execution-valid observation even when grading is partial.

## Validation

- focused report-contract and reporting suites
- adversarial coverage for duplicate/malformed identities, monotone applicability, zero totals, partial grading, survivor means, and telemetry retention
- top-of-stack integration: 1,335 passed, 7 skipped, 858 subtests
- warning-fatal `ty`, Ruff, byte compilation, doc-reference check, and `git diff --check`
