### PR TITLE
Collect property tests with pytest in CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Run the smallest command that proves the change:
 
 - [ ] `python3 -m py_compile *.py scripts/*.py examples/adewale-workspace/*.py examples/demo-skill/*.py type_tests/*.py tests/*.py`
 - [ ] `ty check --error-on-warning`
-- [ ] `python3 -m unittest discover tests -v`
+- [ ] `python3 -m pytest tests -v`
 - [ ] Manifest/eval command, if changed: `skill-benchmark validate ...`
 - [ ] For a stacked PR, all checks pass at this exact tip and the diff does not rely on a later PR
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,11 @@ jobs:
       - name: Run ty
         run: ty check --error-on-warning --output-format github
 
-      - name: Run unit tests
-        run: python -m unittest discover tests -v
+      - name: Verify property tests are collected
+        run: python -m pytest --collect-only -q tests/test_telemetry_properties.py
+
+      - name: Run tests
+        run: python -m pytest tests -v
 
       - name: Check CLI entrypoints
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,13 @@ Run these before opening a PR:
 pip install -e ".[test]"
 python3 -m py_compile *.py scripts/*.py examples/adewale-workspace/*.py examples/demo-skill/*.py type_tests/*.py tests/*.py
 ty check --error-on-warning
-python3 -m unittest discover tests -v
+python3 -m pytest tests -v
 ```
 
-(`pytest tests/` also works — `pyproject.toml` carries the pythonpath config — but CI runs `unittest discover`, so keep tests compatible with both.)
+CI uses pytest so that both the predominantly `unittest` suite and the
+Hypothesis/pytest property tests are collected. Keep ordinary unit tests
+compatible with `unittest discover` where practical, but validate the complete
+suite with pytest.
 
 `ty check` automatically covers every packaged top-level Python module, repository script,
 shipped example, and the static contracts under `type_tests/`. A new runtime boundary module

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -709,3 +709,24 @@ correctness protocol.
 - Treat inventories according to meaning: packaging, static-analysis coverage, and causal identity
   are different sets. A stack-wide guard should enforce their relationship, not collapse them into
   filesystem equality.
+
+## 2026-08-31 — A test exists only if the configured runner collects it
+
+**Problem:** The telemetry suite contained standalone Hypothesis properties and a
+pytest-parametrized test, and the test dependencies were installed, but CI used
+`unittest discover`. The affected file reported zero tests under that runner while the build
+stayed green.
+
+**Lesson:** Source files, decorators, and installed test libraries are not evidence of executed
+coverage. Collection is part of the test contract, especially in this repository's mixed
+`unittest`/pytest suite.
+
+**Rule:**
+- Use pytest as the canonical full-suite runner; it continues to collect the ordinary
+  `unittest.TestCase` suite while also collecting pytest-native and standalone Hypothesis tests.
+- After adding or changing a non-`TestCase` test, run a focused `pytest --collect-only` check and
+  confirm the intended test IDs appear before relying on the full-suite result.
+- Keep CI, contributor guidance, and the PR template on the same full-suite command so local proof
+  cannot silently describe a different suite from the one that gates changes.
+- Audit executed test IDs, not decorator or file counts. A green runner that collected zero tests
+  is missing evidence, not passing evidence.

--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for local setup, validation commands, a
 pip install -e ".[test]"
 python3 -m py_compile *.py scripts/*.py examples/adewale-workspace/*.py examples/demo-skill/*.py type_tests/*.py tests/*.py
 ty check --error-on-warning
-python3 -m unittest discover tests -v
+python3 -m pytest tests -v
 ```
 
 For manifest or grading changes, add or update `tests/test_skill_benchmark.py`. For docs-only changes, still run the same commands so CLI examples stay tied to current behavior.
@@ -611,7 +611,7 @@ skill-eval-harness/
 pip install -e ".[test]"
 python3 -m py_compile *.py scripts/*.py examples/adewale-workspace/*.py examples/demo-skill/*.py type_tests/*.py tests/*.py
 ty check --error-on-warning
-python3 -m unittest discover tests -v
+python3 -m pytest tests -v
 ```
 
 The test suite is organized by subject: manifest validation and eval hygiene (`test_manifest.py`), grading (`test_grading.py`), human-text construction and matching (`test_text_contracts.py`), judge plumbing (`test_judging.py`), report views (`test_reporting.py`), closed-form statistics and pair identity (`test_stats.py`, `test_experimental_pairs.py`), runner/Jetty adapters and lifecycle contracts (`test_runners.py`, `test_jetty_contracts.py`), the ablation experiment end to end (`test_ablations.py`), cost telemetry (`test_cost_telemetry.py`), the confidence floor and detector fixtures (`test_confidence_floor.py`), the trigger matrix (`test_trigger_matrix.py`), plus four executable drift guards: doc code references (`test_doc_refs.py`), shared-owner/doc-sync consolidation guards (`test_consolidation_guards.py`), relative-link resolution across the docs (`test_doc_links.py`), and Python type/package/semantic coverage (`test_type_coverage.py`). Shared fixture builders live in `tests/helpers.py`.


### PR DESCRIPTION
## What

- Make pytest the canonical full-suite runner in CI and contributor documentation.
- Add an explicit collection check for the telemetry property suite.
- Keep the existing unittest-based tests running through pytest.
- Record the mixed-runner collection rule in `LESSONS_LEARNED.md`.

## Why

CI used `unittest discover`, which silently skipped two standalone Hypothesis properties and a pytest-parametrized telemetry test. The repository installed pytest and Hypothesis, but the configured runner did not collect the full suite.

## How

CI now runs `pytest --collect-only` for the affected file, then executes the full test suite with pytest. README, contribution guidance, and the PR template use the same command. The project lesson now treats collected test IDs—not files or decorators—as the evidence that a test exists.

## Testing

- Old runner proof: `unittest discover -p test_telemetry_properties.py` ran 0 tests
- New collection guard finds 56 telemetry cases
- Full pytest suite: 1,335 passed, 7 skipped, 858 subtests
- `py_compile`, Ruff, and `ty check --error-on-warning` passed
- Independent review reran the 56-case collection check
- Lesson follow-up: 12 documentation-reference/link checks and 3 subtests passed

## Risk

CI and documentation only. Pytest becomes the canonical full runner; ordinary unittest-compatible tests continue to run under it.
